### PR TITLE
fix(breadcrumb): added minor fix for the separator after an icon

### DIFF
--- a/components/Breadcrumb/src/breadcrumb.css
+++ b/components/Breadcrumb/src/breadcrumb.css
@@ -64,6 +64,7 @@ ol.denhaag-breadcrumb__list {
 }
 
 /* SVG for the separator */
+.denhaag-breadcrumb__link > .denhaag-icon + .denhaag-icon,
 .denhaag-breadcrumb__link > .denhaag-breadcrumb__text + .denhaag-icon {
   color: initial;
   font-size: inherit;


### PR DESCRIPTION
Fix for the recently approved and merged breadcrumbs HTML and CSS component.

Without:
![Screenshot 2021-12-15 at 15 37 09](https://user-images.githubusercontent.com/94894596/146206469-3718d911-3fde-405e-b4b6-c917a271d817.png)

With fix:
![Screenshot 2021-12-15 at 15 37 02](https://user-images.githubusercontent.com/94894596/146206495-2c421d50-d209-4d78-89b5-911ff32821df.png)
