### PR TITLE
fix: removed alert component a11y check disables

### DIFF
--- a/components/Alert/specs/Alert.spec.jsx
+++ b/components/Alert/specs/Alert.spec.jsx
@@ -46,10 +46,7 @@ describe(`Alerts tests`, () => {
         variant: ['error', 'info', 'success', 'warning'],
       },
       {},
-      [
-        { id: 'duplicate-id', issue: 406 },
-        { id: 'color-contrast', issue: 407 },
-      ],
+      [],
     );
 
     cy.snapshots(
@@ -58,10 +55,7 @@ describe(`Alerts tests`, () => {
         variant: ['error', 'info', 'success', 'warning'],
       },
       {},
-      [
-        { id: 'duplicate-id', issue: 406 },
-        { id: 'color-contrast', issue: 407 },
-      ],
+      [],
     );
 
     cy.snapshots(
@@ -81,10 +75,7 @@ describe(`Alerts tests`, () => {
           focus: 'denhaag-icon-button--focus',
         },
       },
-      [
-        { id: 'duplicate-id', issue: 406 },
-        { id: 'color-contrast', issue: 407 },
-      ],
+      [],
     );
 
     cy.snapshots(
@@ -107,10 +98,7 @@ describe(`Alerts tests`, () => {
           focus: 'denhaag-button--focus',
         },
       },
-      [
-        { id: 'duplicate-id', issue: 406 },
-        { id: 'color-contrast', issue: 407 },
-      ],
+      [],
     );
   });
 });


### PR DESCRIPTION
Quick PR removing a11y check disables in the Alert component tests. These issues have already been resolved in #406 and #407, but we never removed the rule disables, resulting in these properties not being checked and warnings in the GH Actions Annotations (see screenshot).

![image](https://user-images.githubusercontent.com/12658988/150546600-290f9fe2-cbd6-4bf1-bd9d-8a775c604665.png)
