### PR TITLE
Fix timeline missing design token

### DIFF
--- a/src/components/Timeline/src/styles/step.css
+++ b/src/components/Timeline/src/styles/step.css
@@ -11,7 +11,7 @@
 }
 
 .denhaag-timeline__step-collapse-icon {
-  padding-inline-start: var(--denhaag-timeline-step-collapse-icon-start-padding);
+  padding-inline-start: var(--denhaag-timeline-step-collapse-icon-padding);
   height: var(--denhaag-timeline-step-collapse-icon-size);
   width: var(--denhaag-timeline-step-collapse-icon-size);
 }

--- a/src/styles/Components/src/denhaag/timeline/element-modifier.style-dictionary.json
+++ b/src/styles/Components/src/denhaag/timeline/element-modifier.style-dictionary.json
@@ -10,6 +10,11 @@
         },
         "disabled": {
           "color": { "value": "{denhaag.color.grey.2.value}" }
+        },
+        "text": {
+          "active": {
+            "color": {"value":  "{denhaag.color.white.value}" }
+          }
         }
       },
       "step-label": {


### PR DESCRIPTION
Timeline styling is broken in staging due to a missing token after migrating to style-dictionary.
http://dhreactstorybook-staging.azurewebsites.net/?path=/story/components-navigation-timeline--default
![image](https://user-images.githubusercontent.com/24610692/125445435-c97d9f37-35e7-40bc-90cc-7aeff8ff3dd1.png)

Should be
![image](https://user-images.githubusercontent.com/24610692/125445455-f6120827-d93a-4654-84d8-e64898fa9aee.png)
