### PR TITLE
ci: update deployment to use github pages

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,7 +56,7 @@ jobs:
           name: storybook
           path: storybook-static
 
-  deploy-staging:
+  deploy-storybook:
     needs: build
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -68,33 +68,11 @@ jobs:
           name: storybook
           path: storybook-static
 
-      - name: "Deploy to Azure Web App"
-        uses: azure/webapps-deploy@v2
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          app-name: "dhreactstorybook-staging"
-          slot-name: "production"
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_DHSTORYBOOK_STAGING }}
-          package: storybook-static
-
-  deploy-production:
-    needs: build
-    if: github.ref == 'refs/heads/latest'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download storybook
-        uses: actions/download-artifact@v2
-        with:
-          name: storybook
-          path: storybook-static
-
-      - name: "Deploy to Azure Web App"
-        uses: azure/webapps-deploy@v2
-        with:
-          app-name: "dhreactstorybook"
-          slot-name: "production"
-          publish-profile: ${{ secrets.AZUREAPPSERVICE_DHSTORYBOOK_PROD }}
-          package: storybook-static
+          branch: gh-pages
+          folder: storybook-static
 
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the pipeline to deploy to github pages instead of an azure web app. 

**Changes**
- Use GitHub Pages instead of Azure Websites
- Remove staging / production steps and only deploy from master

Uses Github Action: https://github.com/JamesIves/github-pages-deploy-action