### PR TITLE
Fixing MUI stylesProvider warning

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,7 @@
 import '@gemeente-denhaag/design-tokens-proprietary/dist/theme/index.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
 import '@gemeente-denhaag/design-tokens-common/dist/theme/index.css';
+import { StylesProvider } from '@material-ui/styles';
 
 import { addDecorator } from '@storybook/react';
 import { withThemes } from 'storybook-addon-themes/react';
@@ -33,3 +34,5 @@ export const parameters = {
     list: [{ name: 'Gemeente Den Haag', class: 'denhaag-theme', color: '#227b3c' }],
   },
 };
+
+export const decorators = [(Story) => <StylesProvider injectFirst>{<Story />}</StylesProvider>];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,7 @@
 import '@gemeente-denhaag/design-tokens-proprietary/dist/theme/index.css';
 import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
 import '@gemeente-denhaag/design-tokens-common/dist/theme/index.css';
-import { StylesProvider } from '@material-ui/styles';
-
+import StylesProvider from '@gemeente-denhaag/stylesprovider';
 import { addDecorator } from '@storybook/react';
 import { withThemes } from 'storybook-addon-themes/react';
 
@@ -35,4 +34,4 @@ export const parameters = {
   },
 };
 
-export const decorators = [(Story) => <StylesProvider injectFirst>{<Story />}</StylesProvider>];
+export const decorators = [(Story) => <StylesProvider>{<Story />}</StylesProvider>];

--- a/src/components/Button/src/index.tsx
+++ b/src/components/Button/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Button as MaterialButton, ButtonTypeMap, StylesProvider } from '@material-ui/core';
+import { Button as MaterialButton, ButtonTypeMap } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
-
 import { classes } from './bem-mapping';
 import './mui-override.css';
 import './button.css';
@@ -60,21 +59,19 @@ export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
   }
 
   return (
-    <StylesProvider injectFirst>
-      <MaterialButton
-        classes={classes}
-        className={sizeClass}
-        variant={muiVariant}
-        onClick={props.onClick}
-        disabled={props.disabled}
-        type={props.type}
-        startIcon={props.startIcon}
-        endIcon={props.endIcon}
-        disableRipple
-      >
-        {props.children}
-      </MaterialButton>
-    </StylesProvider>
+    <MaterialButton
+      classes={classes}
+      className={sizeClass}
+      variant={muiVariant}
+      onClick={props.onClick}
+      disabled={props.disabled}
+      type={props.type}
+      startIcon={props.startIcon}
+      endIcon={props.endIcon}
+      disableRipple
+    >
+      {props.children}
+    </MaterialButton>
   );
 };
 

--- a/src/components/Card/src/Card/Card.tsx
+++ b/src/components/Card/src/Card/Card.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { Card as MaterialCard, Icon, StylesProvider, Typography } from '@material-ui/core';
+import { Card as MaterialCard, Icon, Typography } from '@material-ui/core';
 import { ArrowRightIcon } from '@gemeente-denhaag/icons';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import './mui-override.css';
@@ -73,31 +73,29 @@ export const Card: React.FC<CardProps> = (props: CardProps) => {
   }
 
   return (
-    <StylesProvider injectFirst>
-      <MaterialCard classes={classes} onClick={onClick}>
-        <div className="denhaag-card__wrapper">
-          <div className="denhaag-card__background"></div>
-          <CardContent>
-            <div className="denhaag-card__text-wrapper">
-              <Typography classes={titleClasses} component="p">
-                {title}
-              </Typography>
-              <Typography classes={subtitleClasses} component="p">
-                {props.subTitle}
-              </Typography>
-            </div>
-            <CardActions disableSpacing={true}>
-              <Typography component="div" classes={subtitleClasses}>
-                <time dateTime={props.date.toDateString()}>{props.date.toLocaleDateString()}</time>
-              </Typography>
-              <Icon classes={arrowClasses} aria-label="ArrowRightIcon">
-                <ArrowRightIcon />
-              </Icon>
-            </CardActions>
-          </CardContent>
-        </div>
-      </MaterialCard>
-    </StylesProvider>
+    <MaterialCard classes={classes} onClick={onClick}>
+      <div className="denhaag-card__wrapper">
+        <div className="denhaag-card__background"></div>
+        <CardContent>
+          <div className="denhaag-card__text-wrapper">
+            <Typography classes={titleClasses} component="p">
+              {title}
+            </Typography>
+            <Typography classes={subtitleClasses} component="p">
+              {props.subTitle}
+            </Typography>
+          </div>
+          <CardActions disableSpacing={true}>
+            <Typography component="div" classes={subtitleClasses}>
+              <time dateTime={props.date.toDateString()}>{props.date.toLocaleDateString()}</time>
+            </Typography>
+            <Icon classes={arrowClasses} aria-label="ArrowRightIcon">
+              <ArrowRightIcon />
+            </Icon>
+          </CardActions>
+        </CardContent>
+      </div>
+    </MaterialCard>
   );
 };
 

