### PR TITLE
fix(typography): lead paragraph exported from typography package

### DIFF
--- a/src/components/Typography/src/index.tsx
+++ b/src/components/Typography/src/index.tsx
@@ -5,3 +5,4 @@ export * from './Heading4';
 export * from './Heading5';
 
 export * from './Paragraph';
+export * from './LeadParagraph';


### PR DESCRIPTION
Adds the `LeadParagraph` component to the `Typography/index.tsx` exports

closes #403 
