### PR TITLE
fix: fixed alignment of icon for link component

### DIFF
--- a/src/components/Link/src/Link.stories.mdx
+++ b/src/components/Link/src/Link.stories.mdx
@@ -167,8 +167,8 @@ const ReactParagraph = (
   <Story name="HTML only Link">
     <p class="utrecht-paragraph utrecht-paragraph--distanced">
       It is possible to put{" "}
-      <a href="#" class="denhaag-link denhaag-link--with-icon" tabindex="0">
-        <span class="denhaag-link__icon denhaag-link__icon--start">
+      <a href="#" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start" tabindex="0">
+        <span class="denhaag-link__icon">
           <svg
             width="1em"
             height="1em"

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -91,21 +91,20 @@ export const Link: React.FC<LinkProps> = ({
     {
       'denhaag-link--disabled': disabled,
       'denhaag-link--with-icon': icon !== undefined,
+      'denhaag-link--with-icon-start': icon !== undefined && iconAlign === 'start',
+      'denhaag-link--with-icon-end': icon !== undefined && iconAlign === 'end',
     },
     props.className,
   );
 
-  const iconClassName = clsx('denhaag-link__icon', {
-    'denhaag-link__icon--start': iconAlign === 'start',
-    'denhaag-link__icon--end': iconAlign === 'end',
-  });
+  const iconClassName = clsx('denhaag-link__icon');
 
   const iconWrapped = <span className={iconClassName}>{icon}</span>;
 
   return (
     <a id={id} href={href} tabIndex={disabled ? -1 : tabIndex} {...props} className={rootClassNames}>
       {icon !== undefined && iconAlign === 'start' ? iconWrapped : ''}
-      {children}
+      <span>{children}</span>
       {icon !== undefined && iconAlign === 'end' ? iconWrapped : ''}
     </a>
   );

--- a/src/components/Link/src/link.css
+++ b/src/components/Link/src/link.css
@@ -1,4 +1,5 @@
 .denhaag-link {
+  position: relative;
   color: var(--denhaag-link-color);
   padding-block-start: var(--denhaag-link-padding);
   padding-block-end: var(--denhaag-link-padding);
@@ -11,6 +12,14 @@
 
 .denhaag-link--with-icon {
   text-decoration: none;
+}
+
+.denhaag-link--with-icon-start {
+  padding-inline-start: calc(var(--denhaag-link-icon-size) + var(--denhaag-link-icon-margin-start));
+}
+
+.denhaag-link--with-icon-end {
+  padding-inline-end: calc(var(--denhaag-link-icon-size) + var(--denhaag-link-icon-margin-end));
 }
 
 .denhaag-link--focus,
@@ -37,23 +46,26 @@
 }
 
 .denhaag-link__icon {
+  position: absolute;
+  top: 0;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   vertical-align: text-top;
-  height: var(--denhaag-link-icon-size);
   width: var(--denhaag-link-icon-size);
+  height: 100%;
+}
+
+.denhaag-link--with-icon-start .denhaag-link__icon {
+  left: 0;
+}
+
+.denhaag-link--with-icon-end .denhaag-link__icon {
+  right: 0;
 }
 
 .denhaag-link__icon > :first-child {
   width: inherit;
-  height: inherit;
-}
-
-.denhaag-link__icon--start {
-  margin-inline-end: var(--denhaag-link-icon-margin-start);
-}
-
-.denhaag-link__icon--end {
-  margin-inline-start: var(--denhaag-link-icon-margin-end);
+  height: var(--denhaag-link-icon-size);
+  font-size: inherit;
 }


### PR DESCRIPTION
FIxes the alignment for icons in the Link component.
Bit of a dirty fix imo but due to the padding on the block for the focus border and the icon being higher than the line-height. 

**Closing issues**
closes #330 
