### PR TITLE
refactor: omit .value in token reference

### DIFF
--- a/proprietary/Common/src/denhaag/focus.tokens.json
+++ b/proprietary/Common/src/denhaag/focus.tokens.json
@@ -2,11 +2,11 @@
   "denhaag": {
     "focus": {
       "background-color": {},
-      "border-color": { "value": "{denhaag.color.ocher.4.value}" },
+      "border-color": { "value": "{denhaag.color.ocher.4}" },
       "border-width": { "value": "2px" },
       "border-style": { "value": "dashed" },
       "border": {
-        "value": "{denhaag.focus.border-width.value} {denhaag.focus.border-style.value} {denhaag.focus.border-color.value}"
+        "value": "{denhaag.focus.border-width} {denhaag.focus.border-style} {denhaag.focus.border-color}"
       },
       "color": {}
     }

--- a/proprietary/Common/src/utrecht/document.tokens.json
+++ b/proprietary/Common/src/utrecht/document.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{denhaag.color.white.value}" },
-      "color": { "value": "{denhaag.color.black.value}" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" }
+      "background-color": { "value": "{denhaag.color.white}" },
+      "color": { "value": "{denhaag.color.black}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" }
     }
   }
 }

--- a/proprietary/Common/src/utrecht/feedback-variant.tokens.json
+++ b/proprietary/Common/src/utrecht/feedback-variant.tokens.json
@@ -3,26 +3,26 @@
     "feedback": {
       "danger": {
         "fill": {
-          "background-color": { "value": "{denhaag.color.red.1.value}" },
-          "color": { "value": "{denhaag.color.red.4.value}" }
+          "background-color": { "value": "{denhaag.color.red.1}" },
+          "color": { "value": "{denhaag.color.red.4}" }
         }
       },
       "warning": {
         "fill": {
-          "background-color": { "value": "{denhaag.color.orange.1.value}" },
-          "color": { "value": "{denhaag.color.orange.4.value}" }
+          "background-color": { "value": "{denhaag.color.orange.1}" },
+          "color": { "value": "{denhaag.color.orange.4}" }
         }
       },
       "safe": {
         "fill": {
-          "background-color": { "value": "{denhaag.color.green.1.value}" },
-          "color": { "value": "{denhaag.color.green.4.value}" }
+          "background-color": { "value": "{denhaag.color.green.1}" },
+          "color": { "value": "{denhaag.color.green.4}" }
         }
       },
       "neutral": {
         "fill": {
-          "background-color": { "value": "{denhaag.color.blue.1.value}" },
-          "color": { "value": "{denhaag.color.blue.4.value}" }
+          "background-color": { "value": "{denhaag.color.blue.1}" },
+          "color": { "value": "{denhaag.color.blue.4}" }
         }
       }
     }

--- a/proprietary/Common/src/utrecht/feedback.tokens.json
+++ b/proprietary/Common/src/utrecht/feedback.tokens.json
@@ -2,20 +2,20 @@
   "utrecht": {
     "feedback": {
       "danger": {
-        "background-color": { "value": "{denhaag.color.red.1.value}" },
-        "color": { "value": "{denhaag.color.red.4.value}" }
+        "background-color": { "value": "{denhaag.color.red.1}" },
+        "color": { "value": "{denhaag.color.red.4}" }
       },
       "warning": {
-        "background-color": { "value": "{denhaag.color.orange.1.value}" },
-        "color": { "value": "{denhaag.color.orange.4.value}" }
+        "background-color": { "value": "{denhaag.color.orange.1}" },
+        "color": { "value": "{denhaag.color.orange.4}" }
       },
       "safe": {
-        "background-color": { "value": "{denhaag.color.green.1.value}" },
-        "color": { "value": "{denhaag.color.green.4.value}" }
+        "background-color": { "value": "{denhaag.color.green.1}" },
+        "color": { "value": "{denhaag.color.green.4}" }
       },
       "neutral": {
-        "background-color": { "value": "{denhaag.color.blue.1.value}" },
-        "color": { "value": "{denhaag.color.blue.4.value}" }
+        "background-color": { "value": "{denhaag.color.blue.1}" },
+        "color": { "value": "{denhaag.color.blue.4}" }
       }
     }
   }

--- a/proprietary/Common/src/utrecht/focus.tokens.json
+++ b/proprietary/Common/src/utrecht/focus.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "focus": {
-      "border-color": { "value": "{denhaag.focus.border-color.value}" },
-      "border-style": { "value": "{denhaag.focus.border-style.value}" },
-      "outline-color": { "value": "{denhaag.focus.border-color.value}" },
-      "outline-style": { "value": "{denhaag.focus.border-style.value}" },
-      "outline-width": { "value": "{denhaag.focus.border-width.value}" }
+      "border-color": { "value": "{denhaag.focus.border-color}" },
+      "border-style": { "value": "{denhaag.focus.border-style}" },
+      "outline-color": { "value": "{denhaag.focus.border-color}" },
+      "outline-style": { "value": "{denhaag.focus.border-style}" },
+      "outline-width": { "value": "{denhaag.focus.border-width}" }
     }
   }
 }

