### PR TITLE
Dot indicator

### DIFF
--- a/src/components/DotIndicator/README.md
+++ b/src/components/DotIndicator/README.md
@@ -1,0 +1,63 @@
+# Dot indicator
+
+![npm (scoped)](https://img.shields.io/npm/v/@gemeente-denhaag/dotindicator?logo=npm&style=flat-square)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/Gemeente-Denhaag/denhaag-component-library/Build%20and%20deploy%20Storybook%20to%20Azure%20Web%20App/master?logo=github&style=flat-square)
+
+Dot indicators are used to show that there is a notification. Dot indicators are commonly used in combination with badges.
+
+## When to use
+
+TODO: Not yet written.
+
+## Alternatives and related components
+
+Use `Tag` when you need to inform users about the status of an object, about an action or when you have data that helps categorize and organize things.
+
+## Anatomy
+
+The dot indicator consists of
+
+1. Dot: shows that there is a notification
+2. Container: the element the dot is placed on
+
+## (Interactive) states
+
+None.
+
+## Design properties
+
+### Colors
+
+- Dot: color Red/3, border color white
+
+### Structure
+- Dot: overlaps container 25%, border 2px, height and width 12px
+
+## Accessibility
+
+TODO: Not yet written.
+
+## Content guidelines
+
+None.
+
+## Best practices
+
+### Do's
+
+Dot indicators should:
+
+- Notify the user that something is new or updated without showing a count, such as an "unread message", or activity notification
+- Notify or draw attention to changed values or states
+- Be used when there is an underlying message in the menu
+- Be used sparingly
+
+### Don'ts
+
+Dot indicators should:
+
+- Not be used if you need to display a count. Use `Badge counter` instead.
+
+## References
+
+https://cultureamp.design/components/badge

--- a/src/components/DotIndicator/package.json
+++ b/src/components/DotIndicator/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "rollup -c ../../../rollup.config.js",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {

--- a/src/components/DotIndicator/package.json
+++ b/src/components/DotIndicator/package.json
@@ -22,12 +22,12 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "@gemeente-denhaag/baseprops": "^0.2.2",
     "clsx": "^1.1.1"
   },
   "devDependencies": {
-    "@gemeente-denhaag/avatar": "^0.1.7",
-    "@gemeente-denhaag/button": "^0.1.7"
+    "@gemeente-denhaag/avatar": "^0.2.2",
+    "@gemeente-denhaag/button": "^0.2.2"
   },
   "peerDependencies": {
     "react": "^17.0.1"

--- a/src/components/DotIndicator/package.json
+++ b/src/components/DotIndicator/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@gemeente-denhaag/dotindicator",
+  "version": "0.1.0",
+  "description": "A Dot Indicator component",
+  "bugs": "https://github.com/Gemeente-DenHaag/denhaag-component-library/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gemeente-DenHaag/denhaag-component-library.git",
+    "directory": "src/components/DotIndicator"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/baseprops": "^0.1.7",
+    "clsx": "^1.1.1"
+  },
+  "devDependencies": {
+    "@gemeente-denhaag/avatar": "^0.1.7",
+    "@gemeente-denhaag/button": "^0.1.7"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+}

--- a/src/components/DotIndicator/src/dot-indicator.css
+++ b/src/components/DotIndicator/src/dot-indicator.css
@@ -1,0 +1,28 @@
+.denhaag-dot-indicator {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+.denhaag-dot-indicator__dot {
+  position: absolute;
+  background-color: var(--denhaag-dot-indicator-background-color);
+  width: var(--denhaag-dot-indicator-size);
+  height: var(--denhaag-dot-indicator-size);
+  transform: scale(1) translate(50%, -50%);
+  border-radius: 50%;
+  border: var(--denhaag-dot-indicator-border);
+}
+
+.denhaag-dot-indicator--overlap-rectangle .denhaag-dot-indicator__dot  {
+  transform: scale(1) translate(50%, -50%);
+  top: 0;
+  right: 0;
+}
+
+.denhaag-dot-indicator--overlap-circle .denhaag-dot-indicator__dot  {
+  transform: scale(1) translate(50%, -50%);
+  top: 14%;
+  right: 14%;
+}

--- a/src/components/DotIndicator/src/index.tsx
+++ b/src/components/DotIndicator/src/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './dot-indicator.css';
+import clsx from 'clsx';
+import BaseProps from '@gemeente-denhaag/baseprops';
+
+export interface DotIndicatorProps extends Omit<BaseProps, 'classes' | 'tabIndex'> {
+  /**
+   * The shape which the dot indicator has to overlap.
+   */
+  overlap: 'circle' | 'rectangle';
+}
+
+/**
+ * A dot indicator is a visual update message that announces something new for the user to see.
+ * Dot indicators are typically used with counter badges
+ * @param props The properties of a Dot Indicator component.
+ */
+export const DotIndicator: React.FC<DotIndicatorProps> = (props: DotIndicatorProps) => {
+  const rootStyles = clsx('denhaag-dot-indicator', {
+    'denhaag-dot-indicator--overlap-rectangle': props.overlap === 'rectangle',
+    'denhaag-dot-indicator--overlap-circle': props.overlap === 'circle',
+  });
+  return (
+    <span className={rootStyles} id={props.id}>
+      {props.children}
+      <span className="denhaag-dot-indicator__dot"></span>
+    </span>
+  );
+};
+
+export default DotIndicator;

--- a/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
+++ b/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
@@ -1,0 +1,79 @@
+import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
+import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+import { Avatar } from "@gemeente-denhaag/avatar";
+import Button from "@gemeente-denhaag/button";
+import { DotIndicator } from "..";
+import pkg from "../../package.json";
+import readme from "../../README.md";
+
+<Meta
+  title="Components/Data Display/Dot indicator"
+  component={DotIndicator}
+  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+/>
+
+<Description markdown={readme} />
+
+## Design Tokens
+
+<DesignTokenDocBlock categoryName="Dot indicator" viewType="table" />
+
+## Stories
+
+### Dot indicator (on rectangle)
+
+<Canvas>
+  <Story
+    name="Indicator on rectangle"
+    parameters={{
+      docs: {
+        source: {
+          code: `
+import { DotIndicator } from "@gemeente-denhaag/dotindicator";
+const elementWithNotification = (<DotIndicator overlap="rectangle"><Button>Read messages</Button></DotIndicator>);
+// This 👆 transpiles into this 👇 in the DOM
+<div class="denhaag-dot-indicator denhaag-dot-indicator--overlap-rectangle">
+  <button>Read messages</button>
+  <span class="denhaag-dot-indicator__dot"></span>
+</div>`,
+        },
+      },
+    }}
+  >
+    {(args) => <DotIndicator overlap={"rectangle"}><Button variant={"secondary"}>Read messages</Button></DotIndicator>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={DotIndicator} />
+
+### Dot indicator(on circle)
+
+<Canvas>
+  <Story
+    name="Indicator on circle"
+    args={{
+      overlap: "circle"
+    }}
+    parameters={{
+      docs: {
+        source: {
+          code: `
+import { DotIndicator } from "@gemeente-denhaag/dotindicator";
+const elementWithNotification = <DotIndicator overlap="circle"><Avatar>DH</Avatar</DotIndicator>;
+// This 👆 transpiles into this 👇 in the DOM
+<div class="denhaag-dot-indicator denhaag-dot-indicator--overlap-rectangle">
+  <Avatar>DH</Avatar>
+  <span class="denhaag-dot-indicator__dot"></span>
+</div>
+    `,
+        },
+      },
+    }}
+  >
+    {(args) => (
+      <DotIndicator overlap={"circle"}>
+        <Avatar>DH</Avatar>
+      </DotIndicator>
+    )}
+  </Story>
+</Canvas>

--- a/src/components/DotIndicator/tsconfig.json
+++ b/src/components/DotIndicator/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "src/stories/**/*"]
+}

--- a/src/styles/Components/src/denhaag/dot-indicator/block.style-dictionary.json
+++ b/src/styles/Components/src/denhaag/dot-indicator/block.style-dictionary.json
@@ -1,10 +1,10 @@
 {
   "denhaag": {
     "dot-indicator": {
-      "size": { "value": "8px" },
-      "background-color": { "value": "#cf1c08" },
+      "size": { "value": "12px" },
+      "background-color": { "value": "{denhaag.color.red.3.value}" },
       "border-size": { "value": "2px" },
-      "border-color": { "value": "#fff" },
+      "border-color": { "value": "{denhaag.color.white.value}" },
       "border": {
         "value": "{denhaag.dot-indicator.border-size.value} solid {denhaag.dot-indicator.border-color.value}"
       }


### PR DESCRIPTION
This PR adds the Dot Indicator component (figma) #62 . The dot indicator is required for the counter badge. 

Remaining todos:
- [x] Change stories file to mdx
- [x] Document component design tokens (design token block)
- [x] Add HTML snippet