### PR TITLE
Design update: font-size, focus, padding

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -43,11 +43,9 @@
 }
 
 .denhaag-accordion__summary {
-  color: var(--denhaag-accordion-summary-color, hsl(0 0% 29%));
+  color: var(--denhaag-accordion-summary-color);
   flex-grow: 1;
   font-weight: var(--denhaag-accordion-font-weight);
-  margin-block-start: var(--denhaag-accordion-margin);
-  margin-block-end: var(--denhaag-accordion-margin);
   padding-inline-end: var(--denhaag-accordion-padding);
 }
 
@@ -66,12 +64,12 @@
 }
 
 .denhaag-accordion__icon .denhaag-icon {
-  color: var(--denhaag-accordion-icon-color, hsl(0 0% 29%));
+  color: var(--denhaag-accordion-icon-color);
 }
 
 .denhaag-accordion__panel[aria-disabled="true"] .denhaag-accordion__title,
 .denhaag-accordion__panel[aria-disabled="true"] .denhaag-icon {
-  color: var(--denhaag-accordion-disabled-color, hsl(0 0% 82%));
+  color: var(--denhaag-accordion-disabled-color);
 }
 
 .denhaag-accordion__panel--expanded .denhaag-accordion__summary,
@@ -81,13 +79,13 @@
 
 .denhaag-accordion__panel--expanded .denhaag-accordion__icon .denhaag-icon {
   transform: var(--denhaag-accordion-expanded-transform);
-  color: var(--denhaag-accordion-expanded-icon-color, hsl(207 80% 35%));
 }
 
 .denhaag-accordion__panel--expanded .denhaag-accordion__summary,