--- a/src/components/Divider/src/index.tsx
+++ b/src/components/Divider/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Divider as MaterialDivider, StylesProvider } from '@material-ui/core';
+import { Divider as MaterialDivider } from '@material-ui/core';
 import { BaseDataDisplayClassesProps } from '@gemeente-denhaag/basedatadisplayprops';
 import './divider.css';
 
@@ -22,9 +22,7 @@ export const Divider: React.FC<DividerProps> = (props: DividerProps) => {
   };
 
   return (
-    <StylesProvider injectFirst>
-      <MaterialDivider variant={'fullWidth'} classes={classes} role={'presentation'} orientation={props.orientation} />
-    </StylesProvider>
+    <MaterialDivider variant={'fullWidth'} classes={classes} role={'presentation'} orientation={props.orientation} />
   );
 };
 

--- a/src/components/IconButton/src/index.tsx
+++ b/src/components/IconButton/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconButton as MaterialIconButton, StylesProvider } from '@material-ui/core';
+import { IconButton as MaterialIconButton } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import './mui-override.css';
 import './iconbutton.css';
@@ -23,17 +23,9 @@ export interface IconButtonProps extends BaseProps {
  */
 export const IconButton: React.FC<IconButtonProps> = ({ disabled = false, ...props }: IconButtonProps) => {
   return (
-    <StylesProvider injectFirst>
-      <MaterialIconButton
-        className="denhaag-icon-button"
-        disabled={disabled}
-        disableRipple
-        disableFocusRipple
-        {...props}
-      >
-        {props.children}
-      </MaterialIconButton>
-    </StylesProvider>
+    <MaterialIconButton className="denhaag-icon-button" disabled={disabled} disableRipple disableFocusRipple {...props}>
+      {props.children}
+    </MaterialIconButton>
   );
 };
 

--- a/src/components/List/src/List.tsx
+++ b/src/components/List/src/List.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List as MaterialList, StylesProvider } from '@material-ui/core';
+import { List as MaterialList } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import { ListSubheaderProps } from './ListSubheader';
 import { list_classes as classes } from './bem-mapping';
@@ -25,11 +25,9 @@ export const List: React.FC<ListProps> = (props: ListProps) => {
   const materialProps = { subheader: props.subheader };
 
   return (
-    <StylesProvider injectFirst>
-      <MaterialList {...materialProps} classes={classes}>
-        {props.children}
-      </MaterialList>
-    </StylesProvider>
+    <MaterialList {...materialProps} classes={classes}>
+      {props.children}
+    </MaterialList>
   );
 };
 

--- a/src/components/StylesProvider/package.json
+++ b/src/components/StylesProvider/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@gemeente-denhaag/stylesprovider",
+  "description": "The StylesProvider component to properly apply our CSS to MUI components",
+  "author": "Municipality of The Hague",
+  "license": "EUPL-1.2",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "exports": "./dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c ../../../rollup.config.js",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nl-design-system/denhaag.git",
+    "directory": "src/components/StylesProvider"
+  },
+  "bugs": "https://github.com/nl-design-system/denhaag/issues",
+  "dependencies": {
+    "@material-ui/core": "^4.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+}

--- a/src/components/StylesProvider/src/index.tsx
+++ b/src/components/StylesProvider/src/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StylesProvider as MaterialStylesProvider } from '@material-ui/core';
+
+export interface StylesProviderProps {
+  children?: React.ReactNode;
+}
+
+/**
+ * Styles provider to be placed at the root of your application in which all other denhaag-components will exist.
+ * @param props Only allow for children
+ */
+export const StylesProvider: React.FC<StylesProviderProps> = (props: StylesProviderProps) => {
+  return <MaterialStylesProvider injectFirst>{props.children}</MaterialStylesProvider>;
+};
+
+/**
+ * Default export
+ */
+export default StylesProvider;

--- a/src/components/StylesProvider/tsconfig.json
+++ b/src/components/StylesProvider/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "src/*.stories.tsx"],
+  "references": []
+}

