### PR TITLE
fix: from --denhaag-paragraph-color to --utrecht-paragraph-color

### DIFF
--- a/components/Typography/src/paragraph.scss
+++ b/components/Typography/src/paragraph.scss
@@ -4,7 +4,7 @@
  */
 
 .utrecht-paragraph {
-  color: var(--denhaag-paragraph-color, var(--utrecht-document-color, inherit));
+  color: var(--utrecht-paragraph-color, var(--utrecht-document-color, inherit));
   font-family: var(--utrecht-paragraph-font-family, var(--utrecht-document-font-family, inherit));
   font-size: var(--utrecht-paragraph-font-size, var(--utrecht-document-font-size, inherit));
   font-weight: var(--utrecht-paragraph-font-weight, inherit);


### PR DESCRIPTION
 `closes #761 `
 
  `--denhaag-paragraph-color` is undefined.   `--utrecht-paragraph-color` has the correct grey/4 color.