+.denhaag-accordion__panel--expanded .denhaag-accordion__icon .denhaag-icon,
 .denhaag-accordion__panel:not(.denhaag-accordion__panel[aria-disabled="true"]):hover .denhaag-accordion__title,
 .denhaag-accordion__panel:not(.denhaag-accordion__panel[aria-disabled="true"]):hover .denhaag-icon {
-  color: var(--denhaag-accordion-expanded-icon-color, hsl(207 80% 35%));
+  color: var(--denhaag-accordion-active-color);
 }
 
 .denhaag-accordion__collapse {
@@ -112,8 +110,15 @@
 
 .denhaag-accordion__paragraph {
   font-weight: var(--denhaag-accordion-font-weight);
-  font-style: normal;
   font-size: var(--denhaag-accordion-paragraph-font-size, 1rem);
   line-height: var(--denhaag-accordion-line-height);
-  color: var(--denhaag-accordion-paragraph-color, hsl(0 0% 29%));
+  color: var(--denhaag-accordion-paragraph-color);
+  margin-block-start: var(
+    --denhaag-accordion-paragraph-margin-block-start,
+    var(--denhaag-accordion-paragraph-margin-block)
+  );
+  margin-block-end: var(
+    --denhaag-accordion-paragraph-margin-block-end,
+    var(--denhaag-accordion-paragraph-margin-block)
+  );
 }

--- a/components/Accordion/src/stories/bem.stories.mdx
+++ b/components/Accordion/src/stories/bem.stories.mdx
@@ -34,105 +34,95 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
-    <div>
-      <div class="story--components-surfaces-accordion--default">
-        <div class="denhaag-theme">
-          <div class="denhaag-accordion">
-            <div class="denhaag-accordion-container">
-              <div
-                class="denhaag-accordion__panel"
-                tabindex="0"
-                role="button"
-                aria-disabled="false"
-                aria-expanded="false"
-              >
-                <div class="denhaag-accordion__summary">
-                  <p class="denhaag-accordion__title">Accordion</p>
-                </div>
-                <div class="denhaag-accordion__icon" aria-disabled="false" aria-hidden="true">
-                  <span>
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span></span>
-                </div>
+    <div class="story--components-surfaces-accordion--default">
+      <div class="denhaag-theme">
+        <div class="denhaag-accordion">
+          <div class="denhaag-accordion-container">
+            <div
+              class="denhaag-accordion__panel"
+              tabindex="0"
+              role="button"
+              aria-disabled="false"
+              aria-expanded="false"
+            >
+              <div class="denhaag-accordion__summary">
+                <p class="denhaag-accordion__title">Accordion</p>
               </div>
-              {/* <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden"> */}
-              <div class="denhaag-accordion__collapse">
-                <div>
-                  <div>
-                    <div role="region">
-                      <div class="denhaag-accordion__details">
-                        <p class="denhaag-accordion__paragraph">
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit
-                          amet blandit leo lobortis eget.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+              <div class="denhaag-accordion__icon" aria-disabled="false" aria-hidden="true">
+                <span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span></span>
+              </div>
+            </div>
+            {/* <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden"> */}
+            <div class="denhaag-accordion__collapse">
+              <div role="region">
+                <div class="denhaag-accordion__details">
+                  <p class="denhaag-accordion__paragraph">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet
+                    blandit leo lobortis eget.
+                  </p>
                 </div>
               </div>
             </div>
-            <div class="denhaag-accordion-container">
-              <div
-                class="denhaag-accordion__panel"
-                tabindex="0"
-                role="button"
-                aria-disabled="false"
-                aria-expanded="false"
-              >
-                <div class="denhaag-accordion__summary">
-                  <p class="denhaag-accordion__title">Accordion</p>
-                </div>
-                <div class="denhaag-accordion__icon" aria-disabled="false" aria-hidden="true">
-                  <span>
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span></span>
-                </div>
+          </div>
+          <div class="denhaag-accordion-container">
+            <div
+              class="denhaag-accordion__panel"
+              tabindex="0"
+              role="button"
+              aria-disabled="false"
+              aria-expanded="false"
+            >
+              <div class="denhaag-accordion__summary">
+                <p class="denhaag-accordion__title">Accordion</p>
               </div>
-              {/* <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden"> */}
-              <div class="denhaag-accordion__collapse">
-                <div>
-                  <div>
-                    <div role="region">
-                      <div class="denhaag-accordion__details">
-                        <p class="denhaag-accordion__paragraph">
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit
-                          amet blandit leo lobortis eget.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+              <div class="denhaag-accordion__icon" aria-disabled="false" aria-hidden="true">
+                <span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span></span>
+              </div>
+            </div>
+            {/* <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden"> */}
+            <div class="denhaag-accordion__collapse">
+              <div role="region">
+                <div class="denhaag-accordion__details">
+                  <p class="denhaag-accordion__paragraph">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet
+                    blandit leo lobortis eget.
+                  </p>
                 </div>
               </div>
             </div>
@@ -149,59 +139,53 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default Expanded">
-    <div>
-      <div class="story--components-surfaces-accordion--default-expanded">
-        <div class="denhaag-theme">
-          <div class="denhaag-accordion">
-            <div class="denhaag-accordion-container">
-              <div
-                class="denhaag-accordion__panel denhaag-accordion__panel--expanded"
-                tabindex="0"
-                role="button"
-                aria-disabled="false"
-                aria-expanded="true"
-              >
-                <div class="denhaag-accordion__summary denhaag-accordion__summary--expanded">
-                  <p class="denhaag-accordion__title">Accordion</p>
-                </div>
-                <div
-                  class="denhaag-accordion__icon denhaag-accordion__icon--expanded"
-                  aria-disabled="false"
-                  aria-hidden="true"
-                >
-                  <span>
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span></span>
-                </div>
+    <div class="story--components-surfaces-accordion--default-expanded">
+      <div class="denhaag-theme">
+        <div class="denhaag-accordion">
+          <div class="denhaag-accordion-container">
+            <div
+              class="denhaag-accordion__panel denhaag-accordion__panel--expanded"
+              tabindex="0"
+              role="button"
+              aria-disabled="false"
+              aria-expanded="true"
+            >
+              <div class="denhaag-accordion__summary denhaag-accordion__summary--expanded">
+                <p class="denhaag-accordion__title">Accordion</p>
               </div>
-              <div class="denhaag-accordion__collapse">
-                <div>
-                  <div>
-                    <div role="region">
-                      <div class="denhaag-accordion__details">
-                        <p class="denhaag-accordion__paragraph">
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit
-                          amet blandit leo lobortis eget.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+              <div
+                class="denhaag-accordion__icon denhaag-accordion__icon--expanded"
+                aria-disabled="false"
+                aria-hidden="true"
+              >
+                <span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span></span>
+              </div>
+            </div>
+            <div class="denhaag-accordion__collapse">
+              <div role="region">
+                <div class="denhaag-accordion__details">
+                  <p class="denhaag-accordion__paragraph">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet
+                    blandit leo lobortis eget.
+                  </p>
                 </div>
               </div>
             </div>
@@ -218,55 +202,49 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Disabled">
-    <div>
-      <div class="story--components-surfaces-accordion--disabled">
-        <div class="denhaag-theme">
-          <div class="denhaag-accordion">
-            <div class="denhaag-accordion-container denhaag-accordion-container--disabled">
-              <div
-                class="denhaag-accordion__panel denhaag-accordion__panel"
-                tabindex="-1"
-                role="button"
-                aria-disabled="true"
-                aria-expanded="false"
-              >
-                <div class="denhaag-accordion__summary" aria-disabled="true" aria-hidden="true">
-                  <p class="denhaag-accordion__title">Accordion</p>
-                </div>
-                <div aria-disabled="false" aria-hidden="true">
-                  <span>
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span></span>
-                </div>
+    <div class="story--components-surfaces-accordion--disabled">
+      <div class="denhaag-theme">
+        <div class="denhaag-accordion">
+          <div class="denhaag-accordion-container denhaag-accordion-container--disabled">
+            <div
+              class="denhaag-accordion__panel denhaag-accordion__panel"
+              tabindex="-1"
+              role="button"
+              aria-disabled="true"
+              aria-expanded="false"
+            >
+              <div class="denhaag-accordion__summary" aria-disabled="true" aria-hidden="true">
+                <p class="denhaag-accordion__title">Accordion</p>
               </div>
-              <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden">
-                <div>
-                  <div>
-                    <div role="region">
-                      <div class="denhaag-accordion__details">
-                        <p class="denhaag-accordion__paragraph">
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit
-                          amet blandit leo lobortis eget.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+              <div aria-disabled="false" aria-hidden="true">
+                <span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span></span>
+              </div>
+            </div>
+            <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden">
+              <div role="region">
+                <div class="denhaag-accordion__details">
+                  <p class="denhaag-accordion__paragraph">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet
+                    blandit leo lobortis eget.
+                  </p>
                 </div>
               </div>
             </div>
@@ -283,55 +261,49 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
-    <div>
-      <div class="story--components-surfaces-accordion--focus">
-        <div class="denhaag-theme">
-          <div class="denhaag-accordion">
-            <div class="denhaag-accordion-container">
-              <div
-                class="denhaag-accordion__panel denhaag-accordion__panel--focus"
-                tabindex="0"
-                role="button"
-                aria-disabled="false"
-                aria-expanded="false"
-              >
-                <div class="denhaag-accordion__summary">
-                  <p class="denhaag-accordion__title">Accordion</p>
-                </div>
-                <div aria-disabled="false" aria-hidden="true">
-                  <span>
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
-                  <span></span>
-                </div>
+    <div class="story--components-surfaces-accordion--focus">
+      <div class="denhaag-theme">
+        <div class="denhaag-accordion">
+          <div class="denhaag-accordion-container">
+            <div
+              class="denhaag-accordion__panel denhaag-accordion__panel--focus"
+              tabindex="0"
+              role="button"
+              aria-disabled="false"
+              aria-expanded="false"
+            >
+              <div class="denhaag-accordion__summary">
+                <p class="denhaag-accordion__title">Accordion</p>
               </div>
-              <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden">
-                <div>
-                  <div>
-                    <div role="region">
-                      <div class="denhaag-accordion__details">
-                        <p class="denhaag-accordion__paragraph">
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit
-                          amet blandit leo lobortis eget.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
+              <div aria-disabled="false" aria-hidden="true">
+                <span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </span>
+                <span></span>
+              </div>
+            </div>
+            <div class="denhaag-accordion__collapse denhaag-accordion__collapse--hidden">
+              <div role="region">
+                <div class="denhaag-accordion__details">
+                  <p class="denhaag-accordion__paragraph">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet
+                    blandit leo lobortis eget.
+                  </p>
                 </div>
               </div>
             </div>

--- a/components/BadgeCounter/package.json
+++ b/components/BadgeCounter/package.json
@@ -22,8 +22,7 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@gemeente-denhaag/dotindicator": "0.1.1-alpha.104",
-    "@utrecht/components": "1.0.0-alpha.140"
+    "@gemeente-denhaag/dotindicator": "0.1.1-alpha.104"
   },
   "peerDependencies": {
     "react": "^17.0.0"

--- a/components/BadgeCounter/package.json
+++ b/components/BadgeCounter/package.json
@@ -22,8 +22,8 @@
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "@gemeente-denhaag/basedatadisplayprops": "0.2.3-alpha.104",
-    "@gemeente-denhaag/dotindicator": "0.1.1-alpha.104"
+    "@gemeente-denhaag/dotindicator": "0.1.1-alpha.104",
+    "@utrecht/components": "1.0.0-alpha.140"
   },
   "peerDependencies": {
     "react": "^17.0.0"

--- a/components/BadgeCounter/src/index.scss
+++ b/components/BadgeCounter/src/index.scss
@@ -1,4 +1,4 @@
-@import "@utrecht/components/badge-counter/bem";
+@import "~@utrecht/components/badge-counter/bem";
 
 .denhaag-badge-counter {
   --denhaag-dot-indicator-size: 8px;

--- a/components/BadgeCounter/src/index.scss
+++ b/components/BadgeCounter/src/index.scss
@@ -1,16 +1,12 @@
+@import "@utrecht/components/badge-counter/bem";
+
 .denhaag-badge-counter {
   --denhaag-dot-indicator-size: 8px;
 }
 
 .denhaag-badge-counter__counter {
-  border-radius: var(--utrecht-badge-counter-border-radius);
-  background-color: var(--utrecht-badge-counter-background-color);
-  padding-block-start: var(--utrecht-badge-counter-padding-block);
-  padding-block-end: var(--utrecht-badge-counter-padding-block);
-  padding-inline-start: var(--utrecht-badge-counter-padding-inline);
-  padding-inline-end: var(--utrecht-badge-counter-padding-inline);
-  color: var(--utrecht-badge-counter-color);
+  @extend .utrecht-badge-counter;
+
   font-family: var(--utrecht-badge-counter-font-family);
   font-size: var(--utrecht-badge-counter-font-size);
-  font-weight: var(--utrecht-badge-counter-font-weight);
 }

--- a/components/BadgeCounter/src/index.tsx
+++ b/components/BadgeCounter/src/index.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { DotIndicator } from '@gemeente-denhaag/dotindicator';
-import BaseProps from '@gemeente-denhaag/baseprops';
 import './index.scss';
 import clsx from 'clsx';
 
-export type BadgeCounterProps = Omit<BaseProps, 'tabIndex' | 'classes'>;
+export type BadgeCounterProps = HTMLAttributes<HTMLDivElement>;
 
 /**
  * A counter badge notifies a user of a specific amount of updates.

--- a/components/BadgeCounter/src/stories/bem.stories.mdx
+++ b/components/BadgeCounter/src/stories/bem.stories.mdx
@@ -5,7 +5,7 @@ import pkg from "../../package.json";
 import readme from "../../README.md";
 
 <Meta
-  title="React/Data Display/Badge Counter"
+  title="CSS/Data Display/Badge Counter"
   component={BadgeCounter}
   parameters={{
     componentSubtitle: `${pkg.name} - ${pkg.version}`,
@@ -23,7 +23,18 @@ import readme from "../../README.md";
 ### Default
 
 <Canvas>
-  <Story name="Default">{(args) => <BadgeCounter {...args}>13</BadgeCounter>}</Story>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Default">
+    {() => (
+      <div class="denhaag-badge-counter">
+        <div class="denhaag-dot-indicator denhaag-dot-indicator--overlap-rectangle">
+          <div class="denhaag-badge-counter__counter">220</div>
+          <div class="denhaag-dot-indicator__dot"></div>
+        </div>
+      </div>
+    )}
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
 </Canvas>
 
 <ArgsTable of={BadgeCounter} />

--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -97,7 +97,6 @@
 
 .denhaag-button--large {
   font-size: var(--denhaag-typography-scale-lg-font-size);
-  line-height: var(--denhaag-typography-scale-base-line-height);
   padding-block-end: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
   padding-block-start: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
   padding-inline-end: var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline));

--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -17,7 +17,9 @@
 }
 
 .denhaag-button--focus::after,
-.denhaag-button:focus::after {
+.denhaag-button:focus::after,
+.denhaag-button--focus-visible::after,
+.denhaag-button:focus-visible::after {
   border: var(--denhaag-focus-border);
   border-radius: var(--denhaag-border-radius);
   bottom: -2px;
@@ -27,6 +29,11 @@
   position: absolute;
   right: -2px;
   top: -2px;
+}
+
+.denhaag-button--focus-visible,
+.denhaag-button:focus-visible {
+  outline: none;
 }
 
 /* Due to the accessibility focus outline overlapping with the border, the outline needs to be repositioned for the border variant */
@@ -90,6 +97,7 @@
 
 .denhaag-button--large {
   font-size: var(--denhaag-typography-scale-lg-font-size);
+  line-height: var(--denhaag-typography-scale-base-line-height);
   padding-block-end: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
   padding-block-start: var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block));
   padding-inline-end: var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline));