--- a/src/components/Timeline/src/StepContent.tsx
+++ b/src/components/Timeline/src/StepContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TransitionProps } from '@material-ui/core/transitions';
-import { StepContent as MaterialStepContent, StylesProvider } from '@material-ui/core';
+import { StepContent as MaterialStepContent } from '@material-ui/core';
 
 import { StepComponentProps } from './StepComponentProps';
 import { stepContentClass } from './bem-mapping';
@@ -45,18 +45,16 @@ export const StepContent: React.FC<StepContentProps> = ({
   ...props
 }: StepContentProps) => {
   return (
-    <StylesProvider injectFirst>
-      <MaterialStepContent
-        id={id}
-        className={stepContentClass}
-        TransitionComponent={TransitionComponent}
-        TransitionProps={TransitionProps}
-        transitionDuration={transitionDuration}
-        {...props}
-      >
-        {children}
-      </MaterialStepContent>
-    </StylesProvider>
+    <MaterialStepContent
+      id={id}
+      className={stepContentClass}
+      TransitionComponent={TransitionComponent}
+      TransitionProps={TransitionProps}
+      transitionDuration={transitionDuration}
+      {...props}
+    >
+      {children}
+    </MaterialStepContent>
   );
 };
 

--- a/src/components/Timeline/src/StepIcon.tsx
+++ b/src/components/Timeline/src/StepIcon.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import clsx from 'clsx';
-import { StylesProvider } from '@material-ui/core';
 import SvgIcon, { SvgIconProps, CheckCircleIcon } from '@gemeente-denhaag/icons';
 
 import { stepIconClasses } from './bem-mapping';
@@ -49,22 +48,16 @@ export const StepIcon: React.FC<StepIconProps> = ({
   };
 
   if (completed) {
-    return (
-      <StylesProvider injectFirst>
-        <CheckCircleIcon classes={stepIconClasses} color={color} />
-      </StylesProvider>
-    );
+    return <CheckCircleIcon classes={stepIconClasses} color={color} />;
   }
 
   return (
-    <StylesProvider injectFirst>
-      <SvgIcon id={id} viewBox="0 0 20 20" classes={stepIconClasses} color={color}>
-        <circle {...circleProps} />
-        <text x="10" y="14" textAnchor="middle" className={textClasses}>
-          {icon}
-        </text>
-      </SvgIcon>
-    </StylesProvider>
+    <SvgIcon id={id} viewBox="0 0 20 20" classes={stepIconClasses} color={color}>
+      <circle {...circleProps} />
+      <text x="10" y="14" textAnchor="middle" className={textClasses}>
+        {icon}
+      </text>
+    </SvgIcon>
   );
 };
 

--- a/src/meta-packages/denhaag-component-library/package.json
+++ b/src/meta-packages/denhaag-component-library/package.json
@@ -27,7 +27,8 @@
     "@gemeente-denhaag/layout": "^0.2.2",
     "@gemeente-denhaag/navigation": "^0.2.2",
     "@gemeente-denhaag/pickers": "^0.2.2",
-    "@gemeente-denhaag/surfaces": "^0.2.2"
+    "@gemeente-denhaag/surfaces": "^0.2.2",
+    "@gemeente-denhaag/stylesprovider": "^0.1.0"
   },
   "peerDependencies": {
     "react": "^17.0.1"

--- a/src/meta-packages/denhaag-component-library/src/index.tsx
+++ b/src/meta-packages/denhaag-component-library/src/index.tsx
@@ -3,3 +3,4 @@ export * from '@gemeente-denhaag/input';
 export * from '@gemeente-denhaag/layout';
 export * from '@gemeente-denhaag/navigation';
 export * from '@gemeente-denhaag/surfaces';
+export * from '@gemeente-denhaag/stylesprovider';


### PR DESCRIPTION
<!--

IMPORTANT: Please do not create a Pull Request without creating an issue first.
Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

Please provide enough information so that others can review your pull request:
You can skip this if you're fixing a typo or adding an app to the Showcase.

Explain the details for making this change. What existing problem does the pull request solve?
Example: When "Adding a function to do X", explain why it is necessary to have a way to do X.

-->
Instead of wrapping every MUI based component with StylesProvider individually, I added a decorator that wraps it for every story.

In the react app, we should then enforce the CSS to be loaded in the correct order.
The easiest way is to do this with StylesProvider in the client and wrapping the whole app in 
`<StyleProvider injectFirst>`

Related links:
https://material-ui.com/styles/advanced/#injectfirst
https://www.sipios.com/blog-tech/how-to-use-styled-components-with-material-ui-in-a-react-app

**Closing issues**
closes #288 

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