--- a/proprietary/Components/src/denhaag/alert.tokens.json
+++ b/proprietary/Components/src/denhaag/alert.tokens.json
@@ -2,20 +2,20 @@
   "denhaag": {
     "alert": {
       "border-radius": { "value": "1px" },
-      "padding-block-start": { "value": "{denhaag.space.block.xl.value}" },
-      "padding-block-end": { "value": "{denhaag.space.block.xl.value}" },
-      "padding-inline-start": { "value": "{denhaag.space.block.xl.value}" },
-      "padding-inline-end": { "value": "{denhaag.space.block.xl.value}" },
+      "padding-block-start": { "value": "{denhaag.space.block.xl}" },
+      "padding-block-end": { "value": "{denhaag.space.block.xl}" },
+      "padding-inline-start": { "value": "{denhaag.space.block.xl}" },
+      "padding-inline-end": { "value": "{denhaag.space.block.xl}" },
       "content": {
         "margin-inline": {
-          "start": { "value": "{denhaag.space.block.xl.value}" },
-          "end": { "value": "{denhaag.space.block.xl.value}" }
+          "start": { "value": "{denhaag.space.block.xl}" },
+          "end": { "value": "{denhaag.space.block.xl}" }
         }
       },
       "action": {
         "padding": {
           "block": {
-            "start": { "value": "{denhaag.space.block.md.value}" }
+            "start": { "value": "{denhaag.space.block.md}" }
           }
         }
       },
@@ -28,99 +28,99 @@
         }
       },
       "error": {
-        "background-color": { "value": "{denhaag.color.red.1.value}" },
+        "background-color": { "value": "{denhaag.color.red.1}" },
         "title": {
-          "color": { "value": "{denhaag.color.red.5.value}" }
+          "color": { "value": "{denhaag.color.red.5}" }
         },
         "paragraph": {
-          "color": { "value": "{denhaag.color.red.5.value}" }
+          "color": { "value": "{denhaag.color.red.5}" }
         },
         "icon": {
-          "color": { "value": "{denhaag.color.red.3.value}" }
+          "color": { "value": "{denhaag.color.red.3}" }
         },
         "action": {
           "button": {
-            "color": { "value": "{denhaag.color.white.value}" },
-            "background-color": { "value": "{denhaag.color.red.3.value}" },
+            "color": { "value": "{denhaag.color.white}" },
+            "background-color": { "value": "{denhaag.color.red.3}" },
             "hover-background": {
-              "color": { "value": "{denhaag.color.red.4.value}" }
+              "color": { "value": "{denhaag.color.red.4}" }
             }
           }
         },
         "close-icon": {
-          "color": { "value": "{denhaag.color.red.5.value}" }
+          "color": { "value": "{denhaag.color.red.5}" }
         }
       },
       "info": {
-        "background-color": { "value": "{denhaag.color.blue.1.value}" },
+        "background-color": { "value": "{denhaag.color.blue.1}" },
         "title": {
-          "color": { "value": "{denhaag.color.blue.5.value}" }
+          "color": { "value": "{denhaag.color.blue.5}" }
         },
         "paragraph": {
-          "color": { "value": "{denhaag.color.blue.5.value}" }
+          "color": { "value": "{denhaag.color.blue.5}" }
         },
         "icon": {
-          "color": { "value": "{denhaag.color.blue.3.value}" }
+          "color": { "value": "{denhaag.color.blue.3}" }
         },
         "action": {
           "button": {
-            "color": { "value": "{denhaag.color.white.value}" },
-            "background-color": { "value": "{denhaag.color.blue.3.value}" },
+            "color": { "value": "{denhaag.color.white}" },
+            "background-color": { "value": "{denhaag.color.blue.3}" },
             "hover": {
-              "background-color": { "value": "{denhaag.color.blue.4.value}" }
+              "background-color": { "value": "{denhaag.color.blue.4}" }
             }
           }
         },
         "close-icon": {
-          "color": { "value": "{denhaag.color.blue.5.value}" }
+          "color": { "value": "{denhaag.color.blue.5}" }
         }
       },
       "success": {
-        "background-color": { "value": "{denhaag.color.green.1.value}" },
+        "background-color": { "value": "{denhaag.color.green.1}" },
         "title": {
-          "color": { "value": "{denhaag.color.green.5.value}" }
+          "color": { "value": "{denhaag.color.green.5}" }
         },
         "paragraph": {
-          "color": { "value": "{denhaag.color.green.5.value}" }
+          "color": { "value": "{denhaag.color.green.5}" }
         },
         "icon": {
-          "color": { "value": "{denhaag.color.green.3.value}" }
+          "color": { "value": "{denhaag.color.green.3}" }
         },
         "action": {
           "button": {
-            "color": { "value": "{denhaag.color.white.value}" },
-            "background-color": { "value": "{denhaag.color.green.3.value}" },
+            "color": { "value": "{denhaag.color.white}" },
+            "background-color": { "value": "{denhaag.color.green.3}" },
             "hover": {
-              "background-color": { "value": "{denhaag.color.green.4.value}" }
+              "background-color": { "value": "{denhaag.color.green.4}" }
             }
           }
         },
         "close-icon": {
-          "color": { "value": "{denhaag.color.green.5.value}" }
+          "color": { "value": "{denhaag.color.green.5}" }
         }
       },
       "warning": {
-        "background-color": { "value": "{denhaag.color.orange.1.value}" },
+        "background-color": { "value": "{denhaag.color.orange.1}" },
         "title": {
-          "color": { "value": "{denhaag.color.orange.5.value}" }
+          "color": { "value": "{denhaag.color.orange.5}" }
         },
         "paragraph": {
-          "color": { "value": "{denhaag.color.orange.5.value}" }
+          "color": { "value": "{denhaag.color.orange.5}" }
         },
         "icon": {
-          "color": { "value": "{denhaag.color.orange.5.value}" }
+          "color": { "value": "{denhaag.color.orange.5}" }
         },
         "action": {
           "button": {
-            "color": { "value": "{denhaag.color.white.value}" },
-            "background-color": { "value": "{denhaag.color.orange.5.value}" },
+            "color": { "value": "{denhaag.color.white}" },
+            "background-color": { "value": "{denhaag.color.orange.5}" },
             "hover": {
-              "background-color": { "value": "{denhaag.color.orange.5.value}" }
+              "background-color": { "value": "{denhaag.color.orange.5}" }
             }
           }
         },
         "close-icon": {
-          "color": { "value": "{denhaag.color.orange.5.value}" }
+          "color": { "value": "{denhaag.color.orange.5}" }
         }
       }
     }

