### PR TITLE
Expose className property on all components

### DIFF
--- a/src/components/Alerts/src/index.tsx
+++ b/src/components/Alerts/src/index.tsx
@@ -54,7 +54,7 @@ export const Alerts: React.FC<AlertsProps> = ({
   supportIcon,
   className,
 }: AlertsProps) => {
-  const rootClassNames = clsx(`denhaag-alert denhaag-alert--${variant}`, className);
+  const rootClassNames = clsx('denhaag-alert', `denhaag-alert--${variant}`, className);
   let icon;
 
   if (supportIcon !== undefined) {

--- a/src/components/Alerts/src/index.tsx
+++ b/src/components/Alerts/src/index.tsx
@@ -6,6 +6,7 @@ import { AlertTriangleIcon, CheckCircleIcon, CircleInformationIcon, CloseIcon } 
 import IconButton from '@gemeente-denhaag/iconbutton';
 
 import './alert.css';
+import clsx from 'clsx';
 
 export interface AlertsProps extends Omit<BaseProps, 'children' | 'classes' | 'tabIndex'> {
   /**
@@ -51,9 +52,9 @@ export const Alerts: React.FC<AlertsProps> = ({
   action,
   close,
   supportIcon,
+  className,
 }: AlertsProps) => {
-  const rootStyles = 'denhaag-alert denhaag-alert--' + variant;
-
+  const rootClassNames = clsx(`denhaag-alert denhaag-alert--${variant}`, className);
   let icon;
 
   if (supportIcon !== undefined) {
@@ -76,7 +77,7 @@ export const Alerts: React.FC<AlertsProps> = ({
   }
 
   return (
-    <div id={id} className={rootStyles}>
+    <div id={id} className={rootClassNames}>
       <div className="denhaag-alert__main-content">
         <div className="denhaag-alert__icon">{icon}</div>
         <div className="denhaag-alert__content">

--- a/src/components/BadgeCounter/src/index.tsx
+++ b/src/components/BadgeCounter/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { DotIndicator } from '@gemeente-denhaag/dotindicator';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import './badge-counter.css';
+import clsx from 'clsx';
 
 export type BadgeCounterProps = Omit<BaseProps, 'tabIndex' | 'classes'>;
 
@@ -11,8 +12,9 @@ export type BadgeCounterProps = Omit<BaseProps, 'tabIndex' | 'classes'>;
  * @constructor Constructs an instance of Badge.
  */
 export const BadgeCounter: React.FC<BadgeCounterProps> = (props: BadgeCounterProps) => {
+  const rootClassNames = clsx('denhaag-badge-counter', props.className);
   return (
-    <div id={props.id} className={'denhaag-badge-counter'}>
+    <div id={props.id} className={rootClassNames}>
       <DotIndicator overlap={'rectangle'}>
         <div className={'denhaag-badge-counter__counter'}>{props.children}</div>
       </DotIndicator>

--- a/src/components/BadgeCounter/src/stories/BadgeCounter.stories.mdx
+++ b/src/components/BadgeCounter/src/stories/BadgeCounter.stories.mdx
@@ -20,7 +20,7 @@ import readme from "../../README.md";
   <Story
     name="Default"
   >
-    {(args) => <BadgeCounter>13</BadgeCounter>}
+    {(args) => <BadgeCounter {...args}>13</BadgeCounter>}
   </Story>
 </Canvas>
 

--- a/src/components/BaseProps/src/index.tsx
+++ b/src/components/BaseProps/src/index.tsx
@@ -23,6 +23,11 @@ export default interface BaseProps {
    * The id attribute is used to specify a unique id for an HTML element.
    */
   id?: string;
+
+  /**
+   * Extend the styles of the component by adding new classes.
+   */
+  className?: string;
 }
 
 /**

--- a/src/components/Button/src/index.tsx
+++ b/src/components/Button/src/index.tsx
@@ -4,6 +4,7 @@ import BaseProps from '@gemeente-denhaag/baseprops';
 import { classes } from './bem-mapping';
 import './mui-override.css';
 import './button.css';
+import clsx from 'clsx';
 
 export interface ButtonProps extends BaseProps {
   /**
@@ -47,6 +48,7 @@ export interface ButtonProps extends BaseProps {
  */
 export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
   const sizeClass = `denhaag-button--${props.size ?? 'medium'}`;
+  const rootClassNames = clsx(sizeClass, props.className);
   let muiVariant: ButtonTypeMap['props']['variant'] = 'contained';
 
   switch (props.variant) {
@@ -61,7 +63,7 @@ export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
   return (
     <MaterialButton
       classes={classes}
-      className={sizeClass}
+      className={rootClassNames}
       variant={muiVariant}
       onClick={props.onClick}
       disabled={props.disabled}

--- a/src/components/Card/src/Card/Card.tsx
+++ b/src/components/Card/src/Card/Card.tsx
@@ -4,11 +4,12 @@ import { ArrowRightIcon } from '@gemeente-denhaag/icons';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import './mui-override.css';
 import './card.css';
-import { cardClasses, cardArrowClasses, cardTitleClasses, cardSubtitleClasses, cardCaseClasses } from './bem-mapping';
+import { cardArrowClasses, cardCaseClasses, cardClasses, cardSubtitleClasses, cardTitleClasses } from './bem-mapping';
 import { CardContent } from '../CardContent/CardContent';
 import { CardActions } from '../CardActions/CardActions';
+import clsx from 'clsx';
 
-export interface CardProps extends BaseProps {
+export interface CardProps extends Omit<BaseProps, 'classes'> {
   /**
    * Callback fired when the Card is clicked.
    */
@@ -45,7 +46,7 @@ export interface CardProps extends BaseProps {
  * Primary UI component for user interaction
  */
 export const Card: React.FC<CardProps> = (props: CardProps) => {
-  let classes;
+  const rootClassNames = clsx(cardClasses.root, props.variant === 'case' && cardCaseClasses.root, props.className);
   const arrowClasses = cardArrowClasses;
   const titleClasses = cardTitleClasses;
   const subtitleClasses = cardSubtitleClasses;
@@ -63,17 +64,8 @@ export const Card: React.FC<CardProps> = (props: CardProps) => {
     }
   };
 
-  switch (props.variant) {
-    case 'case':
-      classes = cardCaseClasses;
-      break;
-    case 'basic':
-    default:
-      classes = cardClasses;
-  }
-
   return (
-    <MaterialCard classes={classes} onClick={onClick}>
+    <MaterialCard className={rootClassNames} onClick={onClick}>
       <div className="denhaag-card__wrapper">
         <div className="denhaag-card__background"></div>
         <CardContent>

--- a/src/components/Checkbox/src/index.tsx
+++ b/src/components/Checkbox/src/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
-import { BaseClassesProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 import { CheckedIcon, UncheckedBoxIcon } from '@gemeente-denhaag/icons';
 
 import './checkbox.css';
 
-export interface CheckboxProps extends BaseClassesProps {
+export interface CheckboxProps extends Omit<BaseProps, 'classes'> {
   /**
    * If `true` the Checkbox is checked.
    * See https://github.com/mui-org/material-ui/blob/master/docs/src/pages/components/checkboxes/Checkboxes.tsx
@@ -50,11 +50,15 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   ...props
 }: CheckboxProps) => {
   const [isChecked, setChecked] = React.useState(checked);
-  const rootStyles = clsx('denhaag-checkbox', {
-    'denhaag-checkbox--error': props.error,
-    'denhaag-checkbox--checked': isChecked,
-    'denhaag-checkbox--disabled': props.disabled,
-  });
+  const rootStyles = clsx(
+    'denhaag-checkbox',
+    {
+      'denhaag-checkbox--error': props.error,
+      'denhaag-checkbox--checked': isChecked,
+      'denhaag-checkbox--disabled': props.disabled,
+    },
+    props.className,
+  );
 
   const icon = isChecked ? checkedIcon : uncheckedIcon;
 

--- a/src/components/Checkbox/src/stories/Checkbox.stories.mdx
+++ b/src/components/Checkbox/src/stories/Checkbox.stories.mdx
@@ -44,7 +44,7 @@ import readme from "../../README.md";
     {(args) => (
       <FormControlLabel
         label="Checkbox"
-        control={<Checkbox onChange={action("Checkbox action")}></Checkbox>}
+        control={<Checkbox onChange={action("Checkbox action")} {...args}></Checkbox>}
       ></FormControlLabel>
     )}
   </Story>
@@ -67,7 +67,7 @@ const ReactCheckBox = <Checkbox onChange={() => {}}></Checkbox>;
       },
     }}
   >
-    {(args) => <Checkbox onChange={action("Checkbox action")}></Checkbox>}
+    {(args) => <Checkbox onChange={action("Checkbox action")} {...args}></Checkbox>}
   </Story>
 </Canvas>
 
@@ -138,15 +138,15 @@ const ReactCheckBox = <Checkbox onChange={() => {}}></Checkbox>;
       <FormGroup label="Label" helperText="You can show errors" error>
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox error checked onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox error checked onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
       </FormGroup>
     )}
@@ -159,15 +159,15 @@ const ReactCheckBox = <Checkbox onChange={() => {}}></Checkbox>;
       <FormGroup label="Label" helperText="Disabled checkboxes">
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox disabled checked onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox disabled checked onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox disabled onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox disabled onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
         <FormControlLabel
           label="Checkbox"
-          control={<Checkbox onChange={action("Checkbox action")}></Checkbox>}
+          control={<Checkbox onChange={action("Checkbox action")} {...args}></Checkbox>}
         ></FormControlLabel>
       </FormGroup>
     )}

--- a/src/components/Divider/src/index.tsx
+++ b/src/components/Divider/src/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Divider as MaterialDivider } from '@material-ui/core';
-import { BaseDataDisplayClassesProps } from '@gemeente-denhaag/basedatadisplayprops';
 import './divider.css';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface DividerProps extends BaseDataDisplayClassesProps {
+export interface DividerProps extends Omit<BaseProps, 'tabIndex' | 'classes' | 'children'> {
   /**
    * The divider orientation.
    */
@@ -22,7 +22,13 @@ export const Divider: React.FC<DividerProps> = (props: DividerProps) => {
   };
 
   return (
-    <MaterialDivider variant={'fullWidth'} classes={classes} role={'presentation'} orientation={props.orientation} />
+    <MaterialDivider
+      className={props.className}
+      variant={'fullWidth'}
+      classes={classes}
+      role={'presentation'}
+      orientation={props.orientation}
+    />
   );
 };
 

--- a/src/components/DotIndicator/package.json
+++ b/src/components/DotIndicator/package.json
@@ -22,8 +22,7 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@gemeente-denhaag/baseprops": "^0.2.3-alpha.18",
-    "clsx": "^1.1.1"
+    "@gemeente-denhaag/baseprops": "^0.2.3-alpha.18"
   },
   "devDependencies": {
     "@gemeente-denhaag/avatar": "^0.2.3-alpha.18",

--- a/src/components/DotIndicator/src/index.tsx
+++ b/src/components/DotIndicator/src/index.tsx
@@ -16,12 +16,16 @@ export interface DotIndicatorProps extends Omit<BaseProps, 'classes' | 'tabIndex
  * @param props The properties of a Dot Indicator component.
  */
 export const DotIndicator: React.FC<DotIndicatorProps> = (props: DotIndicatorProps) => {
-  const rootStyles = clsx('denhaag-dot-indicator', {
-    'denhaag-dot-indicator--overlap-rectangle': props.overlap === 'rectangle',
-    'denhaag-dot-indicator--overlap-circle': props.overlap === 'circle',
-  });
+  const rootClassNames = clsx(
+    'denhaag-dot-indicator',
+    {
+      'denhaag-dot-indicator--overlap-rectangle': props.overlap === 'rectangle',
+      'denhaag-dot-indicator--overlap-circle': props.overlap === 'circle',
+    },
+    props.className,
+  );
   return (
-    <span className={rootStyles} id={props.id}>
+    <span className={rootClassNames} id={props.id}>
       {props.children}
       <span className="denhaag-dot-indicator__dot"></span>
     </span>

--- a/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
+++ b/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
@@ -40,7 +40,7 @@ const elementWithNotification = (<DotIndicator overlap="rectangle"><Button>Read 
       },
     }}
   >
-    {(args) => <DotIndicator overlap={"rectangle"}><Button variant={"secondary"}>Read messages</Button></DotIndicator>}
+    {(args) => <DotIndicator overlap={"rectangle"} {...args}><Button variant={"secondary"}>Read messages</Button></DotIndicator>}
   </Story>
 </Canvas>
 
@@ -71,7 +71,7 @@ const elementWithNotification = <DotIndicator overlap="circle"><Avatar>DH</Avata
     }}
   >
     {(args) => (
-      <DotIndicator overlap={"circle"}>
+      <DotIndicator overlap={"circle"} {...args}>
         <Avatar>DH</Avatar>
       </DotIndicator>
     )}

--- a/src/components/IconButton/src/index.tsx
+++ b/src/components/IconButton/src/index.tsx
@@ -3,6 +3,7 @@ import { IconButton as MaterialIconButton } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 import './mui-override.css';
 import './iconbutton.css';
+import clsx from 'clsx';
 
 export interface IconButtonProps extends BaseProps {
   /**
@@ -22,8 +23,9 @@ export interface IconButtonProps extends BaseProps {
  * @constructor Constructs an instance of IconButton.
  */
 export const IconButton: React.FC<IconButtonProps> = ({ disabled = false, ...props }: IconButtonProps) => {
+  const rootClassNames = clsx('denhaag-icon-button', props.className);
   return (
-    <MaterialIconButton className="denhaag-icon-button" disabled={disabled} disableRipple disableFocusRipple {...props}>
+    <MaterialIconButton {...props} className={rootClassNames} disabled={disabled} disableRipple disableFocusRipple>
       {props.children}
     </MaterialIconButton>
   );

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -86,10 +86,14 @@ export const Link: React.FC<LinkProps> = ({
   tabIndex = 0,
   ...props
 }: LinkProps) => {
-  const anchorClassName = clsx('denhaag-link', {
-    'denhaag-link--disabled': disabled,
-    'denhaag-link--with-icon': icon !== undefined,
-  });
+  const rootClassNames = clsx(
+    'denhaag-link',
+    {
+      'denhaag-link--disabled': disabled,
+      'denhaag-link--with-icon': icon !== undefined,
+    },
+    props.className,
+  );
 
   const iconClassName = clsx('denhaag-link__icon', {
     'denhaag-link__icon--start': iconAlign === 'start',
@@ -99,7 +103,7 @@ export const Link: React.FC<LinkProps> = ({
   const iconWrapped = <span className={iconClassName}>{icon}</span>;
 
   return (
-    <a id={id} href={href} className={anchorClassName} tabIndex={disabled ? -1 : tabIndex} {...props}>
+    <a id={id} href={href} tabIndex={disabled ? -1 : tabIndex} {...props} className={rootClassNames}>
       {icon !== undefined && iconAlign === 'start' ? iconWrapped : ''}
       {children}
       {icon !== undefined && iconAlign === 'end' ? iconWrapped : ''}

--- a/src/components/List/src/List.tsx
+++ b/src/components/List/src/List.tsx
@@ -11,7 +11,7 @@ import './listitemicon.css';
 import './listitemtext.css';
 import './listsubheader.css';
 
-export interface ListProps extends BaseProps {
+export interface ListProps extends Omit<BaseProps, 'classes'> {
   /**
    * The content of the subheader, normally `ListSubheader`.
    */

--- a/src/components/Menu/src/MenuButton.tsx
+++ b/src/components/Menu/src/MenuButton.tsx
@@ -81,9 +81,13 @@ export interface MenuButtonExpandableProps extends Omit<BaseProps, 'classes' | '
 }
 
 export const MenuButton: React.FC<MenuButtonProps> = ({ active = false, ...props }: MenuButtonProps) => {
-  const className = clsx('denhaag-menu-button', {
-    'denhaag-menu-button--active': active,
-  });
+  const className = clsx(
+    'denhaag-menu-button',
+    {
+      'denhaag-menu-button--active': active,
+    },
+    props.className,
+  );
 
   return (
     <a
@@ -109,12 +113,17 @@ export const MenuButtonExpandable: React.FC<MenuButtonProps> = ({
   active = false,
   ...props
 }: MenuButtonExpandableProps) => {
-  const className = clsx('denhaag-menu-button', 'denhaag-menu-button--expandable', {
-    'denhaag-menu-button--active': active,
-  });
+  const rootClassNames = clsx(
+    'denhaag-menu-button',
+    'denhaag-menu-button--expandable',
+    {
+      'denhaag-menu-button--active': active,
+    },
+    props.className,
+  );
 
   return (
-    <button id={props.id} onClick={props.onclick} className={className} title={props.children?.toString()}>
+    <button id={props.id} onClick={props.onclick} className={rootClassNames} title={props.children?.toString()}>
       {props.children}
       <span className="denhaag-menu-button__chevron">
         <ChevronDownIcon aria-label="ChevronDownIcon" />

--- a/src/components/Menu/src/index.tsx
+++ b/src/components/Menu/src/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import './menu.css';
 import BaseProps from '@gemeente-denhaag/baseprops';
+import clsx from 'clsx';
 
-export const Menu: React.FC<BaseProps> = (props: BaseProps) => {
+export const Menu: React.FC<BaseProps> = (props: Omit<BaseProps, 'classes'>) => {
+  const rootClassNames = clsx('denhaag-menu', props.className);
   return (
-    <div className="denhaag-menu" id={props.id}>
+    <div className={rootClassNames} id={props.id}>
       {props.children}
     </div>
   );

--- a/src/components/SwipeableDrawer/src/index.tsx
+++ b/src/components/SwipeableDrawer/src/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { SwipeableDrawer as MaterialSwipeableDrawer } from '@material-ui/core';
-import { BaseChildrenProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface SwipeableDrawerProps extends BaseChildrenProps {
+export interface SwipeableDrawerProps extends Omit<BaseProps, 'classes' | 'tabIndex'> {
   /**
    * Disable the backdrop transition.
    */

--- a/src/components/Switch/src/index.tsx
+++ b/src/components/Switch/src/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Switch as MaterialSwitch } from '@material-ui/core';
-import { BaseClassesProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface SwitchProps extends BaseClassesProps {
+export interface SwitchProps extends Omit<BaseProps, 'classes'> {
   /**
    * If true the Switch is turned on
    */

--- a/src/components/Tab/src/Tab.tsx
+++ b/src/components/Tab/src/Tab.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { Tab as MaterialTab } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface TabProps extends BaseProps {
+export interface TabProps extends Omit<BaseProps, 'classes'> {
   /**
    * If true, the tab will be disabled.
    */

--- a/src/components/Tab/src/TabContext.tsx
+++ b/src/components/Tab/src/TabContext.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { TabContext as MaterialTabContext } from '@material-ui/lab';
-import { BaseChildrenProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface TabContextProps extends BaseChildrenProps {
+export interface TabContextProps extends Omit<BaseProps, 'classes'> {
   /**
    * The value of the currently selected Tab.
    */

--- a/src/components/Tab/src/TabList.tsx
+++ b/src/components/Tab/src/TabList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { TabList as MaterialTabList } from '@material-ui/lab';
-import { BaseChildrenProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export type TabListProps = BaseChildrenProps;
+export type TabListProps = Omit<BaseProps, 'classes'>;
 
 /**
  * Wraps Tab components in a single list.

--- a/src/components/Tab/src/TabPanel.tsx
+++ b/src/components/Tab/src/TabPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TabPanel as MaterialTabPanel } from '@material-ui/lab';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface TabPanelProps extends BaseProps {
+export interface TabPanelProps extends Omit<BaseProps, 'classes'> {
   /**
    * The value of the corresponding Tab.
    * Must use the index of the Tab when no value was passed to Tab

--- a/src/components/Tab/src/TabScrollButton.tsx
+++ b/src/components/Tab/src/TabScrollButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TabScrollButton as MaterialTabScrollButton } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface TabScrollButtonProps extends BaseProps {
+export interface TabScrollButtonProps extends Omit<BaseProps, 'classes'> {
   /**
    * Which direction should the button indicate?
    */

--- a/src/components/Tab/src/Tabs.tsx
+++ b/src/components/Tab/src/Tabs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tabs as MaterialTabs } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface TabsProps extends BaseProps {
+export interface TabsProps extends Omit<BaseProps, 'classes'> {
   /**
    * Callback fired when the component mounts.
    */

--- a/src/components/TextField/src/BaseTextFieldProps.ts
+++ b/src/components/TextField/src/BaseTextFieldProps.ts
@@ -1,8 +1,8 @@
 import { FormHelperTextProps, InputLabelProps, PropTypes, SelectProps } from '@material-ui/core';
 import React from 'react';
-import { BaseClassesProps } from '@gemeente-denhaag/baseprops';
+import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface BaseTextFieldProps extends BaseClassesProps {
+export interface BaseTextFieldProps extends Omit<BaseProps, 'classes'> {
   /**
    * This prop helps users to fill forms faster, especially on mobile devices.
    * The name can be confusing, as it's more like an autofill.

--- a/src/components/Timeline/package.json
+++ b/src/components/Timeline/package.json
@@ -25,8 +25,7 @@
     "@gemeente-denhaag/baseprops": "^0.2.3-alpha.18",
     "@gemeente-denhaag/icons": "^0.2.3-alpha.18",
     "@gemeente-denhaag/typography": "^0.2.3-alpha.18",
-    "@material-ui/core": "^4.11.0",
-    "clsx": "^1.1.1"
+    "@material-ui/core": "^4.11.0"
   },
   "peerDependencies": {
     "react": "^17.0.1"

--- a/src/components/Timeline/src/Step.tsx
+++ b/src/components/Timeline/src/Step.tsx
@@ -88,6 +88,7 @@ export const Step: React.FC<StepProps> = ({
       role={role}
       tabIndex={tabIndex}
       {...props}
+      className={props.className}
     >
       <StepLabel>
         {label}

--- a/src/components/Timeline/src/StepComponentProps.ts
+++ b/src/components/Timeline/src/StepComponentProps.ts
@@ -1,6 +1,6 @@
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface StepComponentProps extends BaseProps {
+export interface StepComponentProps extends Omit<BaseProps, 'classes'> {
   /**
    * Sets the step as active.
    */

--- a/src/components/Timeline/src/StepContent.tsx
+++ b/src/components/Timeline/src/StepContent.tsx
@@ -4,6 +4,7 @@ import { StepContent as MaterialStepContent } from '@material-ui/core';
 
 import { StepComponentProps } from './StepComponentProps';
 import { stepContentClass } from './bem-mapping';
+import clsx from 'clsx';
 
 export interface StepContentProps extends StepComponentProps {
   /**
@@ -44,14 +45,16 @@ export const StepContent: React.FC<StepContentProps> = ({
   id = undefined,
   ...props
 }: StepContentProps) => {
+  const rootClassNames = clsx(stepContentClass, props.className);
+
   return (
     <MaterialStepContent
       id={id}
-      className={stepContentClass}
       TransitionComponent={TransitionComponent}
       TransitionProps={TransitionProps}
       transitionDuration={transitionDuration}
       {...props}
+      className={rootClassNames}
     >
       {children}
     </MaterialStepContent>

--- a/src/components/Timeline/src/StepLabel.tsx
+++ b/src/components/Timeline/src/StepLabel.tsx
@@ -36,6 +36,7 @@ export const StepLabel: React.FC<StepLabelProps> = ({
   disabled = false,
   expanded = false,
   id = undefined,
+  className,
 }: StepLabelProps) => {
   let UpdatedStepIconComponent: React.ReactElement;
   if (StepIconComponent === undefined) {
@@ -47,11 +48,15 @@ export const StepLabel: React.FC<StepLabelProps> = ({
     UpdatedStepIconComponent.props = { ...StepIconComponent.props, ...StepIconProps };
   }
 
-  const classes = clsx('denhaag-timeline__step-label', {
-    'denhaag-timeline__step-label--active': active || expanded,
-    'denhaag-timeline__step-label--disabled': disabled,
-    'denhaag-timeline__step-label--completed': completed,
-  });
+  const classes = clsx(
+    'denhaag-timeline__step-label',
+    {
+      'denhaag-timeline__step-label--active': active || expanded,
+      'denhaag-timeline__step-label--disabled': disabled,
+      'denhaag-timeline__step-label--completed': completed,
+    },
+    className,
+  );
 
   return (
     <div id={id} className={classes}>

--- a/src/components/Timeline/src/Timeline.tsx
+++ b/src/components/Timeline/src/Timeline.tsx
@@ -4,7 +4,7 @@ import BaseProps from '@gemeente-denhaag/baseprops';
 
 import { timelineClasses } from './bem-mapping';
 
-export interface TimelineProps extends BaseProps {
+export interface TimelineProps extends Omit<BaseProps, 'classes'> {
   /**
    * Set the active step (zero based index). Set to -1 to disable all the steps.
    */
@@ -21,7 +21,12 @@ export interface TimelineProps extends BaseProps {
  * @param props The properties of a Timeline component.
  * @constructor Constructs an instance of Timeline.
  */
-export const Timeline: React.FC<TimelineProps> = ({ activeStep, children, id = undefined }: TimelineProps) => {
+export const Timeline: React.FC<TimelineProps> = ({
+  activeStep,
+  children,
+  id = undefined,
+  className,
+}: TimelineProps) => {
   return (
     <MaterialStepper
       activeStep={activeStep}
@@ -30,6 +35,7 @@ export const Timeline: React.FC<TimelineProps> = ({ activeStep, children, id = u
       id={id}
       nonLinear
       orientation="vertical"
+      className={className}
     >
       {children}
     </MaterialStepper>

--- a/src/components/Toolbar/src/index.tsx
+++ b/src/components/Toolbar/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Toolbar as MaterialToolbar } from '@material-ui/core';
 import BaseProps from '@gemeente-denhaag/baseprops';
 
-export interface ToolbarProps extends BaseProps {
+export interface ToolbarProps extends Omit<BaseProps, 'classes'> {
   /**
    * The component used for the root node. Either a string to use a HTML element or a component.
    */

--- a/src/components/Typography/src/Heading1.tsx
+++ b/src/components/Typography/src/Heading1.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
 import clsx from 'clsx';
 
-export type Heading1Props = BaseDataDisplayProps;
+export type Heading1Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading1: React.FC<Heading1Props> = (props: Heading1Props) => {
   const rootClassNames = clsx('utrecht-heading-1 utrecht-heading-1--distanced', props.className);

--- a/src/components/Typography/src/Heading1.tsx
+++ b/src/components/Typography/src/Heading1.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading1Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading1: React.FC<Heading1Props> = (props: Heading1Props) => {
-  const rootClassNames = clsx('utrecht-heading-1 utrecht-heading-1--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-1', 'utrecht-heading-1--distanced', props.className);
   return <h1 className={rootClassNames}>{props.children}</h1>;
 };

--- a/src/components/Typography/src/Heading1.tsx
+++ b/src/components/Typography/src/Heading1.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
+import clsx from 'clsx';
 
 export type Heading1Props = BaseDataDisplayProps;
 
 export const Heading1: React.FC<Heading1Props> = (props: Heading1Props) => {
-  return <h1 className="utrecht-heading-1 utrecht-heading-1--distanced">{props.children}</h1>;
+  const rootClassNames = clsx('utrecht-heading-1 utrecht-heading-1--distanced', props.className);
+  return <h1 className={rootClassNames}>{props.children}</h1>;
 };

--- a/src/components/Typography/src/Heading2.tsx
+++ b/src/components/Typography/src/Heading2.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
 import clsx from 'clsx';
 
-export type Heading2Props = BaseDataDisplayProps;
+export type Heading2Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading2: React.FC<Heading2Props> = (props: Heading2Props) => {
   const rootClassNames = clsx('utrecht-heading-2 utrecht-heading-2--distanced', props.className);

--- a/src/components/Typography/src/Heading2.tsx
+++ b/src/components/Typography/src/Heading2.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
+import clsx from 'clsx';
 
 export type Heading2Props = BaseDataDisplayProps;
 
 export const Heading2: React.FC<Heading2Props> = (props: Heading2Props) => {
-  return <h2 className="utrecht-heading-2 utrecht-heading-2--distanced">{props.children}</h2>;
+  const rootClassNames = clsx('utrecht-heading-2 utrecht-heading-2--distanced', props.className);
+  return <h2 className={rootClassNames}>{props.children}</h2>;
 };

--- a/src/components/Typography/src/Heading2.tsx
+++ b/src/components/Typography/src/Heading2.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading2Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading2: React.FC<Heading2Props> = (props: Heading2Props) => {
-  const rootClassNames = clsx('utrecht-heading-2 utrecht-heading-2--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-2', 'utrecht-heading-2--distanced', props.className);
   return <h2 className={rootClassNames}>{props.children}</h2>;
 };

--- a/src/components/Typography/src/Heading3.tsx
+++ b/src/components/Typography/src/Heading3.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
+import clsx from 'clsx';
 
 export type Heading3Props = BaseDataDisplayProps;
 
 export const Heading3: React.FC<Heading3Props> = (props: Heading3Props) => {
-  return <h3 className="utrecht-heading-3 utrecht-heading-3--distanced">{props.children}</h3>;
+  const rootClassNames = clsx('utrecht-heading-3 utrecht-heading-3--distanced', props.className);
+  return <h3 className={rootClassNames}>{props.children}</h3>;
 };

--- a/src/components/Typography/src/Heading3.tsx
+++ b/src/components/Typography/src/Heading3.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
 import clsx from 'clsx';
 
-export type Heading3Props = BaseDataDisplayProps;
+export type Heading3Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading3: React.FC<Heading3Props> = (props: Heading3Props) => {
   const rootClassNames = clsx('utrecht-heading-3 utrecht-heading-3--distanced', props.className);

--- a/src/components/Typography/src/Heading3.tsx
+++ b/src/components/Typography/src/Heading3.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading3Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading3: React.FC<Heading3Props> = (props: Heading3Props) => {
-  const rootClassNames = clsx('utrecht-heading-3 utrecht-heading-3--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-3', 'utrecht-heading-3--distanced', props.className);
   return <h3 className={rootClassNames}>{props.children}</h3>;
 };

--- a/src/components/Typography/src/Heading4.tsx
+++ b/src/components/Typography/src/Heading4.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading4Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading4: React.FC<Heading4Props> = (props: Heading4Props) => {
-  const rootClassNames = clsx('utrecht-heading-4 utrecht-heading-4--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-4', 'utrecht-heading-4--distanced', props.className);
   return <h4 className={rootClassNames}>{props.children}</h4>;
 };

--- a/src/components/Typography/src/Heading4.tsx
+++ b/src/components/Typography/src/Heading4.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
+import clsx from 'clsx';
 
 export type Heading4Props = BaseDataDisplayProps;
 
 export const Heading4: React.FC<Heading4Props> = (props: Heading4Props) => {
-  return <h4 className="utrecht-heading-4 utrecht-heading-4--distanced">{props.children}</h4>;
+  const rootClassNames = clsx('utrecht-heading-4 utrecht-heading-4--distanced', props.className);
+  return <h4 className={rootClassNames}>{props.children}</h4>;
 };

--- a/src/components/Typography/src/Heading4.tsx
+++ b/src/components/Typography/src/Heading4.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
 import clsx from 'clsx';
 
-export type Heading4Props = BaseDataDisplayProps;
+export type Heading4Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading4: React.FC<Heading4Props> = (props: Heading4Props) => {
   const rootClassNames = clsx('utrecht-heading-4 utrecht-heading-4--distanced', props.className);

--- a/src/components/Typography/src/Heading5.tsx
+++ b/src/components/Typography/src/Heading5.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading5Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading5: React.FC<Heading5Props> = (props: Heading5Props) => {
-  const rootClassNames = clsx('utrecht-heading-5 utrecht-heading-5--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-5', 'utrecht-heading-5--distanced', props.className);
   return <h5 className={rootClassNames}>{props.children}</h5>;
 };

--- a/src/components/Typography/src/Heading5.tsx
+++ b/src/components/Typography/src/Heading5.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
+import clsx from 'clsx';
 
 export type Heading5Props = BaseDataDisplayProps;
 
 export const Heading5: React.FC<Heading5Props> = (props: Heading5Props) => {
-  return <h5 className="utrecht-heading-5 utrecht-heading-5--distanced">{props.children}</h5>;
+  const rootClassNames = clsx('utrecht-heading-5 utrecht-heading-5--distanced', props.className);
+  return <h5 className={rootClassNames}>{props.children}</h5>;
 };

--- a/src/components/Typography/src/Heading5.tsx
+++ b/src/components/Typography/src/Heading5.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.css';
 import clsx from 'clsx';
 
-export type Heading5Props = BaseDataDisplayProps;
+export type Heading5Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading5: React.FC<Heading5Props> = (props: Heading5Props) => {
   const rootClassNames = clsx('utrecht-heading-5 utrecht-heading-5--distanced', props.className);

--- a/src/components/Typography/src/LeadParagraph.tsx
+++ b/src/components/Typography/src/LeadParagraph.tsx
@@ -7,7 +7,9 @@ export type LeadParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const LeadParagraph: React.FC<LeadParagraphProps> = (props: LeadParagraphProps) => {
   const rootClassNames = clsx(
-    'utrecht-paragraph utrecht-paragraph--lead utrecht-paragraph--distanced',
+    'utrecht-paragraph',
+    'utrecht-paragraph--lead',
+    'utrecht-paragraph--distanced',
     props.className,
   );
   return <p className={rootClassNames}>{props.children}</p>;

--- a/src/components/Typography/src/LeadParagraph.tsx
+++ b/src/components/Typography/src/LeadParagraph.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.css';
 import clsx from 'clsx';
 
-export type LeadParagraphProps = BaseDataDisplayProps;
+export type LeadParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const LeadParagraph: React.FC<LeadParagraphProps> = (props: LeadParagraphProps) => {
   const rootClassNames = clsx(

--- a/src/components/Typography/src/LeadParagraph.tsx
+++ b/src/components/Typography/src/LeadParagraph.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.css';
+import clsx from 'clsx';
 
 export type LeadParagraphProps = BaseDataDisplayProps;
 
 export const LeadParagraph: React.FC<LeadParagraphProps> = (props: LeadParagraphProps) => {
-  return <p className="utrecht-paragraph utrecht-paragraph--lead utrecht-paragraph--distanced">{props.children}</p>;
+  const rootClassNames = clsx(
+    'utrecht-paragraph utrecht-paragraph--lead utrecht-paragraph--distanced',
+    props.className,
+  );
+  return <p className={rootClassNames}>{props.children}</p>;
 };

--- a/src/components/Typography/src/Paragraph.tsx
+++ b/src/components/Typography/src/Paragraph.tsx
@@ -3,7 +3,7 @@ import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.css';
 import clsx from 'clsx';
 
-export type ParagraphProps = BaseDataDisplayProps;
+export type ParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Paragraph: React.FC<ParagraphProps> = (props: ParagraphProps) => {
   const rootClassNames = clsx('utrecht-paragraph utrecht-paragraph--distanced', props.className);

--- a/src/components/Typography/src/Paragraph.tsx
+++ b/src/components/Typography/src/Paragraph.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type ParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Paragraph: React.FC<ParagraphProps> = (props: ParagraphProps) => {
-  const rootClassNames = clsx('utrecht-paragraph utrecht-paragraph--distanced', props.className);
+  const rootClassNames = clsx('utrecht-paragraph', 'utrecht-paragraph--distanced', props.className);
   return <p className={rootClassNames}> {props.children}</p>;
 };

--- a/src/components/Typography/src/Paragraph.tsx
+++ b/src/components/Typography/src/Paragraph.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.css';
+import clsx from 'clsx';
 
 export type ParagraphProps = BaseDataDisplayProps;
 
 export const Paragraph: React.FC<ParagraphProps> = (props: ParagraphProps) => {
-  return <p className="utrecht-paragraph utrecht-paragraph--distanced">{props.children}</p>;
+  const rootClassNames = clsx('utrecht-paragraph utrecht-paragraph--distanced', props.className);
+  return <p className={rootClassNames}> {props.children}</p>;
 };


### PR DESCRIPTION
This PR enables implementors of the component library to pass a `className` property, allowing them to add their own classes to our components.

**Changes in this PR**
- **Breaking change**: Where encountered, interfaces extending `BaseProps` were modified to extend `Omit<BaseProps, 'classes'>`. This removes the `classes` property from the component props. The reason for this is that classes is a MaterialUI concept, which we don't want to support, as Material UI will be migrated out of our component implementations. The reason for not just throwing `classes` out of the BaseProps interface is that we are using it in some places ourselves, and we should investigate properly if we want to support our own implementation similar to the Material UI one.
- Add `className` to `BaseProps.tsx` interface
- Make sure each component's root element receives the `className` property
- Merging our own classNames with className values that can be passed by implementers
- Remove the `clsx` package dependency from component-packages: `Timeline` and `DotIndicator`, since almost all packages now use clsx to combine the external className with our own. There was already a clsx dependency in the project root


closes #375 
