### PR TITLE
Link: not exported from component library

### DIFF
--- a/src/meta-packages/navigation/src/index.tsx
+++ b/src/meta-packages/navigation/src/index.tsx
@@ -4,3 +4,4 @@ export * from '@gemeente-denhaag/menu';
 export * from '@gemeente-denhaag/timeline';
 export * from '@gemeente-denhaag/swipeabledrawer';
 export * from '@gemeente-denhaag/tab';
+export * from '@gemeente-denhaag/link';


### PR DESCRIPTION
This PR adds the `Link` component to the exported components in the `@gemeente-denhaag/navigation` meta-package.

closes #386 