@@ -133,12 +141,4 @@
   display: inherit;
   margin-inline-end: -4px;
   margin-inline-start: 8px;
-}
-
-.denhaag-button--large.denhaag-button--start-icon .denhaag-button__icon {
-  margin-inline-end: 12px;
-}
-
-.denhaag-button--large.denhaag-button--end-icon .denhaag-button__icon {
-  margin-inline-start: 12px;
 }

--- a/components/IconButton/src/index.scss
+++ b/components/IconButton/src/index.scss
@@ -5,8 +5,8 @@
   padding-block-start: var(--denhaag-icon-button-padding-block-start);
   padding-block-end: var(--denhaag-icon-button-padding-block-end);
   border: 0;
+  border-radius: 0;
   outline: 0;
-  border-radius: 50%;
   cursor: pointer;
   background-color: transparent;
   appearance: none;

--- a/components/PublicationDate/src/index.scss
+++ b/components/PublicationDate/src/index.scss
@@ -1,6 +1,6 @@
 .denhaag-publication-date {
-  color: var(--denhaag-publication-date-color, #4b4b4b);
-  font-family: var(--denhaag-publication-date-font-family, inherit);
+  color: var(--denhaag-publication-date-color);
+  font-family: var(--denhaag-publication-date-font-family);
   font-weight: var(--denhaag-publication-date-font-weight);
   font-size: var(--denhaag-publication-date-font-size);
 }
@@ -17,7 +17,9 @@
   }
 
   .denhaag-publication-date__published {
-    border-inline-end: var(--denhaag-publication-date-border);
+    border-inline-end-color: var(--denhaag-publication-date-border-color);
+    border-inline-end-style: var(--denhaag-publication-date-border-style);
+    border-inline-end-width: var(--denhaag-publication-date-border-width);
     margin-inline-end: var(--denhaag-publication-date-margin);
     padding-inline-end: var(--denhaag-publication-date-padding);
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@material-ui/core": "4.12.3",
     "@material-ui/lab": "4.11.3-deprecations.1",
     "@utrecht/component-library-css": "1.0.0-alpha.171",
+    "@utrecht/components": "1.0.0-alpha.140",
     "clsx": "1.1.1",
     "sass": "1.49.7"
   },

