### PR TITLE
Fix/#386 link issues

### DIFF
--- a/src/components/BaseProps/src/index.tsx
+++ b/src/components/BaseProps/src/index.tsx
@@ -49,3 +49,18 @@ export interface BaseClassesProps {
    */
   classes?: Record<string, unknown>;
 }
+
+type OverrideProps<M, C extends React.ElementType> = M & Omit<React.ComponentPropsWithRef<C>, keyof M>;
+
+export interface OverridableComponent<M> {
+  <C extends React.ElementType>(
+    props: {
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      component: C;
+    } & OverrideProps<M, C>,
+  ): JSX.Element;
+  (props: BaseProps & M): JSX.Element;
+}

--- a/src/components/Link/package.json
+++ b/src/components/Link/package.json
@@ -25,9 +25,6 @@
         "@gemeente-denhaag/baseprops": "^0.2.3-alpha.33",
         "@gemeente-denhaag/icons": "^0.2.3-alpha.33"
     },
-    "devDependencies": {
-        "@gemeente-denhaag/typography": "^0.2.3-alpha.33"
-    },
     "peerDependencies": {
         "react": "^17.0.1"
     }

--- a/src/components/Link/src/Link.stories.mdx
+++ b/src/components/Link/src/Link.stories.mdx
@@ -20,6 +20,53 @@ import readme from '../README.md';
 
 <Description markdown={readme} />
 
+## Usage
+This component can be used in two ways:
+
+- As a standard `a`-tag with icon support. For this you need to supply at least an `href`, and an icon can be added in the `icon` prop:
+  `<Link href="/home" icon={<ArrowRightIcon />} iconAlign="end">Home</Link>`
+
+- With another way of routing, for example using `react-router-dom`. For this we have exposed the `component` property. When adding a `component` all props of this component will be usable on our `Link` component and will be passed through.
+  An example with `react-router-dom`:
+
+  ```
+  import { Link } from '@gemeente-denhaag/denhaag-component-library';
+  import { ArrowRightIcon } from '@gemeente-denhaag/icons';
+  import {
+    BrowserRouter as Router,
+    Switch,
+    Route,
+    Link as RouterLink,
+  } from 'react-router-dom';
+
+  export default function App() {
+    return (
+      <Router>
+        <div>
+          <nav>
+            <ul>
+              <li>
+                 <Link component={RouterLink} to="/" icon={<ArrowRightIcon />}>Home</Link>
+              </li>
+              <li>
+                 <Link component={RouterLink} to="/nl" hrefLang="nl">NL</Link>
+              </li>
+            </ul>
+          </nav>
+           <Switch>
+              <Route path="/nl">
+                <h1>NL home</h1>
+              </Route>
+              <Route path="/">
+                <h1>Home</h1>
+              </Route>
+            </Switch>
+        </div>
+      </Router>
+    );
+  }
+  ```
+
 ## Design Tokens
 
 <DesignTokenDocBlock categoryName="Link" viewType="table" />

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -22,7 +22,7 @@ export interface LinkProps extends Omit<BaseProps, 'classes'> {
   /**
    * Icon to display at the start or the end of the link
    */
-  icon?: React.FC<SvgIconProps>;
+  icon?: React.ReactElement<SvgIconProps>;
 
   /**
    * If an `icon` is specified, should it be aligned on the left or the right?

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -107,7 +107,7 @@ export const Link: OverridableComponent<LinkProps> = ({
 
   const iconWrapped = <span className={iconClassName}>{icon}</span>;
 
-  const Component = component === undefined ? 'a' : component;
+  const Component = component || 'a';
 
   return (
     <Component id={id} href={href} tabIndex={disabled ? -1 : tabIndex} {...props} className={rootClassNames}>

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -110,4 +110,21 @@ export const Link: React.FC<LinkProps> = ({
   );
 };
 
+export const RouterLink: React.FC<LinkProps & { navigate: () => void }> = (
+  props: LinkProps & { navigate: () => void },
+) => {
+  const { navigate, ...otherProps } = props;
+  const extendedProps = {
+    onClick: (e: React.MouseEvent) => {
+      if (!props.target || props.target === '_self') {
+        e.preventDefault();
+        navigate();
+      }
+    },
+    ...otherProps,
+  };
+
+  return <Link {...extendedProps} />;
+};
+
 export default Link;

--- a/src/components/Link/src/index.tsx
+++ b/src/components/Link/src/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import BaseProps from '@gemeente-denhaag/baseprops';
+import BaseProps, { OverridableComponent } from '@gemeente-denhaag/baseprops';
 import { SvgIconProps } from '@gemeente-denhaag/icons';
 import clsx from 'clsx';
 
@@ -12,7 +12,7 @@ export interface LinkProps extends Omit<BaseProps, 'classes'> {
    *
    * [(See MDN Web Docs for details)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href)
    */
-  href: string;
+  href?: string;
 
   /**
    * [See MDN Web Docs for details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-hreflang)
@@ -69,6 +69,11 @@ export interface LinkProps extends Omit<BaseProps, 'classes'> {
    * [See MDN Web Docs for details](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-referrerpolicy)
    */
   referrerPolicy?: React.HTMLAttributeReferrerPolicy;
+
+  /**
+   * Override base component
+   */
+  component?: React.ElementType | undefined;
 }
 
 /**
@@ -76,7 +81,7 @@ export interface LinkProps extends Omit<BaseProps, 'classes'> {
  * @param props The properties of a Link component.
  * @constructor Constructs an instance of Link.
  */