--- a/proprietary/Components/src/denhaag/breadcrumb.tokens.json
+++ b/proprietary/Components/src/denhaag/breadcrumb.tokens.json
@@ -2,47 +2,47 @@
   "denhaag": {
     "breadcrumb": {
       "color": {
-        "value": "{denhaag.color.grey.4.value}"
+        "value": "{denhaag.color.grey.4}"
       },
       "spacing": {
-        "value": "{denhaag.space.inline.xs.value}"
+        "value": "{denhaag.space.inline.xs}"
       },
       "current": {
         "color": {
-          "value": "{denhaag.color.grey.4.value}"
+          "value": "{denhaag.color.grey.4}"
         }
       },
       "dots": {
         "background-color": {
-          "value": "{denhaag.color.grey.1.value}"
+          "value": "{denhaag.color.grey.1}"
         },
         "border-radius": {
-          "value": "{denhaag.border-radius.value}"
+          "value": "{denhaag.border-radius}"
         },
         "color": {
-          "value": "{denhaag.color.grey.3.value}"
+          "value": "{denhaag.color.grey.3}"
         },
         "hover": {
           "background-color": {
-            "value": "{denhaag.color.grey.2.value}"
+            "value": "{denhaag.color.grey.2}"
           }
         }
       },
       "link": {
         "color": {
-          "value": "{denhaag.color.blue.3.value}"
+          "value": "{denhaag.color.blue.3}"
         },
         "focus": {
           "color": {
-            "value": "{denhaag.color.blue.4.value}"
+            "value": "{denhaag.color.blue.4}"
           },
           "outline": {
-            "value": "{denhaag.focus.border.value}"
+            "value": "{denhaag.focus.border}"
           }
         },
         "hover": {
           "color": {
-            "value": "{denhaag.color.blue.4.value}"
+            "value": "{denhaag.color.blue.4}"
           }
         }
       }

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -1,44 +1,44 @@
 {
   "denhaag": {
     "button": {
-      "border-radius": { "value": "{denhaag.border-radius.value}" },
+      "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
       "padding-block": { "value": "6px" },
       "padding-inline": { "value": "16px" },
       "focus": {
-        "border-color": { "value": "{denhaag.focus.border-color.value}" },
-        "border-width": { "value": "{denhaag.focus.border-width.value}" },
-        "border-style": { "value": "{denhaag.focus.border-style.value}" }
+        "border-color": { "value": "{denhaag.focus.border-color}" },
+        "border-width": { "value": "{denhaag.focus.border-width}" },
+        "border-style": { "value": "{denhaag.focus.border-style}" }
       },
       "disabled": {
         "color": {}
       },
       "primary-action": {
-        "background-color": { "value": "{denhaag.color.green.3.value}" },
-        "color": { "value": "{denhaag.color.white.value}" },
+        "background-color": { "value": "{denhaag.color.green.3}" },
+        "color": { "value": "{denhaag.color.white}" },
         "hover": {
-          "background-color": { "value": "{denhaag.color.green.4.value}" },
-          "color": { "value": "{denhaag.color.white.value}" }
+          "background-color": { "value": "{denhaag.color.green.4}" },
+          "color": { "value": "{denhaag.color.white}" }
         },
         "disabled": {
-          "background-color": { "value": "{denhaag.color.grey.2.value}" },
-          "color": { "value": "{denhaag.color.white.value}" }
+          "background-color": { "value": "{denhaag.color.grey.2}" },
+          "color": { "value": "{denhaag.color.white}" }
         }
       },
       "secondary-action": {
-        "background-color": { "value": "{denhaag.color.white.value}" },
-        "color": { "value": "{denhaag.color.green.3.value}" },
-        "border-color": { "value": "{denhaag.color.green.3.value}" },
+        "background-color": { "value": "{denhaag.color.white}" },
+        "color": { "value": "{denhaag.color.green.3}" },
+        "border-color": { "value": "{denhaag.color.green.3}" },
         "hover": {
-          "background-color": { "value": "{denhaag.color.white.value}" },
-          "border-color": { "value": "{denhaag.color.green.4.value}" },
-          "color": { "value": "{denhaag.color.green.4.value}" }
+          "background-color": { "value": "{denhaag.color.white}" },
+          "border-color": { "value": "{denhaag.color.green.4}" },
+          "color": { "value": "{denhaag.color.green.4}" }
         },
         "disabled": {
-          "background-color": { "value": "{denhaag.color.white.value}" },
-          "border-color": { "value": "{denhaag.color.grey.2.value}" },
-          "color": { "value": "{denhaag.color.grey.2.value}" }
+          "background-color": { "value": "{denhaag.color.white}" },
+          "border-color": { "value": "{denhaag.color.grey.2}" },
+          "color": { "value": "{denhaag.color.grey.2}" }
         }
       },
       "large-size": {
@@ -46,8 +46,8 @@
         "padding-inline": { "value": "20px" }
       },
       "medium-size": {
-        "padding-block": { "value": "{denhaag.button.padding-block.value}" },
-        "padding-inline": { "value": "{denhaag.button.padding-inline.value}" }
+        "padding-block": { "value": "{denhaag.button.padding-block}" },
+        "padding-inline": { "value": "{denhaag.button.padding-inline}" }
       }
     }
   }

--- a/proprietary/Components/src/denhaag/card.tokens.json
+++ b/proprietary/Components/src/denhaag/card.tokens.json
@@ -1,29 +1,29 @@
 {
   "denhaag": {
     "card": {
-      "border-color": { "value": "{denhaag.color.grey.2.value}" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
       "border-radius": { "value": "3px" },
       "border-width": { "value": "1px" },
       "height": { "value": "181px" },
       "width": { "value": "352px" },
-      "background-color": { "value": "{denhaag.color.white.value}" },
+      "background-color": { "value": "{denhaag.color.white}" },
       "case-primary": {
-        "background-color": { "value": "{denhaag.color.green.1.value}" }
+        "background-color": { "value": "{denhaag.color.green.1}" }
       },
       "case-secondary": {
-        "background-color": { "value": "{denhaag.color.green.2.value}" }
+        "background-color": { "value": "{denhaag.color.green.2}" }
       },
       "case-archived": {
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "primary": {
-          "background-color": { "value": "{denhaag.color.grey.1.value}" }
+          "background-color": { "value": "{denhaag.color.grey.1}" }
         },
         "secondary": {
-          "background-color": { "value": "{denhaag.color.grey.2.value}" }
+          "background-color": { "value": "{denhaag.color.grey.2}" }
         }
       },
       "case-paper": {
-        "color": { "value": "{denhaag.color.white.value}" }
+        "color": { "value": "{denhaag.color.white}" }
       },
       "actions": {
         "padding-block-end": { "value": "0" },
@@ -38,36 +38,36 @@
       },
       "case": {
         "border-width": { "value": "0" },
-        "color": { "value": "{denhaag.color.green.4.value}" },
+        "color": { "value": "{denhaag.color.green.4}" },
         "height": { "value": "200px" },
         "padding-block-end": { "value": "24px" },
         "padding-block-start": { "value": "20px" },
         "active": {
-          "color": { "value": "{denhaag.color.green.5.value}" }
+          "color": { "value": "{denhaag.color.green.5}" }
         }
       },
       "wrapper": {
         "padding": { "value": "24px" },
-        "padding-block": { "value": "{denhaag.card.wrapper.padding.value}" },
-        "padding-inline": { "value": "{denhaag.card.wrapper.padding.value}" }
+        "padding-block": { "value": "{denhaag.card.wrapper.padding}" },
+        "padding-inline": { "value": "{denhaag.card.wrapper.padding}" }
       },
       "subtitle": {
-        "font-color": { "value": "{denhaag.color.grey.4.value}" },
-        "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+        "font-color": { "value": "{denhaag.color.grey.4}" },
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
         "font-weight": { "value": "500" },
         "line-height": { "value": "24px" },
         "padding": { "value": "0" },
-        "padding-block": { "value": "{denhaag.card.subtitle.padding.value}" },
-        "padding-inline": { "value": "{denhaag.card.subtitle.padding.value}" }
+        "padding-block": { "value": "{denhaag.card.subtitle.padding}" },
+        "padding-inline": { "value": "{denhaag.card.subtitle.padding}" }
       },
       "title": {
-        "font-color": { "value": "{denhaag.color.black.value}" },
-        "font-size": { "value": "{denhaag.typography.scale.xl.font-size.value}" },
+        "font-color": { "value": "{denhaag.color.black}" },
+        "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
         "font-weight": { "value": "bold" },
         "line-height": { "value": "28px" },
         "padding": { "value": "0" },
-        "padding-block": { "value": "{denhaag.card.title.padding.value}" },
-        "padding-inline": { "value": "{denhaag.card.title.padding.value}" }
+        "padding-block": { "value": "{denhaag.card.title.padding}" },
+        "padding-inline": { "value": "{denhaag.card.title.padding}" }
       }
     }
   }

--- a/proprietary/Components/src/denhaag/checkbox.tokens.json
+++ b/proprietary/Components/src/denhaag/checkbox.tokens.json
@@ -2,8 +2,8 @@
   "denhaag": {
     "checkbox": {
       "normal": {
-        "unchecked": { "color": { "value": "{denhaag.color.grey.4.value}" } },
-        "checked": { "color": { "value": "{denhaag.color.blue.3.value}" } }
+        "unchecked": { "color": { "value": "{denhaag.color.grey.4}" } },
+        "checked": { "color": { "value": "{denhaag.color.blue.3}" } }
       },
       "margin": {
         "inline": {
@@ -16,15 +16,15 @@
         }
       },
       "hover": {
-        "color": { "value": "{denhaag.color.blue.3.value}" }
+        "color": { "value": "{denhaag.color.blue.3}" }
       },
       "disabled": {
-        "color": { "value": "{denhaag.color.grey.2.value}" }
+        "color": { "value": "{denhaag.color.grey.2}" }
       },
       "error": {
-        "color": { "value": "{denhaag.color.red.3.value}" },
+        "color": { "value": "{denhaag.color.red.3}" },
         "hover": {
-          "color": { "value": "{denhaag.color.red.4.value}" }
+          "color": { "value": "{denhaag.color.red.4}" }
         }
       }
     }

--- a/proprietary/Components/src/denhaag/divider.tokens.json
+++ b/proprietary/Components/src/denhaag/divider.tokens.json
@@ -1,7 +1,7 @@
 {
   "denhaag": {
     "divider": {
-      "border-color": { "value": "{denhaag.color.grey.2.value}" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
       "border-width": { "value": "1px" },
       "margin-block-start": { "value": "16px" },
       "margin-block-end": { "value": "16px" },

--- a/proprietary/Components/src/denhaag/dot-indicator.tokens.json
+++ b/proprietary/Components/src/denhaag/dot-indicator.tokens.json
@@ -2,11 +2,11 @@
   "denhaag": {
     "dot-indicator": {
       "size": { "value": "12px" },
-      "background-color": { "value": "{denhaag.color.red.3.value}" },
+      "background-color": { "value": "{denhaag.color.red.3}" },
       "border-size": { "value": "2px" },
-      "border-color": { "value": "{denhaag.color.white.value}" },
+      "border-color": { "value": "{denhaag.color.white}" },
       "border": {
-        "value": "{denhaag.dot-indicator.border-size.value} solid {denhaag.dot-indicator.border-color.value}"
+        "value": "{denhaag.dot-indicator.border-size} solid {denhaag.dot-indicator.border-color}"
       }
     }
   }

--- a/proprietary/Components/src/denhaag/form-control-label.tokens.json
+++ b/proprietary/Components/src/denhaag/form-control-label.tokens.json
@@ -3,15 +3,15 @@
     "form-control": {
       "label": {
         "font": {
-          "family": { "value": "{utrecht.paragraph.font-family.value}" },
-          "size": { "value": "{utrecht.paragraph.font-size.value}" },
-          "weight": { "value": "{utrecht.paragraph.font-weight.value}" }
+          "family": { "value": "{utrecht.paragraph.font-family}" },
+          "size": { "value": "{utrecht.paragraph.font-size}" },
+          "weight": { "value": "{utrecht.paragraph.font-weight}" }
         },
         "line": {
-          "height": { "value": "{utrecht.paragraph.line-height.value}" }
+          "height": { "value": "{utrecht.paragraph.line-height}" }
         },
-        "color": { "value": "{utrecht.paragraph.color.value}" },
-        "hover": { "color": { "value": "{denhaag.checkbox.hover.color.value}" } },
+        "color": { "value": "{utrecht.paragraph.color}" },
+        "hover": { "color": { "value": "{denhaag.checkbox.hover.color}" } },
         "margin": {
           "block": { "start": { "value": "8px" }, "end": { "value": "8px" } },
           "inline": { "start": { "value": "8px" }, "end": { "value": "8px" } }

--- a/proprietary/Components/src/denhaag/form-group.tokens.json
+++ b/proprietary/Components/src/denhaag/form-group.tokens.json
@@ -1,13 +1,13 @@
 {
   "denhaag": {
     "form-group": {
-      "label": { "color": { "value": "{denhaag.color.blue.5.value}" } },
+      "label": { "color": { "value": "{denhaag.color.blue.5}" } },
       "helper": {
         "text": {
-          "color": { "value": "{denhaag.color.grey.4.value}" },
-          "size": { "value": "{denhaag.typography.scale.s.font-size.value}" },
+          "color": { "value": "{denhaag.color.grey.4}" },
+          "size": { "value": "{denhaag.typography.scale.s.font-size}" },
           "margin": { "block": { "start": { "value": "4px" } } },
-          "error": { "color": { "value": "{denhaag.color.red.3.value}" } }
+          "error": { "color": { "value": "{denhaag.color.red.3}" } }
         }
       },
       "margin": {

--- a/proprietary/Components/src/denhaag/icon-button.tokens.json
+++ b/proprietary/Components/src/denhaag/icon-button.tokens.json
@@ -1,19 +1,19 @@
 {
   "denhaag": {
     "icon-button": {
-      "color": { "value": "{denhaag.color.grey.4.value}" },
+      "color": { "value": "{denhaag.color.grey.4}" },
       "padding-block-start": { "value": "2px" },
       "padding-block-end": { "value": "2px" },
       "padding-inline-start": { "value": "2px" },
       "padding-inline-end": { "value": "2px" },
       "focus": {
-        "outline-color": { "value": "{denhaag.focus.border-color.value}" },
-        "outline-width": { "value": "{denhaag.focus.border-width.value}" },
-        "outline-style": { "value": "{denhaag.focus.border-style.value}" },
+        "outline-color": { "value": "{denhaag.focus.border-color}" },
+        "outline-width": { "value": "{denhaag.focus.border-width}" },
+        "outline-style": { "value": "{denhaag.focus.border-style}" },
         "outline-offset": { "value": "0px" }
       },
       "hover": {
-        "color": { "value": "{denhaag.color.blue.4.value}" }
+        "color": { "value": "{denhaag.color.blue.4}" }
       }
     }
   }

--- a/proprietary/Components/src/denhaag/link.tokens.json
+++ b/proprietary/Components/src/denhaag/link.tokens.json
@@ -1,17 +1,17 @@
 {
   "denhaag": {
     "link": {
-      "color": { "value": "{denhaag.color.blue.3.value}" },
+      "color": { "value": "{denhaag.color.blue.3}" },
       "padding": { "value": "8px" },
       "focus": {
-        "color": { "value": "{denhaag.color.blue.4.value}" },
-        "outline": { "value": "{denhaag.focus.border.value}" }
+        "color": { "value": "{denhaag.color.blue.4}" },
+        "outline": { "value": "{denhaag.focus.border}" }
       },
       "hover": {
-        "color": { "value": "{denhaag.color.blue.4.value}" }
+        "color": { "value": "{denhaag.color.blue.4}" }
       },
       "disabled": {
-        "color": { "value": "{denhaag.color.grey.2.value}" }
+        "color": { "value": "{denhaag.color.grey.2}" }
       },
       "icon": {
         "margin-start": { "value": "8px" },

--- a/proprietary/Components/src/denhaag/list.tokens.json
+++ b/proprietary/Components/src/denhaag/list.tokens.json
@@ -2,27 +2,27 @@
   "denhaag": {
     "list": {
       "font-family": {
-        "value": "{denhaag.typography.sans-serif.font-family.value}"
+        "value": "{denhaag.typography.sans-serif.font-family}"
       },
       "item": {
         "padding-inline": { "value": "16px" },
         "padding-block": { "value": "12px" },
         "border-size": { "value": "2px" },
         "secondary-action": {
-          "color": { "value": "{denhaag.color.grey.4.value}" },
+          "color": { "value": "{denhaag.color.grey.4}" },
           "right": { "value": "16px" },
           "padding": { "value": "4px" },
           "focus": {
-            "color": { "value": "{denhaag.color.blue.3.value}" }
+            "color": { "value": "{denhaag.color.blue.3}" }
           }
         },
         "focus": {
-          "border-color": { "value": "{denhaag.color.ocher.4.value}" },
-          "border-width": { "value": "{denhaag.focus.border-width.value}" },
-          "border-style": { "value": "{denhaag.focus.border-style.value}" }
+          "border-color": { "value": "{denhaag.color.ocher.4}" },
+          "border-width": { "value": "{denhaag.focus.border-width}" },
+          "border-style": { "value": "{denhaag.focus.border-style}" }
         },
         "active": {
-          "border-color": { "value": "{denhaag.color.blue.3.value}" }
+          "border-color": { "value": "{denhaag.color.blue.3}" }
         },
         "secondary": {
           "padding-block": {
@@ -31,29 +31,29 @@
         }
       },
       "item-icon": {
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "focus": {
-          "color": { "value": "{denhaag.color.blue.3.value}" }
+          "color": { "value": "{denhaag.color.blue.3}" }
         },
         "hover": {
-          "color": { "value": "{denhaag.color.blue.3.value}" }
+          "color": { "value": "{denhaag.color.blue.3}" }
         }
       },
       "item-text": {
         "primary": {
-          "color": { "value": "{denhaag.color.grey.4.value}" },
+          "color": { "value": "{denhaag.color.grey.4}" },
           "font-weight": { "value": "400" },
           "hover": {
-            "color": { "value": "{denhaag.color.blue.3.value}" }
+            "color": { "value": "{denhaag.color.blue.3}" }
           },
           "focus": {
-            "color": { "value": "{denhaag.color.blue.3.value}" }
+            "color": { "value": "{denhaag.color.blue.3}" }
           }
         },
         "secondary": {
-          "color": { "value": "{denhaag.color.grey.4.value}" },
+          "color": { "value": "{denhaag.color.grey.4}" },
           "font-weight": { "value": "400" },
-          "font-size": { "value": "{denhaag.typography.scale.s.font-size.value}" },
+          "font-size": { "value": "{denhaag.typography.scale.s.font-size}" },
           "bottom-padding": { "value": "8px" },
           "line-height": { "value": "16px" }
         },
@@ -66,7 +66,7 @@
           "value": "700"
         },
         "color": {
-          "value": "{denhaag.color.grey.4.value}"
+          "value": "{denhaag.color.grey.4}"
         }
       }
     }

--- a/proprietary/Components/src/denhaag/menu-button.tokens.json
+++ b/proprietary/Components/src/denhaag/menu-button.tokens.json
@@ -2,25 +2,25 @@
   "denhaag": {
     "menu-button": {
       "active": {
-        "color": { "value": "{denhaag.color.blue.3.value}" },
+        "color": { "value": "{denhaag.color.blue.3}" },
         "font-weight": { "value": "700" }
       },
-      "color": { "value": "{denhaag.color.grey.4.value}" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "color": { "value": "{denhaag.color.grey.4}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "font-weight": { "value": "500" },
       "hover": {
-        "color": { "value": "{denhaag.menu-button.active.color.value}" }
+        "color": { "value": "{denhaag.menu-button.active.color}" }
       },
       "line-height": { "value": "21px" },
       "chevron": {
         "padding-inline-start": { "value": "4px" },
         "size": { "value": "12px" },
         "active": {
-          "color": { "value": "{denhaag.menu-button.active.color.value}" }
+          "color": { "value": "{denhaag.menu-button.active.color}" }
         },
         "hover": {
-          "color": { "value": "{denhaag.menu-button.chevron.active.color.value}" }
+          "color": { "value": "{denhaag.menu-button.chevron.active.color}" }
         }
       }
     }

--- a/proprietary/Components/src/denhaag/pagination.tokens.json
+++ b/proprietary/Components/src/denhaag/pagination.tokens.json
@@ -3,12 +3,12 @@
     "pagination": {
       "border": {
         "radius": {
-          "value": "{denhaag.border-radius.value}"
+          "value": "{denhaag.border-radius}"
         }
       },
       "font": {
         "size": {
-          "value": "{denhaag.typography.scale.base.font-size.value}"
+          "value": "{denhaag.typography.scale.base.font-size}"
         },
         "weight": {
           "value": 400
@@ -18,14 +18,14 @@
         "value": "0.625rem"
       },
       "size": {
-        "value": "{denhaag.space.block.2xl.value}"
+        "value": "{denhaag.space.block.2xl}"
       },
       "arrow": {
         "font-size": {
-          "value": "{denhaag.typography.scale.s.font-size.value}"
+          "value": "{denhaag.typography.scale.s.font-size}"
         },
         "size": {
-          "value": "{denhaag.space.block.lg.value}"
+          "value": "{denhaag.space.block.lg}"
         }
       },
       "link": {
@@ -33,39 +33,39 @@
           "value": "transparent"
         },
         "color": {
-          "value": "{denhaag.color.grey.4.value}"
+          "value": "{denhaag.color.grey.4}"
         },
         "hover": {
           "color": {
-            "value": "{denhaag.color.green.3.value}"
+            "value": "{denhaag.color.green.3}"
           }
         },
         "disabled": {
           "color": {
-            "value": "{denhaag.color.grey.2.value}"
+            "value": "{denhaag.color.grey.2}"
           }
         },
         "current": {
           "background-color": {
-            "value": "{denhaag.color.green.3.value}"
+            "value": "{denhaag.color.green.3}"
           },
           "color": {
-            "value": "{denhaag.color.white.value}"
+            "value": "{denhaag.color.white}"
           },
           "hover": {
             "background-color": {
-              "value": "{denhaag.color.green.4.value}"
+              "value": "{denhaag.color.green.4}"
             },
             "color": {
-              "value": "{denhaag.color.white.value}"
+              "value": "{denhaag.color.white}"
             }
           },
           "disabled": {
             "background-color": {
-              "value": "{denhaag.color.grey.2.value}"
+              "value": "{denhaag.color.grey.2}"
             },
             "color": {
-              "value": "{denhaag.color.white.value}"
+              "value": "{denhaag.color.white}"
             }
           }
         }

--- a/proprietary/Components/src/denhaag/tabs.tokens.json
+++ b/proprietary/Components/src/denhaag/tabs.tokens.json
@@ -1,25 +1,25 @@
 {
   "denhaag": {
     "tabs": {
-      "border-color": { "value": "{denhaag.color.grey.2.value}" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
       "border-width": { "value": "2px" },
       "border-style": { "value": "solid" },
       "tab": {
-        "background-color": { "value": "{denhaag.color.white.value}" },
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "background-color": { "value": "{denhaag.color.white}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "font-weight": { "value": "400" },
-        "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
-        "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
-        "padding-block-start": { "value": "{denhaag.space.block.xs.value}" },
-        "padding-block-end": { "value": "{denhaag.space.block.xs.value}" },
-        "padding-inline-start": { "value": "{denhaag.space.inline.xs.value}" },
-        "padding-inline-end": { "value": "{denhaag.space.inline.xs.value}" },
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
+        "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+        "padding-block-start": { "value": "{denhaag.space.block.xs}" },
+        "padding-block-end": { "value": "{denhaag.space.block.xs}" },
+        "padding-inline-start": { "value": "{denhaag.space.inline.xs}" },
+        "padding-inline-end": { "value": "{denhaag.space.inline.xs}" },
         "selected": {
           "font-weight": { "value": "700" }
         }
       },
       "tab-indicator": {
-        "border-color": { "value": "{denhaag.color.blue.3.value}" },
+        "border-color": { "value": "{denhaag.color.blue.3}" },
         "border-width": { "value": "2px" }
       },
       "tab-panel": {

--- a/proprietary/Components/src/denhaag/timeline.tokens.json
+++ b/proprietary/Components/src/denhaag/timeline.tokens.json
@@ -1,41 +1,41 @@
 {
   "denhaag": {
     "timeline": {
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "line-height": { "value": "24px" },
       "step-icon": {
-        "color": { "value": "{denhaag.color.grey.3.value}" },
+        "color": { "value": "{denhaag.color.grey.3}" },
         "margin": { "value": "auto" },
         "padding": { "value": "12px" },
         "size": { "value": "20px" },
         "completed": {
-          "color": { "value": "{denhaag.color.green.3.value}" }
+          "color": { "value": "{denhaag.color.green.3}" }
         },
         "active": {
-          "color": { "value": "{denhaag.color.blue.3.value}" }
+          "color": { "value": "{denhaag.color.blue.3}" }
         },
         "disabled": {
-          "color": { "value": "{denhaag.color.grey.2.value}" }
+          "color": { "value": "{denhaag.color.grey.2}" }
         },
         "text": {
           "active": {
-            "color": { "value": "{denhaag.color.white.value}" }
+            "color": { "value": "{denhaag.color.white}" }
           }
         }
       },
       "step-label": {
         "completed": {
           "hover": {
-            "color": { "value": "{denhaag.color.blue.3.value}" }
+            "color": { "value": "{denhaag.color.blue.3}" }
           }
         },
         "active": {
-          "color": { "value": "{denhaag.color.blue.3.value}" },
+          "color": { "value": "{denhaag.color.blue.3}" },
           "font-weight": { "value": "700" }
         },
         "disabled": {
-          "color": { "value": "{denhaag.color.grey.2.value}" }
+          "color": { "value": "{denhaag.color.grey.2}" }
         }
       },
       "step-collapse-icon": {
@@ -43,15 +43,15 @@
         "padding": { "value": "4px" }
       },
       "step-content": {
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "margin": { "value": "12px" }
       },
       "step-icon-text": {
-        "font-size": { "value": "{denhaag.typography.scale.s.font-size.value}" }
+        "font-size": { "value": "{denhaag.typography.scale.s.font-size}" }
       },
       "step": {
         "outline-offset": { "value": "2px" },
-        "outline": { "value": "{denhaag.focus.border.value}" },
+        "outline": { "value": "{denhaag.focus.border}" },
         "padding": { "value": "12px" }
       }
     }

--- a/proprietary/Components/src/utrecht/badge-counter.tokens.json
+++ b/proprietary/Components/src/utrecht/badge-counter.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{denhaag.color.grey.1.value}"
+        "value": "{denhaag.color.grey.1}"
       },
       "border-radius": {
-        "value": "{denhaag.border-radius.value}"
+        "value": "{denhaag.border-radius}"
       },
       "color": {
-        "value": "{denhaag.color.grey.4.value}"
+        "value": "{denhaag.color.grey.4}"
       },
       "font-family": {
-        "value": "{denhaag.typography.sans-serif.font-family.value}"
+        "value": "{denhaag.typography.sans-serif.font-family}"
       },
       "font-weight": {
         "value": "700"
       },
       "font-size": {
-        "value": "{denhaag.typography.scale.s.font-size.value}"
+        "value": "{denhaag.typography.scale.s.font-size}"
       },
       "padding-block": {
         "value": "4px"

--- a/proprietary/Components/src/utrecht/badge.tokens.json
+++ b/proprietary/Components/src/utrecht/badge.tokens.json
@@ -2,16 +2,16 @@
   "utrecht": {
     "badge": {
       "border-radius": {
-        "value": "{denhaag.border-radius.value}"
+        "value": "{denhaag.border-radius}"
       },
       "font-family": {
-        "value": "{denhaag.typography.sans-serif.font-family.value}"
+        "value": "{denhaag.typography.sans-serif.font-family}"
       },
       "font-weight": {
         "value": "700"
       },
       "font-size": {
-        "value": "{denhaag.typography.scale.s.font-size.value}"
+        "value": "{denhaag.typography.scale.s.font-size}"
       },
       "padding-block": {
         "value": "6px"

--- a/proprietary/Components/src/utrecht/breadcrumb.tokens.json
+++ b/proprietary/Components/src/utrecht/breadcrumb.tokens.json
@@ -3,7 +3,7 @@
     "breadcrumb": {
       "block-size": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "text-transform": {},
       "divider": {
         "content": { "value": "›" },
@@ -17,10 +17,10 @@
       },
       "link": {
         "background-color": {},
-        "color": { "value": "{denhaag.color.blue.4.value}" },
+        "color": { "value": "{denhaag.color.blue.4}" },
         "focus": {
           "background-color": {},
-          "color": { "value": "{denhaag.color.blue.3.value}" }
+          "color": { "value": "{denhaag.color.blue.3}" }
         }
       }
     }

--- a/proprietary/Components/src/utrecht/button.tokens.json
+++ b/proprietary/Components/src/utrecht/button.tokens.json
@@ -1,11 +1,11 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{denhaag.color.green.3.value}" },
+      "background-color": { "value": "{denhaag.color.green.3}" },
       "border-width": { "value": "0" },
-      "border-radius": { "value": "{denhaag.border-radius.value}" },
-      "color": { "value": "{denhaag.color.white.value}" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
+      "border-radius": { "value": "{denhaag.border-radius}" },
+      "color": { "value": "{denhaag.color.white}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
       "padding-inline-start": { "value": "16px" },
       "padding-inline-end": { "value": "16px" },
       "padding-block-start": { "value": "13px" },
@@ -15,36 +15,36 @@
       "margin-block-start": { "value": "0" },
       "margin-block-end": { "value": "0" },
       "primary-action": {
-        "background-color": { "value": "{denhaag.color.green.3.value}" },
-        "color": { "value": "{denhaag.color.white.value}" },
+        "background-color": { "value": "{denhaag.color.green.3}" },
+        "color": { "value": "{denhaag.color.white}" },
         "hover": {
-          "background-color": { "value": "{denhaag.color.green.4.value}" },
-          "color": { "value": "{denhaag.color.white.value}" }
+          "background-color": { "value": "{denhaag.color.green.4}" },
+          "color": { "value": "{denhaag.color.white}" }
         }
       },
       "secondary-action": {
-        "background-color": { "value": "{denhaag.color.white.value}" },
-        "color": { "value": "{denhaag.color.green.3.value}" },
-        "border-color": { "value": "{denhaag.color.green.3.value}" },
+        "background-color": { "value": "{denhaag.color.white}" },
+        "color": { "value": "{denhaag.color.green.3}" },
+        "border-color": { "value": "{denhaag.color.green.3}" },
         "border-width": { "value": "2px" },
         "hover": {
-          "background-color": { "value": "{denhaag.color.white.value}" },
-          "color": { "value": "{denhaag.color.green.4.value}" },
-          "border-color": { "value": "{denhaag.color.green.4.value}" }
+          "background-color": { "value": "{denhaag.color.white}" },
+          "color": { "value": "{denhaag.color.green.4}" },
+          "border-color": { "value": "{denhaag.color.green.4}" }
         },
         "disabled": {
-          "background-color": { "value": "{denhaag.color.white.value}" },
-          "border-color": { "value": "{denhaag.color.grey.2.value}" },
-          "color": { "value": "{denhaag.color.grey.2.value}" }
+          "background-color": { "value": "{denhaag.color.white}" },
+          "border-color": { "value": "{denhaag.color.grey.2}" },
+          "color": { "value": "{denhaag.color.grey.2}" }
         }
       },
       "focus": {
-        "border-color": { "value": "{denhaag.focus.border-color.value}" },
-        "border-width": { "value": "{denhaag.focus.border-width.value}" }
+        "border-color": { "value": "{denhaag.focus.border-color}" },
+        "border-width": { "value": "{denhaag.focus.border-width}" }
       },
       "disabled": {
-        "background-color": { "value": "{denhaag.color.grey.2.value}" },
-        "color": { "value": "{denhaag.color.white.value}" }
+        "background-color": { "value": "{denhaag.color.grey.2}" },
+        "color": { "value": "{denhaag.color.white}" }
       }
     }
   }

--- a/proprietary/Components/src/utrecht/document.tokens.json
+++ b/proprietary/Components/src/utrecht/document.tokens.json
@@ -3,7 +3,7 @@
     "document": {
       "background-color": {},
       "color": {},
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
       "font-size": { "value": "normal" },
       "line-height": { "value": "normal" }
     }

--- a/proprietary/Components/src/utrecht/form-input.tokens.json
+++ b/proprietary/Components/src/utrecht/form-input.tokens.json
@@ -1,25 +1,25 @@
 {
   "utrecht": {
     "form-input": {
-      "background-color": { "value": "{denhaag.color.white.value}" },
-      "border-color": { "value": "{denhaag.color.grey.2.value}" },
-      "border-radius": { "value": "{denhaag.border-radius.value}" },
+      "background-color": { "value": "{denhaag.color.white}" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
+      "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
-      "color": { "value": "{denhaag.color.grey.4.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
+      "color": { "value": "{denhaag.color.grey.4}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
       "padding-block-end": { "value": "8px" },
       "padding-block-start": { "value": "8px" },
       "padding-inline-end": { "value": "16px" },
       "padding-inline-start": { "value": "16px" },
       "placeholder": {
-        "color": { "value": "{denhaag.color.grey.3.value}" }
+        "color": { "value": "{denhaag.color.grey.3}" }
       },
       "disabled": {
-        "border-color": { "value": "{denhaag.color.grey.2.value}" },
-        "color": { "value": "{denhaag.color.grey.2.value}" }
+        "border-color": { "value": "{denhaag.color.grey.2}" },
+        "color": { "value": "{denhaag.color.grey.2}" }
       },
       "invalid": {
-        "border-color": { "value": "{denhaag.color.red.3.value}" },
+        "border-color": { "value": "{denhaag.color.red.3}" },
         "border-width": { "value": "2px" }
       }
     }

--- a/proprietary/Components/src/utrecht/form-label.tokens.json
+++ b/proprietary/Components/src/utrecht/form-label.tokens.json
@@ -1,15 +1,15 @@
 {
   "utrecht": {
     "form-label": {
-      "color": { "value": "{denhaag.color.blue.5.value}" },
+      "color": { "value": "{denhaag.color.blue.5}" },
       "font-weight": { "value": "700" },
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "checkbox": {
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "font-weight": { "value": "400" }
       },
       "radio": {
-        "color": { "value": "{denhaag.color.grey.4.value}" },
+        "color": { "value": "{denhaag.color.grey.4}" },
         "font-weight": { "value": "400" }
       }
     }

--- a/proprietary/Components/src/utrecht/heading-1.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-1.tokens.json
@@ -3,7 +3,7 @@
     "heading-1": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.3xl.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.3xl.font-size}" },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},

--- a/proprietary/Components/src/utrecht/heading-2.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-2.tokens.json
@@ -3,7 +3,7 @@
     "heading-2": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.2xl.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.2xl.font-size}" },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},

--- a/proprietary/Components/src/utrecht/heading-3.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-3.tokens.json
@@ -3,7 +3,7 @@
     "heading-3": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.xl.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},

--- a/proprietary/Components/src/utrecht/heading-4.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-4.tokens.json
@@ -3,7 +3,7 @@
     "heading-4": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.lg.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.lg.font-size}" },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},

--- a/proprietary/Components/src/utrecht/heading-5.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-5.tokens.json
@@ -3,7 +3,7 @@
     "heading-5": {
       "color": {},
       "font-family": {},
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},

--- a/proprietary/Components/src/utrecht/heading.tokens.json
+++ b/proprietary/Components/src/utrecht/heading.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "heading": {
-      "color": { "value": "{denhaag.color.grey.4.value}" },
-      "font-family": { "value": "{denhaag.typography.sans-serif-alternate.font-family.value}" },
+      "color": { "value": "{denhaag.color.grey.4}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif-alternate.font-family}" },
       "font-weight": { "value": "700" }
     }
   }

--- a/proprietary/Components/src/utrecht/link.tokens.json
+++ b/proprietary/Components/src/utrecht/link.tokens.json
@@ -2,16 +2,16 @@
   "utrecht": {
     "link": {
       "color": {
-        "value": "{denhaag.color.blue.3.value}"
+        "value": "{denhaag.color.blue.3}"
       },
       "text-decoration": {
         "value": "underline"
       },
       "focus": {
-        "color": { "value": "{denhaag.color.blue.4.value}" }
+        "color": { "value": "{denhaag.color.blue.4}" }
       },
       "hover": {
-        "color": { "value": "{denhaag.color.blue.4.value}" }
+        "color": { "value": "{denhaag.color.blue.4}" }
       }
     }
   }

--- a/proprietary/Components/src/utrecht/page-footer.tokens.json
+++ b/proprietary/Components/src/utrecht/page-footer.tokens.json
@@ -5,7 +5,7 @@
         "value": "hsl(48deg 94% 48%)"
       },
       "color": {
-        "value": "{denhaag.color.black.value}"
+        "value": "{denhaag.color.black}"
       },
       "padding-block-end": {
         "value": "40px"

--- a/proprietary/Components/src/utrecht/paragraph.tokens.json
+++ b/proprietary/Components/src/utrecht/paragraph.tokens.json
@@ -1,15 +1,15 @@
 {
   "utrecht": {
     "paragraph": {
-      "color": { "value": "{denhaag.color.grey.4.value}" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{denhaag.typography.scale.base.font-size.value}" },
+      "color": { "value": "{denhaag.color.grey.4}" },
+      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "font-weight": { "value": "400" },
       "line-height": { "value": "normal" },
       "margin-block-start": { "value": "0" },
       "margin-block-end": { "value": "0" },
       "lead": {
-        "font-size": { "value": "{denhaag.typography.scale.lg.font-size.value} " },
+        "font-size": { "value": "{denhaag.typography.scale.lg.font-size} " },
         "font-weight": {},
         "line-height": { "value": "26px" }
       }

--- a/proprietary/Components/src/utrecht/separator.tokens.json
+++ b/proprietary/Components/src/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{denhaag.color.grey.2.value}" },
+      "color": { "value": "{denhaag.color.grey.2}" },
       "width": { "value": "1px" },
       "margin-block-start": { "value": "16px" },
       "margin-block-end": { "value": "16px" }

--- a/proprietary/Components/src/utrecht/table.tokens.json
+++ b/proprietary/Components/src/utrecht/table.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "table": {
-      "border-color": { "value": "{denhaag.color.grey.2.value}" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
       "border-width": { "value": "2px" },
       "margin-block-end": {},
       "margin-block-start": {},
@@ -19,13 +19,13 @@
         "font-weight": {},
         "color": {},
         "text-transform": {},
-        "border-block-end-color": { "value": "{denhaag.color.grey.1.value}" },
+        "border-block-end-color": { "value": "{denhaag.color.grey.1}" },
         "border-block-end-width": { "value": "1px" }
       },
       "heading": {
         "font-size": { "value": "18px" },
         "font-weight": { "value": "700" },
-        "color": { "value": "{denhaag.color.green.3.value}" },
+        "color": { "value": "{denhaag.color.green.3}" },
         "text-transform": {}
       },
       "cell": {
@@ -36,7 +36,7 @@
         "padding-inline-start": { "value": "15px" }
       },
       "row": {
-        "border-block-end-color": { "value": "{denhaag.color.grey.1.value}" },
+        "border-block-end-color": { "value": "{denhaag.color.grey.1}" },
         "border-block-end-width": { "value": "1px" },
         "padding-inline-end": { "value": "24px" },
         "padding-inline-start": { "value": "24px" },


### PR DESCRIPTION
Let's get rid of the most annoying thing of the design token JSONs: the `.value` at the end of references. Omitting `.value` is supported since style-dictionary@3.1.0.

https://github.com/amzn/style-dictionary/pull/746

Tested it by diffing the `dist/index.css` before and after: no difference.