--- a/proprietary/Common/src/denhaag/focus.tokens.json
+++ b/proprietary/Common/src/denhaag/focus.tokens.json
@@ -2,7 +2,7 @@
   "denhaag": {
     "focus": {
       "background-color": {},
-      "border-color": { "value": "{denhaag.color.ocher.4}" },
+      "border-color": { "value": "{denhaag.color.ocher.5}" },
       "border-width": { "value": "2px" },
       "border-style": { "value": "dashed" },
       "border": {

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -3,10 +3,13 @@
     "accordion": {
       "border": { "value": "1px solid {denhaag.color.grey.2}" },
       "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
-      "font-weight": { "value": "400" },
-      "line-height": { "value": "24px" },
+      "font-weight": { "value": "{denhaag.typography.weight.regular}" },
+      "line-height": { "value": "{denhaag.typography.scale.base.line-height}" },
       "padding": { "value": "16px" },
       "margin": { "value": "12px" },
+      "active": {
+        "color": { "value": "{denhaag.color.blue.3}" }
+      },
       "expanded": {
         "font-weight": { "value": "500" },
         "transform": { "value": "rotate(180deg)" }
@@ -16,6 +19,14 @@
       },
       "focus": {
         "border": { "value": "2px dashed {denhaag.color.ocher.5}" }
+      },
+      "title": {
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" }
+      },
+      "paragraph": {
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
+        "margin-block-start": { "value": "4px" },
+        "margin-block-end": { "value": "16px" }
       }
     }
   }

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -4,7 +4,7 @@
       "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
       "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
-      "padding-block": { "value": "6px" },
+      "padding-block": { "value": "8px" },
       "padding-inline": { "value": "16px" },
       "focus": {
         "border-color": { "value": "{denhaag.focus.border-color}" },
@@ -42,7 +42,7 @@
         }
       },
       "large-size": {
-        "padding-block": { "value": "6px" },
+        "padding-block": { "value": "11px" },
         "padding-inline": { "value": "20px" }
       },
       "medium-size": {

--- a/proprietary/Components/src/denhaag/card.tokens.json
+++ b/proprietary/Components/src/denhaag/card.tokens.json
@@ -55,7 +55,7 @@
         "font-color": { "value": "{denhaag.color.grey.4}" },
         "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
         "font-weight": { "value": "500" },
-        "line-height": { "value": "24px" },
+        "line-height": { "value": "1.5" },
         "padding": { "value": "0" },
         "padding-block": { "value": "{denhaag.card.subtitle.padding}" },
         "padding-inline": { "value": "{denhaag.card.subtitle.padding}" }
@@ -64,7 +64,7 @@
         "font-color": { "value": "{denhaag.color.black}" },
         "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
         "font-weight": { "value": "bold" },
-        "line-height": { "value": "28px" },
+        "line-height": { "value": "1.3" },
         "padding": { "value": "0" },
         "padding-block": { "value": "{denhaag.card.title.padding}" },
         "padding-inline": { "value": "{denhaag.card.title.padding}" }

--- a/proprietary/Components/src/denhaag/card.tokens.json
+++ b/proprietary/Components/src/denhaag/card.tokens.json
@@ -54,7 +54,7 @@
       "subtitle": {
         "font-color": { "value": "{denhaag.color.grey.4}" },
         "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
-        "font-weight": { "value": "500" },
+        "font-weight": { "value": "{denhaag.typography.weight.regular}" },
         "line-height": { "value": "1.5" },
         "padding": { "value": "0" },
         "padding-block": { "value": "{denhaag.card.subtitle.padding}" },
@@ -63,7 +63,7 @@
       "title": {
         "font-color": { "value": "{denhaag.color.black}" },
         "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
-        "font-weight": { "value": "bold" },
+        "font-weight": { "value": "{denhaag.typography.weight.bold}" },
         "line-height": { "value": "1.3" },
         "padding": { "value": "0" },
         "padding-block": { "value": "{denhaag.card.title.padding}" },

--- a/proprietary/Components/src/denhaag/cta-download.tokens.json
+++ b/proprietary/Components/src/denhaag/cta-download.tokens.json
@@ -15,7 +15,7 @@
           "value": "{denhaag.typography.scale.lg.font-size}"
         },
         "weight": {
-          "value": 400
+          "value": "{denhaag.typography.weight.regular}"
         }
       },
       "line-height": {
@@ -26,7 +26,7 @@
       },
       "padding": {
         "block": {
-          "value": "{denhaag.space.block.lg}"
+          "value": "{denhaag.space.block.xl}"
         },
         "inline": {
           "value": "{denhaag.space.inline.md}"
@@ -71,7 +71,7 @@
             "value": "{denhaag.typography.scale.lg.font-size}"
           },
           "weight": {
-            "value": 700
+            "value": "{denhaag.typography.weight.bold}"
           }
         }
       }

--- a/proprietary/Components/src/denhaag/cta-event.tokens.json
+++ b/proprietary/Components/src/denhaag/cta-event.tokens.json
@@ -2,69 +2,69 @@
   "denhaag": {
     "cta-event": {
       "border-color": {
-        "value": "{denhaag.color.grey.2.value}"
+        "value": "{denhaag.color.grey.2}"
       },
       "color": {
-        "value": "{denhaag.color.grey.4.value}"
+        "value": "{denhaag.color.grey.4}"
       },
       "font": {
         "family": {
-          "value": "{denhaag.typography.sans-serif.font-family.value}"
+          "value": "{denhaag.typography.sans-serif.font-family}"
         },
         "size": {
-          "value": "{denhaag.typography.scale.lg.font-size.value}"
+          "value": "{denhaag.typography.scale.lg.font-size}"
         },
         "weight": {
-          "value": 400
+          "value": "{denhaag.typography.weight.regular}"
         }
       },
       "line-height": {
         "value": 1.3
       },
       "gap": {
-        "value": "{denhaag.space.block.lg.value}"
+        "value": "{denhaag.space.block.lg}"
       },
       "padding": {
         "block": {
-          "value": "{denhaag.space.block.lg.value}"
+          "value": "{denhaag.space.block.xl}"
         },
         "inline": {
-          "value": "{denhaag.space.inline.md.value}"
+          "value": "{denhaag.space.inline.md}"
         }
       },
       "width": {
-        "value": "{denhaag.space.block.5xl.value}"
+        "value": "{denhaag.space.block.5xl}"
       },
       "focus": {
         "highlight": {
           "color": {
-            "value": "{denhaag.color.blue.4.value}"
+            "value": "{denhaag.color.blue.4}"
           }
         },
         "outline": {
-          "value": "{denhaag.focus.border.value}"
+          "value": "{denhaag.focus.border}"
         }
       },
       "hover": {
         "highlight": {
           "color": {
-            "value": "{denhaag.color.blue.4.value}"
+            "value": "{denhaag.color.blue.4}"
           }
         }
       },
       "date": {
         "color": {
-          "value": "{denhaag.color.white.value}"
+          "value": "{denhaag.color.white}"
         },
         "font": {
           "family": {
-            "value": "{denhaag.typography.sans-serif.font-family.value}"
+            "value": "{denhaag.typography.sans-serif.font-family}"
           },
           "size": {
-            "value": "{denhaag.typography.scale.s.font-size.value}"
+            "value": "{denhaag.typography.scale.s.font-size}"
           },
           "weight": {
-            "value": 400
+            "value": "{denhaag.typography.weight.regular}"
           }
         },
         "line-height": {
@@ -73,24 +73,24 @@
       },
       "day": {
         "font-size": {
-          "value": "1.125rem"
+          "value": "{denhaag.typography.scale.base.font-size}"
         }
       },
       "excerpt": {
         "gap": {
-          "value": "{denhaag.space.block.2xs.value}"
+          "value": "{denhaag.space.block.2xs}"
         }
       },
       "title": {
         "color": {
-          "value": "{denhaag.color.blue.3.value}"
+          "value": "{denhaag.color.blue.3}"
         },
         "font": {
           "size": {
-            "value": "{denhaag.typography.scale.lg.font-size.value}"
+            "value": "{denhaag.typography.scale.lg.font-size}"
           },
           "weight": {
-            "value": 700
+            "value": "{denhaag.typography.weight.bold}"
           }
         }
       }

--- a/proprietary/Components/src/denhaag/cta-link.tokens.json
+++ b/proprietary/Components/src/denhaag/cta-link.tokens.json
@@ -15,7 +15,7 @@
           "value": "{denhaag.typography.sans-serif.font-family}"
         },
         "weight": {
-          "value": 400
+          "value": "{denhaag.typography.weight.regular}"
         }
       },
       "gap": {
@@ -23,7 +23,7 @@
       },
       "padding": {
         "block": {
-          "value": "{denhaag.space.block.lg}"
+          "value": "{denhaag.space.block.xl}"
         },
         "inline": {
           "value": "{denhaag.space.inline.md}"
@@ -34,7 +34,7 @@
           "value": "{denhaag.color.blue.3}"
         },
         "font-weight": {
-          "value": 700
+          "value": "{denhaag.typography.weight.bold}"
         }
       },
       "width": {

--- a/proprietary/Components/src/denhaag/datepicker.tokens.json
+++ b/proprietary/Components/src/denhaag/datepicker.tokens.json
@@ -11,9 +11,9 @@
         "background-color": { "value": "{denhaag.color.white}" },
         "color": { "value": "{denhaag.color.grey.4}" },
         "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
-        "height": { "value": "40px" },
+        "height": { "value": "52px" },
         "line-height": { "value": "24px" },
-        "padding-inline": { "value": "16px" },
+        "padding-inline": { "value": "12px" },
         "placeholder": {
           "color": { "value": "{denhaag.color.grey.3}" }
         },

--- a/proprietary/Components/src/denhaag/publication-date.tokens.json
+++ b/proprietary/Components/src/denhaag/publication-date.tokens.json
@@ -1,12 +1,14 @@
 {
   "denhaag": {
     "publication-date": {
-      "border": { "value": "1px solid #D2D2D2" },
+      "border-width": { "value": "1px" },
+      "border-style": { "value": "solid" },
+      "border-color": { "value": "{denhaag.color.grey.2}" },
       "color": { "value": "{denhaag.color.grey.4}" },
       "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
       "font-weight": { "value": "400" },
-      "font-size": { "value": "1.125rem" },
-      "line-height": { "value": "1.5" },
+      "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
+      "line-height": { "value": "{denhaag.typography.scale.base.line-height}" },
       "margin": { "value": "0.75rem" },
       "padding": { "value": "0.75rem" }
     }

--- a/proprietary/Proprietary/src/typography.tokens.json
+++ b/proprietary/Proprietary/src/typography.tokens.json
@@ -29,7 +29,7 @@
         },
         "base": {
           "font-size": {
-            "value": "1rem"
+            "value": "1.125rem"
           },
           "line-height": { "value": 1.5 }
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,6 +5195,13 @@
   resolved "https://registry.yarnpkg.com/@utrecht/component-library-css/-/component-library-css-1.0.0-alpha.171.tgz#cc3e371322565bed5367a32f8468fd4e30341deb"
   integrity sha512-QExsa6mTrvtn6fQMcOPczq8+x4siJ1ZrmTBwMBttWGDChgnsrZsBychcdqTtIsSxfOJHtTELHeE5NHNsG/yDDw==
 
+"@utrecht/components@1.0.0-alpha.140":
+  version "1.0.0-alpha.140"
+  resolved "https://registry.yarnpkg.com/@utrecht/components/-/components-1.0.0-alpha.140.tgz#537b0d1da3f978a4cd8f79fa3af6aa67818618db"
+  integrity sha512-4c9F4acWUdYS1tQrvHBseKefcPR5GqGcSiY3pTPzH1WJ+CW7wx+m1zwq7JLdQ0R5yLCgWF/cFJjq+7AAOeDZ9w==
+  dependencies:
+    clsx "1.1.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"


### PR DESCRIPTION
Changes

- [x] Change base-font-size from 1rem to 1.125rem (16px -> 18px) (#704)
- [x] Update focus color to `ocher-5`
- [x] Update icon-button focus to be rectangular (#626)
- [x] Use `utrecht-badge-counter` for `denhaag-badge-counter__counter` css
- [x] Update all new component padding values
- [x] Check focus-within user agent style on all components
- [ ] Update visual regression tests