-export const Link: React.FC<LinkProps> = ({
+export const Link: OverridableComponent<LinkProps> = ({
   href,
   id,
   children = undefined,
@@ -84,6 +89,7 @@ export const Link: React.FC<LinkProps> = ({
   icon = undefined,
   iconAlign = 'end',
   tabIndex = 0,
+  component = undefined,
   ...props
 }: LinkProps) => {
   const rootClassNames = clsx(
@@ -101,30 +107,15 @@ export const Link: React.FC<LinkProps> = ({
 
   const iconWrapped = <span className={iconClassName}>{icon}</span>;
 
+  const Component = component === undefined ? 'a' : component;
+
   return (
-    <a id={id} href={href} tabIndex={disabled ? -1 : tabIndex} {...props} className={rootClassNames}>
+    <Component id={id} href={href} tabIndex={disabled ? -1 : tabIndex} {...props} className={rootClassNames}>
       {icon !== undefined && iconAlign === 'start' ? iconWrapped : ''}
       <span>{children}</span>
       {icon !== undefined && iconAlign === 'end' ? iconWrapped : ''}
-    </a>
+    </Component>
   );
-};
-
-export const RouterLink: React.FC<LinkProps & { navigate: () => void }> = (
-  props: LinkProps & { navigate: () => void },
-) => {
-  const { navigate, ...otherProps } = props;
-  const extendedProps = {
-    onClick: (e: React.MouseEvent) => {
-      if (!props.target || props.target === '_self') {
-        e.preventDefault();
-        navigate();
-      }
-    },
-    ...otherProps,
-  };
-
-  return <Link {...extendedProps} />;
 };
 
 export default Link;

--- a/src/meta-packages/navigation/package.json
+++ b/src/meta-packages/navigation/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@gemeente-denhaag/baseprops": "^0.2.3-alpha.33",
     "@gemeente-denhaag/drawer": "^0.2.3-alpha.33",
+    "@gemeente-denhaag/link": "^0.2.3-alpha.33",
     "@gemeente-denhaag/menu": "^0.2.3-alpha.33",
     "@gemeente-denhaag/swipeabledrawer": "^0.2.3-alpha.33",
     "@gemeente-denhaag/tab": "^0.2.3-alpha.33",


### PR DESCRIPTION
In this PR the following two things were done:
- Fixed export for link component in `denhaag-component-library` and `navigation` packages.
- Added `RouterLink` component.

A few notes about the `RouterLink` component:
- I experimented with making the `RouterLink` component export a `Link` component from `react-router-dom`. This would however result in issues in the `react-router-dom` implementation; the `Link` component checks whether it is wrapped in a `Router` component **from the same package**. This meant when using our `RouterLink` component in a application with a `Router` component from `react-router-dom` this would throw an error. Because of this we had the following options: export all component from `react-router-dom` ourselves, or adjust our implementation, and I chose to do the latter.
- The `RouterLink` component is supposed to be used as `component` prop in the `react-router-dom` link. When doing this with our default `Link` component this would result in the `react-router-dom` navigation breaking, since when using a custom component there is no `onClick` functionality passed through. Due to this I had to create our own `RouterLink` component with a `onClick` which calls the `navigate()` function which is passed through by the `react-router-dom` `Link` component. This implementation is based on the implentation of the `AnchorLink` component in `react-router-dom` which is used internally when no custom `component` is specified in the `Link`. 

Usage:
`<Link to="/" component={RouterLink} id="123">Home</Link>`

When using this in a TS project there is a small quirk: the `react-router-dom` `Link` component passes on all extra props to the underlying element. However, in its TS definition it only accepts all usable `a` HTMLProps. Due to this you cannot by default use our `icon` and `iconAlign` props of the Link, since these are not default `a` HTMLProps and thus will result in a TS build error, so this will not work:
`<Link to="/" id="123" icon={<ArrowRightIcon />} iconAlign="end">Home</Link>`

To fix this an end-user can do the following:

```
import { RouterLink, LinkProps } from '@gemeente-denhaag/denhaag-component-library';
import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';

interface RouterLinkProps extends Omit<LinkProps, 'href'>, Pick<RouterDomLinkProps, 'to' | 'replace'> {}
const Link: React.FC<RouterLinkProps> = (props: RouterLinkProps) => {
  return <RouterDomLink component={RouterLink} {...props} />;
};
```

By creating a custom `Link` component which accepts both our `LinkProps` and the `to` and `replace` prop from the `LinkProps` from `react-router-dom` you can now do the following in your project: 
`<Link to="/" id="123" icon={<ArrowRightIcon />} iconAlign="end">Home</Link>`

Again, we can not offer this functionality by default out of our component library without also exporting all other `react-router-dom` components a user wants to use, which doesn't seem like a good idea to me, but would like to know your thoughts :)

**Closing issues**
#386 
