### PR TITLE
Storybook: add status plugin

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,7 @@ module.exports = {
     },
     'storybook-addon-themes',
     'storybook-design-token',
+    '@etchteam/storybook-addon-status/register'
   ],
 
   webpackFinal: async (config, { configType }) => {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,6 +17,37 @@ const tokenFiles = tokenContext.keys().map((filename) => {
   return { filename: filename, content: tokenContext(filename).default };
 });
 
+const addonStatus = {
+  status: {
+    statuses: {
+      PRODUCTION: {
+        background: '#006400',
+        color: '#ffffff',
+        description:
+          'Used in production in a variety of situations, well tested, stable APIs, mostly patches and minor releases.',
+      },
+      BETA: {
+        background: '#cca300',
+        color: '#ffffff',
+        description:
+          'Used in production in a specific situation, evolving APIs based on feedback, breaking changes are still likely.',
+      },
+      ALPHA: {
+        background: '#cc0000',
+        color: '#ffffff',
+        description:
+          'Used in prototypes and in projects that are still in development, breaking changes occur frequently and are not communicated.',
+      },
+      'WORK IN PROGRESS': {
+        background: '#cc0000',
+        color: '#ffffff',
+        description:
+          'Do not use in production. Does not follow semantic versioning and any published packages are for internal use only.',
+      },
+    },
+  },
+};
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   designToken: {
@@ -32,6 +63,7 @@ export const parameters = {
     default: 'Gemeente Den Haag',
     list: [{ name: 'Gemeente Den Haag', class: 'denhaag-theme', color: '#227b3c' }],
   },
+  status: addonStatus.status
 };
 
 export const decorators = [(Story) => <StylesProvider>{<Story />}</StylesProvider>];

--- a/.storybook/stories/ReleaseStrategy.stories.mdx
+++ b/.storybook/stories/ReleaseStrategy.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Den Haag/Release strategy" />
+
+# Release strategy
+
+## Semantic versioning and pre-releases
+
+| Description                                             | npm version     | release type  |
+| ------------------------------------------------------- | --------------- | ------------- |
+| Production: Bugfix or improvement with breaking changes | `>=2.0.0`       | major version |
+| Production: Improvement with no breaking changes        | `^1.1.0`        | minor version |
+| Production: Bugfix with no breaking changes             | `~1.0.1`        | patch version |
+| Production: First stable release                        | `1.0.0`         | release       |
+| Beta                                                    | `1.0.0-beta.0`  | pre-release   |
+| Alpha                                                   | `1.0.0-alpha.0` | pre-release   |
+| Work in Progress                                        | `1.0.0-alpha.0` | pre-release   |
+
+### Production
+
+Used in production in a variety of situations, well tested, stable APIs, mostly patches and minor releases. Changes are communicated via the version number and via the changelog.
+
+### Beta
+
+Used in production in a specific situation, evolving APIs based on feedback, breaking changes are still likely. Design tokens are unlikely to change.
+
+### Alpha
+
+Used in prototypes and in projects that are still in development, breaking changes occur frequently and are not communicated. Design tokens exist but are subject to change.
+
+### Work in Progress
+
+Don't use in production. Breaking changes occur frequently. The component cannot be used as CSS only component. Design tokens not implemented or experimental.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@commitlint/config-conventional": "^12.1.4",
     "@cypress/react": "^5.4.2",
     "@cypress/webpack-dev-server": "^1.1.6",
+    "@etchteam/storybook-addon-status": "^4.0.0",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",

--- a/src/components/Accordion/src/Accordion.stories.tsx
+++ b/src/components/Accordion/src/Accordion.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { ChevronDownIcon } from '@gemeente-denhaag/icons';
 import { Paragraph } from '@gemeente-denhaag/typography';
-import Accordion, { AccordionSummary, AccordionDetails, AccordionProps } from '.';
+import Accordion, { AccordionDetails, AccordionProps, AccordionSummary } from '.';
 import pkg from '../package.json';
 
 export default {
@@ -13,6 +13,9 @@ export default {
       source: {
         type: 'dynamic',
       },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
     },
   },
   component: Accordion,
@@ -34,17 +37,17 @@ const Template: Story<AccordionProps> = (args: AccordionProps) => (
 
 // language=JS
 const defaultCode = `
-<Accordion>
-  <AccordionSummary expandIcon={<ExpandMore/>}>
-    <Paragraph>Click me to collapse me!</Paragraph>
-  </AccordionSummary>
-  <AccordionDetails>
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo
-      lobortis eget.
-    </Paragraph>
-  </AccordionDetails>
-</Accordion>
+  <Accordion>
+    <AccordionSummary expandIcon={<ExpandMore/>}>
+      <Paragraph>Click me to collapse me!</Paragraph>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo
+        lobortis eget.
+      </Paragraph>
+    </AccordionDetails>
+  </Accordion>
 `;
 
 /**
@@ -61,18 +64,18 @@ Default.parameters = {
 
 // language=JS
 const defaultExpandedCode = `
-<Accordion defaultExpanded>
-  <AccordionSummary expandIcon={<ExpandMore/>}>
-    <Paragraph>Click me to collapse me!</Paragraph>
-  </AccordionSummary>
-  <AccordionDetails>
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-      leo
-      lobortis eget.
-    </Paragraph>
-  </AccordionDetails>
-</Accordion>
+  <Accordion defaultExpanded>
+    <AccordionSummary expandIcon={<ExpandMore/>}>
+      <Paragraph>Click me to collapse me!</Paragraph>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+        leo
+        lobortis eget.
+      </Paragraph>
+    </AccordionDetails>
+  </Accordion>
 `;
 
 /**
@@ -93,18 +96,18 @@ DefaultExpanded.parameters = {
 
 // language=JS
 const disabledCode = `
-<Accordion disabled>
-  <AccordionSummary expandIcon={<ExpandMore/>}>
-    <Paragraph>Click me to collapse me!</Paragraph>
-  </AccordionSummary>
-  <AccordionDetails>
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-      leo
-      lobortis eget.
-    </Paragraph>
-  </AccordionDetails>
-</Accordion>
+  <Accordion disabled>
+    <AccordionSummary expandIcon={<ExpandMore/>}>
+      <Paragraph>Click me to collapse me!</Paragraph>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+        leo
+        lobortis eget.
+      </Paragraph>
+    </AccordionDetails>
+  </Accordion>
 `;
 
 /**
@@ -126,18 +129,18 @@ Disabled.parameters = {
 
 // language=JS
 const squaredCode = `
-<Accordion square>
-  <AccordionSummary expandIcon={<ExpandMore/>}>
-    <Paragraph>Click me to collapse me!</Paragraph>
-  </AccordionSummary>
-  <AccordionDetails>
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-      leo
-      lobortis eget.
-    </Paragraph>
-  </AccordionDetails>
-</Accordion>
+  <Accordion square>
+    <AccordionSummary expandIcon={<ExpandMore/>}>
+      <Paragraph>Click me to collapse me!</Paragraph>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+        leo
+        lobortis eget.
+      </Paragraph>
+    </AccordionDetails>
+  </Accordion>
 `;
 
 /**

--- a/src/components/Alerts/src/stories/Alerts.stories.mdx
+++ b/src/components/Alerts/src/stories/Alerts.stories.mdx
@@ -1,16 +1,22 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
 
-import { MegaphoneIcon } from "@gemeente-denhaag/icons";
-import { action } from "@storybook/addon-actions";
-import { Alerts } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { MegaphoneIcon } from '@gemeente-denhaag/icons';
+import { action } from '@storybook/addon-actions';
+import { Alerts } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Data Display/Alerts"
   component={Alerts}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'WORK IN PROGRESS'
+    }
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/AppBar/src/AppBar.stories.tsx
+++ b/src/components/AppBar/src/AppBar.stories.tsx
@@ -17,6 +17,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: AppBar,
 } as Meta;
@@ -37,15 +40,15 @@ const Template: Story<AppBarProps> = (args: AppBarProps) => {
 
 // language=JS
 const defaultCode = `
-<AppBar position='relative'>
-  <Toolbar>
-    <IconButton aria-label="menu">
-      <HamburgerIcon/>
-    </IconButton>
-    <Heading5>News</Heading5>
-  </Toolbar>
-  <Button>I am a button!</Button>
-</AppBar>
+  <AppBar position='relative'>
+    <Toolbar>
+      <IconButton aria-label="menu">
+        <HamburgerIcon/>
+      </IconButton>
+      <Heading5>News</Heading5>
+    </Toolbar>
+    <Button>I am a button!</Button>
+  </AppBar>
 `;
 
 /**
@@ -66,15 +69,15 @@ Default.parameters = {
 
 // language=JS
 const staticCode = `
-<AppBar position='static'>
-  <Toolbar>
-    <IconButton aria-label="menu">
-      <HamburgerIcon/>
-    </IconButton>
-    <Heading5>News</Heading5>
-  </Toolbar>
-  <Button>I am a button!</Button>
-</AppBar>
+  <AppBar position='static'>
+    <Toolbar>
+      <IconButton aria-label="menu">
+        <HamburgerIcon/>
+      </IconButton>
+      <Heading5>News</Heading5>
+    </Toolbar>
+    <Button>I am a button!</Button>
+  </AppBar>
 `;
 
 /**
@@ -95,15 +98,15 @@ StaticPosition.parameters = {
 
 // language=JS
 const secondaryCode = `
-<AppBar position='static' color={'secondary'}>
-  <Toolbar>
-    <IconButton aria-label="menu">
-      <HamburgerIcon/>
-    </IconButton>
-    <Heading5>News</Heading5>
-  </Toolbar>
-  <Button>I am a button!</Button>
-</AppBar>
+  <AppBar position='static' color={'secondary'}>
+    <Toolbar>
+      <IconButton aria-label="menu">
+        <HamburgerIcon/>
+      </IconButton>
+      <Heading5>News</Heading5>
+    </Toolbar>
+    <Button>I am a button!</Button>
+  </AppBar>
 `;
 
 /**

--- a/src/components/Avatar/src/stories/Avatar.stories.tsx
+++ b/src/components/Avatar/src/stories/Avatar.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Avatar,
 } as Meta;

--- a/src/components/Avatar/src/stories/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/src/stories/AvatarGroup.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: AvatarGroup,
 } as Meta;

--- a/src/components/BadgeCounter/src/stories/BadgeCounter.stories.mdx
+++ b/src/components/BadgeCounter/src/stories/BadgeCounter.stories.mdx
@@ -1,13 +1,19 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
 
-import { BadgeCounter } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { BadgeCounter } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Data Display/Badge Counter"
   component={BadgeCounter}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'ALPHA',
+    },
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/Box/src/Box.stories.tsx
+++ b/src/components/Box/src/Box.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Box,
 } as Meta;

--- a/src/components/Button/src/stories/Button.stories.mdx
+++ b/src/components/Button/src/stories/Button.stories.mdx
@@ -1,15 +1,21 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
-import { ArrowLeftIcon, ArrowRightIcon } from "@gemeente-denhaag/icons";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
+import { ArrowLeftIcon, ArrowRightIcon } from '@gemeente-denhaag/icons';
 
-import { Button } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { Button } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Input/Button"
   component={Button}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'ALPHA'
+    }
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/Card/src/stories/Card.stories.tsx
+++ b/src/components/Card/src/stories/Card.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: 'Components/Cards/Card',
   parameters: {
     componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Card,
 } as Meta;

--- a/src/components/Checkbox/src/stories/Checkbox.stories.mdx
+++ b/src/components/Checkbox/src/stories/Checkbox.stories.mdx
@@ -1,17 +1,23 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
-import { action } from "@storybook/addon-actions";
+import { Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
+import { action } from '@storybook/addon-actions';
 
-import { Checkbox } from "..";
-import { FormControlLabel } from "../../../FormControlLabel";
-import { FormGroup } from "../../../FormGroup";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { Checkbox } from '..';
+import { FormControlLabel } from '../../../FormControlLabel';
+import { FormGroup } from '../../../FormGroup';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Input/Checkbox"
   component={Checkbox}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/Container/src/Container.stories.tsx
+++ b/src/components/Container/src/Container.stories.tsx
@@ -13,6 +13,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
 } as Meta;
 

--- a/src/components/Divider/src/Divider.stories.tsx
+++ b/src/components/Divider/src/Divider.stories.tsx
@@ -15,6 +15,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Divider,
 } as Meta;

--- a/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
+++ b/src/components/DotIndicator/src/stories/DotIndicator.stories.mdx
@@ -1,15 +1,21 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
-import { Avatar } from "@gemeente-denhaag/avatar";
-import Button from "@gemeente-denhaag/button";
-import { DotIndicator } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
+import { Avatar } from '@gemeente-denhaag/avatar';
+import Button from '@gemeente-denhaag/button';
+import { DotIndicator } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Data Display/Dot indicator"
   component={DotIndicator}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'ALPHA',
+    },
+  }}
 />
 
 <Description markdown={readme} />
@@ -40,7 +46,8 @@ const elementWithNotification = (<DotIndicator overlap="rectangle"><Button>Read 
       },
     }}
   >
-    {(args) => <DotIndicator overlap={"rectangle"} {...args}><Button variant={"secondary"}>Read messages</Button></DotIndicator>}
+    {(args) => <DotIndicator overlap={"rectangle"} {...args}><Button variant={"secondary"}>Read
+      messages</Button></DotIndicator>}
   </Story>
 </Canvas>
 

--- a/src/components/Drawer/src/Drawer.stories.tsx
+++ b/src/components/Drawer/src/Drawer.stories.tsx
@@ -13,6 +13,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Drawer,
 } as Meta;

--- a/src/components/FormControlLabel/src/stories/FormControlLabel.stories.mdx
+++ b/src/components/FormControlLabel/src/stories/FormControlLabel.stories.mdx
@@ -1,14 +1,20 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+import { Description, Meta } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
 
-import { FormControlLabel } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { FormControlLabel } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Input/FormControlLabel"
   component={FormControlLabel}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/FormGroup/src/stories/FormGroup.stories.mdx
+++ b/src/components/FormGroup/src/stories/FormGroup.stories.mdx
@@ -1,14 +1,20 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+import { Description, Meta } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
 
-import { FormGroup } from "..";
-import pkg from "../../package.json";
-import readme from "../../README.md";
+import { FormGroup } from '..';
+import pkg from '../../package.json';
+import readme from '../../README.md';
 
 <Meta
   title="Components/Input/FormGroup"
   component={FormGroup}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/Grid/src/Grid.stories.tsx
+++ b/src/components/Grid/src/Grid.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Grid,
 } as Meta;

--- a/src/components/GridList/src/stories/GridList.stories.tsx
+++ b/src/components/GridList/src/stories/GridList.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: GridList,
 } as Meta;

--- a/src/components/GridList/src/stories/GridListTile.stories.tsx
+++ b/src/components/GridList/src/stories/GridListTile.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: GridListTile,
 } as Meta;

--- a/src/components/GridList/src/stories/GridListTileBar.stories.tsx
+++ b/src/components/GridList/src/stories/GridListTileBar.stories.tsx
@@ -14,6 +14,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: GridListTileBar,
 } as Meta;

--- a/src/components/Hidden/src/Hidden.stories.tsx
+++ b/src/components/Hidden/src/Hidden.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Hidden,
 } as Meta;

--- a/src/components/IconButton/src/stories/iconbutton.stories.mdx
+++ b/src/components/IconButton/src/stories/iconbutton.stories.mdx
@@ -1,14 +1,20 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
-import { TrashIcon } from "@gemeente-denhaag/icons";
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
+import { TrashIcon } from '@gemeente-denhaag/icons';
 
-import { IconButton } from "..";
-import pkg from "../../package.json";
+import { IconButton } from '..';
+import pkg from '../../package.json';
 
 <Meta
   title="Components/Input/IconButton"
   component={IconButton}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'ALPHA',
+    },
+  }}
 />
 
 ## Design Tokens

--- a/src/components/Icons/src/Icons.stories.tsx
+++ b/src/components/Icons/src/Icons.stories.tsx
@@ -16,6 +16,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   argTypes: {
     component: {

--- a/src/components/Link/src/Link.stories.mdx
+++ b/src/components/Link/src/Link.stories.mdx
@@ -1,16 +1,21 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
-import { Paragraph } from "@gemeente-denhaag/typography";
-import { ArrowLeftIcon, ArrowRightIcon } from "@gemeente-denhaag/icons";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
+import { Paragraph } from '@gemeente-denhaag/typography';
+import { ArrowLeftIcon, ArrowRightIcon } from '@gemeente-denhaag/icons';
 
-import { Link } from ".";
-import pkg from "../package.json";
-import readme from "../README.md";
+import { Link } from '.';
+import pkg from '../package.json';
+import readme from '../README.md';
 
 <Meta
   title="Components/Navigation/Link"
   component={Link}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}` }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  }}
 />
 
 <Description markdown={readme} />

--- a/src/components/List/src/List.stories.tsx
+++ b/src/components/List/src/List.stories.tsx
@@ -14,6 +14,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: List,
 } as Meta;

--- a/src/components/Menu/src/MenuButton.stories.mdx
+++ b/src/components/Menu/src/MenuButton.stories.mdx
@@ -1,14 +1,20 @@
-import { ArgsTable, Canvas, Description, Meta, Story } from "@storybook/addon-docs";
-import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+import { ArgsTable, Canvas, Description, Meta, Story } from '@storybook/addon-docs';
+import { DesignTokenDocBlock } from 'storybook-design-token/dist/doc-blocks';
 
-import { Menu, MenuButton, MenuButtonExpandable } from ".";
-import pkg from "../package.json";
-import readme from "../README.md";
+import { Menu, MenuButton, MenuButtonExpandable } from '.';
+import pkg from '../package.json';
+import readme from '../README.md';
 
 <Meta
   title="Components/Navigation/MenuButton"
   component={(MenuButton, MenuButtonExpandable)}
-  parameters={{ componentSubtitle: `${pkg.name} - ${pkg.version}`, docs: { source: { type: "dynamic" } } }}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  }}
 />
 
 <Description markdown={readme} />
@@ -30,9 +36,9 @@ import readme from "../README.md";
         source: {
           code: `
           import { MenuButton } from "@gemeente-denhaag/menubutton";
-          const ReactMenuButton = <MenuButton href='https://github.com/nl-design-system/denhaag' variant='normal'>Label</MenuButton>};`,
-        },
+          const ReactMenuButton = <MenuButton href="https://github.com/nl-design-system/denhaag" variant="normal">Label</MenuButton>};`,
       },
+    },
     }}
   >
     {(args) => <MenuButton {...args}>Label</MenuButton>}
@@ -52,8 +58,8 @@ import readme from "../README.md";
           code: `
           import { MenuButtonExpandable } from "@gemeente-denhaag/menubutton";
           const ReactMenuButton = <MenuButtonExpandable variant='expandable' onclick={() => alert('Hello from MenuButton 👋')}>Label</MenuButtonExpandable>;`,
-        },
       },
+    },
     }}
   >
     {(args) => <MenuButtonExpandable onclick={() => alert("Hello from MenuButton 👋")}>Label</MenuButtonExpandable>}
@@ -70,7 +76,7 @@ import readme from "../README.md";
       docs: {
         source: {
           code: `
-            <Menu id='menu-id' >
+            <Menu id="menu-id" >
               <MenuButton href="https://github.com/nl-design-system/denhaag">
                 Label
               </MenuButton>

--- a/src/components/Pickers/src/DatePicker.stories.tsx
+++ b/src/components/Pickers/src/DatePicker.stories.tsx
@@ -9,6 +9,9 @@ export default {
   title: 'Components/Input/DatePicker',
   parameters: {
     componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: DatePicker,
 } as Meta;

--- a/src/components/Radio/src/stories/Radio.stories.tsx
+++ b/src/components/Radio/src/stories/Radio.stories.tsx
@@ -15,6 +15,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Radio,
 } as Meta;

--- a/src/components/Radio/src/stories/RadioGroup.stories.tsx
+++ b/src/components/Radio/src/stories/RadioGroup.stories.tsx
@@ -14,6 +14,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: RadioGroup,
 } as Meta;

--- a/src/components/Select/src/Select.stories.tsx
+++ b/src/components/Select/src/Select.stories.tsx
@@ -15,6 +15,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Select,
 } as Meta;

--- a/src/components/SwipeableDrawer/src/SwipeableDrawer.stories.tsx
+++ b/src/components/SwipeableDrawer/src/SwipeableDrawer.stories.tsx
@@ -13,6 +13,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: SwipeableDrawer,
 } as Meta;

--- a/src/components/Switch/src/Switch.stories.tsx
+++ b/src/components/Switch/src/Switch.stories.tsx
@@ -13,6 +13,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Switch,
 } as Meta;

--- a/src/components/Tab/src/Tab.stories.tsx
+++ b/src/components/Tab/src/Tab.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Tab,
 } as Meta;

--- a/src/components/TextField/src/TextField.stories.tsx
+++ b/src/components/TextField/src/TextField.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: TextField,
   argTypes: {

--- a/src/components/Timeline/src/stories/Timeline.stories.tsx
+++ b/src/components/Timeline/src/stories/Timeline.stories.tsx
@@ -13,6 +13,9 @@ export default {
         type: 'code',
       },
     },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
   },
   component: Timeline,
 } as Meta;

--- a/src/components/Typography/src/stories/Heading1.stories.tsx
+++ b/src/components/Typography/src/stories/Heading1.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Heading1,
 } as Meta;

--- a/src/components/Typography/src/stories/Heading2.stories.tsx
+++ b/src/components/Typography/src/stories/Heading2.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Heading2,
 } as Meta;

--- a/src/components/Typography/src/stories/Heading3.stories.tsx
+++ b/src/components/Typography/src/stories/Heading3.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Heading3,
 } as Meta;

--- a/src/components/Typography/src/stories/Heading4.stories.tsx
+++ b/src/components/Typography/src/stories/Heading4.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Heading4,
 } as Meta;

--- a/src/components/Typography/src/stories/Heading5.stories.tsx
+++ b/src/components/Typography/src/stories/Heading5.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Heading5,
 } as Meta;

--- a/src/components/Typography/src/stories/LeadParagraph.stories.tsx
+++ b/src/components/Typography/src/stories/LeadParagraph.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: LeadParagraph,
 } as Meta;

--- a/src/components/Typography/src/stories/Paragraph.stories.tsx
+++ b/src/components/Typography/src/stories/Paragraph.stories.tsx
@@ -12,6 +12,9 @@ export default {
         type: 'dynamic',
       },
     },
+    status: {
+      type: 'ALPHA',
+    },
   },
   component: Paragraph,
 } as Meta;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,23 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@etchteam/storybook-addon-status@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@etchteam/storybook-addon-status/-/storybook-addon-status-4.0.0.tgz#299b36062084e285fd4ebb627cd0cce0d5c63303"
+  integrity sha512-CK69kfB/0HKSwMpnt7sC24h2sNFqPcCX/+o2CCOi6PP7ERqoqmy+DbnqLNtxYdshEJXs5pd6k5admbzpnZkevw==
+  dependencies:
+    "@storybook/addons" "^6.2.9"
+    "@storybook/api" "^6.2.9"
+    "@storybook/client-logger" "^6.2.9"
+    "@storybook/components" "^6.2.9"
+    "@storybook/core-events" "^6.2.9"
+    "@storybook/theming" "^6.2.9"
+    core-js "^3.0.1"
+    lodash "^4.17.21"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    util-deprecate "^1.0.2"
+
 "@gemeente-denhaag/baseprops@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@gemeente-denhaag/baseprops/-/baseprops-0.1.7.tgz#0ca508a161c53afc42f711704edc41cc2c6c3a2e"
@@ -3834,7 +3851,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.3.8", "@storybook/addons@^6.0.0", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.2", "@storybook/addons@^6.3.4":
+"@storybook/addons@6.3.8", "@storybook/addons@^6.0.0", "@storybook/addons@^6.2.9", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.2", "@storybook/addons@^6.3.4":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.8.tgz#c4a839ae9b86fb4a1183466db6eb16201c1a0553"
   integrity sha512-TzYk1f/wvfoGDkLxXIx85ii5ED7IfGP/6eu00/i2Hyn4uGqdNi/ltSOJxnxa+DZv8KjYQRVAEo/Fbh95IEXI1Q==
@@ -3901,7 +3918,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/api@6.3.8", "@storybook/api@^6.0.0", "@storybook/api@^6.3.0":
+"@storybook/api@6.3.8", "@storybook/api@^6.0.0", "@storybook/api@^6.2.9", "@storybook/api@^6.3.0":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.8.tgz#251bcf6cc3a4e0b908bea7fb0aa9e48d6c48d720"
   integrity sha512-8b61KnWhN+sA+Gq+AHH3M4qM0L8pNS9DtdfPi5GUGWzOg6IZ1EgYVsk9afEwkNESxyZ+GM2O6mGu05J0HfyqNg==
@@ -4265,7 +4282,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/client-logger@6.3.8":
+"@storybook/client-logger@6.3.8", "@storybook/client-logger@^6.2.9":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.3.8.tgz#042b81c45f73066e4f6c32942c72f4aca0ae6646"
   integrity sha512-d/65629nvnlDpeubcElTypHuSvOqxNTNKnuN0oKDM8BsE0EO5rhTfzrx2vhiSW8At8MuD1eFC19BWdCZV18Edg==
@@ -4352,7 +4369,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/components@6.3.8", "@storybook/components@^6.0.0", "@storybook/components@^6.3.0", "@storybook/components@^6.3.4":
+"@storybook/components@6.3.8", "@storybook/components@^6.0.0", "@storybook/components@^6.2.9", "@storybook/components@^6.3.0", "@storybook/components@^6.3.4":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.8.tgz#cb84b0245d8784d41e7e6be25a0d5774363e5b87"
   integrity sha512-zIvCk7MAL9z17EI58h7WE/TgFTm0njGwFkQrbXOgGkkKYoFt/yrrs8HqylcqBqfTivJNiXJNnmmx0ooJ83PIwA==
@@ -4550,7 +4567,7 @@
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/core-events@6.3.8", "@storybook/core-events@^6.0.0", "@storybook/core-events@^6.3.0":
+"@storybook/core-events@6.3.8", "@storybook/core-events@^6.0.0", "@storybook/core-events@^6.2.9", "@storybook/core-events@^6.3.0":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.8.tgz#4c9a3deb9334b10116befbf2db5534d1319d2f39"
   integrity sha512-M3d2iX842YfopqmOHlXzL/Xy4fICzaRnet99GdfOqWjZhC2CVSemVk1b/vgfQv4MFYOQkSLsAjkbDH/kU8n9Aw==
@@ -4994,7 +5011,7 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/theming@6.3.8", "@storybook/theming@^6.0.0", "@storybook/theming@^6.3.4":
+"@storybook/theming@6.3.8", "@storybook/theming@^6.0.0", "@storybook/theming@^6.2.9", "@storybook/theming@^6.3.4":
   version "6.3.8"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.3.8.tgz#3af76408aa8a4f13e217cf407e63a03db217eedc"
   integrity sha512-Np51rvecnuHNevZ7Em0uElT5UkgASP5K2u8NpHcCxP/Hd73wxS/h//6XnjA9Aich7h/JanG71jAC3qqhZabatA==
@@ -8252,6 +8269,11 @@ core-js@^2.4.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
+core-js@^3.0.1:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.17.3.tgz#8e8bd20e91df9951e903cabe91f9af4a0895bc1e"
+  integrity sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==
 
 core-js@^3.0.4, core-js@^3.4.1, core-js@^3.6.4, core-js@^3.6.5, core-js@^3.8.2:
   version "3.15.2"
@@ -18011,6 +18033,15 @@ react-use-clipboard@^1.0.7:
   integrity sha512-blIprqARyITp0uVw/2Rh87mcujqXdH6vZ5NrcuXEhI5EmjBGxcGnwt/79+vdN7rwM6OliGj481lOj6ZCcsiYEQ==
   dependencies:
     copy-to-clipboard "^3.3.1"
+
+react@^16.8.3:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 react@^17.0.1:
   version "17.0.2"


### PR DESCRIPTION
This PR adds the storybook-addon-status plugin to display component statuses. Components that are currently being used in the nl-portal-libraries are set to the alpha state instead of work in progress.

**Todos**
- [x] Add docs page about statuses  

closes #346 
