### PR TITLE
Add type property to Button

### DIFF
--- a/src/components/input/Button/Button.tsx
+++ b/src/components/input/Button/Button.tsx
@@ -33,6 +33,11 @@ export interface ButtonProps extends BaseProps {
    * Button variant
    */
   variant?: "outlined" | "contained" | "text";
+
+  /**
+   * HTML type prop
+   */
+  type?: "button" | "submit" | "reset";
 }
 
 /**


### PR DESCRIPTION
This pull request fixes the following bug: https://github.com/Gemeente-DenHaag/denhaag-component-library/issues/37

In order to use submit form behavior in implementers of the Component Library, the button should support the standard button HTML property 'type'. More information can be found in the issue.