### PR TITLE
Storybook theme switcher and Style Dictionary theme output

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,17 @@ module.exports = {
     '../src/components/*/src/**/*.stories.@(js|jsx|ts|tsx)',
     '../src/components/*/src/**/*.stories.mdx',
   ],
-  addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials', 'storybook-design-token'],
+  addons: [
+    '@storybook/addon-a11y',
+    '@storybook/addon-links',
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        backgrounds: false,
+      },
+    },
+    'storybook-design-token',
+  ],
 
   webpackFinal: async (config, { configType }) => {
     const rules = config.module.rules;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,6 +13,7 @@ module.exports = {
         backgrounds: false,
       },
     },
+    'storybook-addon-themes',
     'storybook-design-token',
   ],
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,11 @@
-import '@gemeente-denhaag/design-tokens-proprietary';
-import '@gemeente-denhaag/design-tokens-components';
-import '@gemeente-denhaag/design-tokens-common';
+import '@gemeente-denhaag/design-tokens-proprietary/dist/theme/index.css';
+import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
+import '@gemeente-denhaag/design-tokens-common/dist/theme/index.css';
+
+import { addDecorator } from '@storybook/react';
+import { withThemes } from 'storybook-addon-themes/react';
+
+addDecorator(withThemes);
 
 const tokenContext = require.context(
   '!!raw-loader!../src',
@@ -22,5 +27,9 @@ export const parameters = {
     storySort: {
       order: ['Den Haag', ['Introduction', 'Design Tokens'], 'Components'],
     },
+  },
+  themes: {
+    default: 'Gemeente Den Haag',
+    list: [{ name: 'Gemeente Den Haag', class: 'denhaag-theme', color: '#227b3c' }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "rollup-plugin-postcss": "^4.0.0",
     "rollup-plugin-svgo": "^1.1.0",
     "storybook": "^6.3.2",
+    "storybook-addon-themes": "^6.1.0",
     "storybook-design-token": "^1.1.1",
     "style-dictionary": "^3.0.1",
     "stylelint": "^13.8.0",

--- a/style-dictionary.config.json
+++ b/style-dictionary.config.json
@@ -33,6 +33,20 @@
           }
         }
       ]
+    },
+    "css-theme": {
+      "transforms": ["attribute/cti", "name/cti/kebab", "color/hsl-4"],
+      "buildPath": "dist/",
+      "files": [
+        {
+          "destination": "theme/index.css",
+          "format": "css/variables",
+          "options": {
+            "selector": ".denhaag-theme",
+            "outputReferences": true
+          }
+        }
+      ]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,7 +3477,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.3.4", "@storybook/addons@^6.2.9", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.2":
+"@storybook/addons@6.3.4", "@storybook/addons@^6.0.0", "@storybook/addons@^6.2.9", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.2":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.4.tgz#016c5c3e36c78a320eb8b022cf7fe556d81577c2"
   integrity sha512-rf8K8X3JrB43gq5nw5SYgfucQkFg2QgUMWdByf7dQ4MyIl5zet+2MYiSXJ9lfbhGKJZ8orc81rmMtiocW4oBjg==
@@ -3492,7 +3492,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.3.2":
+"@storybook/api@6.3.2", "@storybook/api@^6.3.0":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.2.tgz#669c9eb1b5f50659b894f374af1c3eb3d4c2ac20"
   integrity sha512-rXe7l8mwNEvk3cqHYJ4H2XQWWY8oeezJezgt1ZBq4GvNVzVUPjASi1meXQwAYm39SdCL5+lP/hLpAZvobB1Tag==
@@ -3518,7 +3518,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/api@6.3.4", "@storybook/api@^6.3.0":
+"@storybook/api@6.3.4", "@storybook/api@^6.0.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.4.tgz#25b8b842104693000b018b3f64986e95fa032b45"
   integrity sha512-12q6dvSR4AtyuZbKAy3Xt+ZHzZ4ePPRV1q20xtgYBoiFEgB9vbh4XKEeeZD0yIeTamQ2x1Hn87R79Rs1GIdKRQ==
@@ -3809,7 +3809,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/components@6.3.4", "@storybook/components@^6.2.9", "@storybook/components@^6.3.0":
+"@storybook/components@6.3.4", "@storybook/components@^6.0.0", "@storybook/components@^6.2.9", "@storybook/components@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.4.tgz#c872ec267edf315eaada505be8595c70eb6db09b"
   integrity sha512-0hBKTkkQbW+daaA6nRedkviPr2bEzy1kwq0H5eaLKI1zYeXN3U5Z8fVhO137PPqH5LmLietrmTPkqiljUBk9ug==
@@ -3923,7 +3923,7 @@
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/core-events@6.3.4", "@storybook/core-events@^6.3.0":
+"@storybook/core-events@6.3.4", "@storybook/core-events@^6.0.0", "@storybook/core-events@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.4.tgz#f841b8659a8729d334acd9a6dcfc470c88a2be8f"
   integrity sha512-6qI5bU5VcAoRfxkvpdRqO16eYrX5M0P2E3TakqUUDcgDo5Rfcwd1wTTcwiXslMIh7oiVGiisA+msKTlfzyKf9Q==
@@ -4181,7 +4181,7 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/theming@6.3.4", "@storybook/theming@^6.2.9":
+"@storybook/theming@6.3.4", "@storybook/theming@^6.0.0", "@storybook/theming@^6.2.9":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.3.4.tgz#69d3f912c74a7b6ba78c1c95fac3315356468bdd"
   integrity sha512-L0lJcwUi7mse+U7EBAv5NVt81mH1MtUzk9paik8hMAc68vDtR/X0Cq4+zPsgykCROOTtEGrQ/JUUrpcEqeprTQ==
@@ -7378,7 +7378,7 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.0.4, core-js@^3.4.1, core-js@^3.6.5, core-js@^3.8.2:
+core-js@^3.0.4, core-js@^3.4.1, core-js@^3.6.4, core-js@^3.6.5, core-js@^3.8.2:
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.2.tgz#740660d2ff55ef34ce664d7e2455119c5bdd3d61"
   integrity sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
@@ -17941,6 +17941,20 @@ storybook-addon-outline@^1.4.1:
     "@storybook/components" "^6.3.0"
     "@storybook/core-events" "^6.3.0"
     ts-dedent "^2.1.1"
+
+storybook-addon-themes@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/storybook-addon-themes/-/storybook-addon-themes-6.1.0.tgz#5d7afe293cd4bc28a8f634aa466dbd8fd2f9222e"
+  integrity sha512-ZT8aNgrwFVNEOmOPBLNS0WBacjvMFo/bZ83P8MmsJ3Ewqt0AbmPioghTZccARUn/EQ+LrDxyh2D0QgmLaKo07Q==
+  dependencies:
+    "@storybook/addons" "^6.0.0"
+    "@storybook/api" "^6.0.0"
+    "@storybook/components" "^6.0.0"
+    "@storybook/core-events" "^6.0.0"
+    "@storybook/theming" "^6.0.0"
+    core-js "^3.6.4"
+    global "^4.4.0"
+    memoizerific "^1.11.3"
 
 storybook-design-token@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Replace "light" and "dark" toolbar button with full-fledged theme switcher addon.

https://github.com/tonai/storybook-addon-themes

To make this work, the design tokens should always not be available on `:root` but be provided via a theme class name instead.

I have added an additional file to the Style Dictionary output, `theme/index.css`, that provides all the design tokens for the `.denhaag-theme` class name.