### PR TITLE
FormProgress Component

### DIFF
--- a/components/FormProgress/package.json
+++ b/components/FormProgress/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@gemeente-denhaag/form-progress",
+  "version": "0.1.0",
+  "description": "A FormProgress component",
+  "bugs": "https://github.com/nl-design-system/denhaag/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nl-design-system/denhaag.git",
+    "directory": "components/FormProgress"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c ../../rollup.config.js",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@gemeente-denhaag/icons": "0.2.3-alpha.121",
+    "@gemeente-denhaag/link": "0.2.3-alpha.121"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0"
+  },
+  "gitHead": "dcf72a9b79266c1ebede35aff4a02dd9121a980f"
+}

--- a/components/FormProgress/specs/FormProgress.spec.jsx
+++ b/components/FormProgress/specs/FormProgress.spec.jsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import FormProgress from '../dist';
+
+describe('FormProgress tests', () => {
+  // Starting with functionality tests
+  it('does not show back button in first step', () => {
+    cy.mount(<FormProgress value={1} max={4} label="Stap 1 van 4" />);
+
+    cy.get('.denhaag-form-progress').should('not.contain', 'Vorige stap');
+  });
+
+  it('does not show back button in first step', () => {
+    cy.mount(<FormProgress value={2} max={4} label="Stap 2 van 4" />);
+
+    cy.get('.denhaag-form-progress').should('contain', 'Vorige stap');
+  });
+
+  it('a11y and snapshots', () => {
+    cy.snapshots(
+      <div style={{ width: '400px' }}>
+        <FormProgress value={2} max={4} label="Stap 2 van 4" />
+      </div>,
+      {},
+    );
+  });
+});

--- a/components/FormProgress/specs/FormProgress.spec.jsx
+++ b/components/FormProgress/specs/FormProgress.spec.jsx
@@ -16,11 +16,8 @@ describe('FormProgress tests', () => {
   });
 
   it('a11y and snapshots', () => {
-    cy.snapshots(
-      <div style={{ width: '400px' }}>
-        <FormProgress value={2} max={4} label="Stap 2 van 4" />
-      </div>,
-      {},
-    );
+    cy.snapshots(<FormProgress value={2} max={4} label="Stap 2 van 4" />, {}, [], [], null, () => {
+      cy.get('#wrapper').invoke('css', 'width', '400px');
+    });
   });
 });

--- a/components/FormProgress/specs/__snapshots__/FormProgress.spec.jsx.snap
+++ b/components/FormProgress/specs/__snapshots__/FormProgress.spec.jsx.snap
@@ -1,0 +1,45 @@
+exports[`FormProgress tests > a11y and snapshots #0`] = `
+<div id="wrapper" style="display: inline-block; width: 400px;">
+  <div style="padding: 10px;">
+    <div class="denhaag-form-progress">
+      <div class="denhaag-form-progress__header">
+        <div class="denhaag-form-progress__previous">
+          <a
+            href="javascript:history.back()"
+            tabindex="0"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+            ><span class="denhaag-link__icon"
+              ><svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="MuiSvgIcon-root denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M11.707 18.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 111.414 1.414L7.414 11H19a1 1 0 110 2H7.414l4.293 4.293a1 1 0 010 1.414z"
+                  fill="currentColor"
+                ></path></svg></span
+            ><span>Vorige stap</span></a
+          >
+        </div>
+        <label
+          class="denhaag-form-progress__label"
+          for="denhaag-form-progress-bar"
+          >Stap 2 van 4</label
+        >
+      </div>
+      <progress
+        id="denhaag-form-progress-bar"
+        class="denhaag-form-progress__progress"
+        max="4"
+        value="2"
+      ></progress>
+    </div>
+  </div>
+</div>
+`;

--- a/components/FormProgress/src/index.scss
+++ b/components/FormProgress/src/index.scss
@@ -1,0 +1,42 @@
+.denhaag-form-progress {
+  display: flex;
+  flex-direction: column;
+}
+
+.denhaag-form-progress__header {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-block-end: var(--denhaag-form-progress-header-margin-block-end);
+}
+
+.denhaag-form-progress__previous {
+  position: absolute;
+  inset-inline-start: 0;
+}
+
+.denhaag-form-progress__label {
+  font-family: var(--denhaag-form-progress-label-font-family);
+  font-size: var(--denhaag-form-progress-label-font-size);
+  font-weight: var(--denhaag-form-progress-label-font-weight);
+  color: var(--denhaag-form-progress-label-color);
+  line-height: var(--denhaag-form-progress-label-line-height);
+}
+
+.denhaag-form-progress__progress {
+  width: 100%;
+  height: var(--denhaag-form-progress-progress-height);
+  appearance: none;
+  border: none;
+  background-color: var(--denhaag-form-progress-progress-background-color);
+
+  &::-webkit-progress-bar {
+    background-color: var(--denhaag-form-progress-progress-background-color);
+  }
+
+  &::-webkit-progress-value,
+  &::-moz-progress-bar {
+    background-color: var(--denhaag-form-progress-progress-bar-background-color);
+  }
+}

--- a/components/FormProgress/src/index.tsx
+++ b/components/FormProgress/src/index.tsx
@@ -6,10 +6,9 @@ import './index.scss';
 export interface FormProgressProps extends HTMLAttributes<HTMLDivElement> {
   value: number;
   max: number;
+  label: string;
   previousHref?: string;
   previousLabel?: string;
-  stepLabel?: string;
-  ofLabel?: string;
 }
 
 /**
@@ -18,10 +17,10 @@ export interface FormProgressProps extends HTMLAttributes<HTMLDivElement> {
 export const FormProgress: React.FC<FormProgressProps> = ({
   value,
   max,
+  label,
   previousHref = 'javascript:history.back()',
   previousLabel = 'Vorige stap',
-  stepLabel = 'Stap',
-  ofLabel = 'van',
+  id = 'denhaag-form-progress-bar',
   ...props
 }: FormProgressProps) => {
   return (
@@ -34,16 +33,11 @@ export const FormProgress: React.FC<FormProgressProps> = ({
             </Link>
           </div>
         )}
-        <label className="denhaag-form-progress__label" htmlFor="denhaag-form-progress-bar">
-          {stepLabel} {value} {ofLabel} {max}
+        <label className="denhaag-form-progress__label" htmlFor={id}>
+          {label}
         </label>
       </div>
-      <progress
-        id="denhaag-form-progress-bar"
-        className="denhaag-form-progress__progress"
-        max={max}
-        value={value}
-      ></progress>
+      <progress id={id} className="denhaag-form-progress__progress" max={max} value={value}></progress>
     </div>
   );
 };

--- a/components/FormProgress/src/index.tsx
+++ b/components/FormProgress/src/index.tsx
@@ -1,0 +1,54 @@
+import React, { HTMLAttributes } from 'react';
+import Link from '@gemeente-denhaag/link';
+import { ArrowLeftIcon } from '@gemeente-denhaag/icons';
+import './index.scss';
+
+export interface FormProgressProps extends HTMLAttributes<HTMLDivElement> {
+  value: number;
+  max: number;
+  previousHref?: string;
+  previousLabel?: string;
+  stepLabel?: string;
+  ofLabel?: string;
+}
+
+/**
+ * Primary UI component for user interaction
+ */
+export const FormProgress: React.FC<FormProgressProps> = ({
+  value,
+  max,
+  previousHref = 'javascript:history.back()',
+  previousLabel = 'Vorige stap',
+  stepLabel = 'Stap',
+  ofLabel = 'van',
+  ...props
+}: FormProgressProps) => {
+  return (
+    <div className="denhaag-form-progress" {...props}>
+      <div className="denhaag-form-progress__header">
+        {value > 1 && (
+          <div className="denhaag-form-progress__previous">
+            <Link href={previousHref} icon={<ArrowLeftIcon />} iconAlign="start">
+              {previousLabel}
+            </Link>
+          </div>
+        )}
+        <label className="denhaag-form-progress__label" htmlFor="denhaag-form-progress-bar">
+          {stepLabel} {value} {ofLabel} {max}
+        </label>
+      </div>
+      <progress
+        id="denhaag-form-progress-bar"
+        className="denhaag-form-progress__progress"
+        max={max}
+        value={value}
+      ></progress>
+    </div>
+  );
+};
+
+/**
+ * Default export for FormProgress
+ */
+export default FormProgress;

--- a/components/FormProgress/src/stories/bem.stories.mdx
+++ b/components/FormProgress/src/stories/bem.stories.mdx
@@ -1,0 +1,88 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+
+import pkg from "../../package.json";
+
+<Meta
+  title="CSS/Input/Form Progress"
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: "ALPHA",
+    },
+  }}
+/>
+
+## Design Tokens
+
+<DesignTokenDocBlock categoryName="FormProgress" viewType="table" />
+
+## Stories
+
+### Default
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Default">
+    {() => (
+      <div class="denhaag-form-progress">
+        <div class="denhaag-form-progress__header">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label for="denhaag-form-progress-bar">
+            <p class="utrecht-paragraph utrecht-paragraph--distanced">Stap 1 van 4</p>
+          </label>
+        </div>
+        <progress id="denhaag-form-progress-bar" class="denhaag-form-progress__progress" max="4" value="1"></progress>
+      </div>
+    )}
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Second Step
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Second Step">
+    {() => (
+      <div class="denhaag-form-progress">
+        <div class="denhaag-form-progress__header">
+          <div class="denhaag-form-progress__previous">
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a
+              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+              href="javascript:history.back()"
+            >
+              <span class="denhaag-link__icon">
+                <svg
+                  class="denhaag-icon"
+                  width="1em"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  focusable="false"
+                  aria-hidden="true"
+                  shape-rendering="auto"
+                >
+                  <path
+                    d="M11.707 18.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 111.414 1.414L7.414 11H19a1 1 0 110 2H7.414l4.293 4.293a1 1 0 010 1.414z"
+                    fill="currentColor"
+                  ></path>
+                </svg>
+              </span>
+              <span>Vorige stap</span>
+            </a>
+          </div>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label for="denhaag-form-progress-bar">
+            <p class="utrecht-paragraph utrecht-paragraph--distanced">Stap 2 van 4</p>
+          </label>
+        </div>
+        <progress id="denhaag-form-progress-bar" class="denhaag-form-progress__progress" max="4" value="2"></progress>
+      </div>
+    )}
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>

--- a/components/FormProgress/src/stories/react.stories.mdx
+++ b/components/FormProgress/src/stories/react.stories.mdx
@@ -1,0 +1,41 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
+
+import { FormProgress } from "../index";
+import pkg from "../../package.json";
+
+<Meta
+  title="React/Input/Form Progress"
+  component={FormProgress}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: "ALPHA",
+    },
+  }}
+/>
+
+## Design Tokens
+
+<DesignTokenDocBlock categoryName="FormProgress" viewType="table" />
+
+## Stories
+
+### Default
+
+<Canvas>
+  <Story name="Default" args={{ value: 1, max: 4 }}>
+    {(args) => <FormProgress {...args} />}
+  </Story>
+</Canvas>
+
+<ArgsTable of={FormProgress} />
+
+### Second Step
+
+<Canvas>
+  <Story name="Second Step" args={{ value: 2, max: 4 }}>
+    {(args) => <FormProgress {...args} />}
+  </Story>
+</Canvas>

--- a/components/FormProgress/src/stories/react.stories.mdx
+++ b/components/FormProgress/src/stories/react.stories.mdx
@@ -25,7 +25,7 @@ import pkg from "../../package.json";
 ### Default
 
 <Canvas>
-  <Story name="Default" args={{ value: 1, max: 4 }}>
+  <Story name="Default" args={{ value: 1, max: 4, label: "Stap 1 van 4" }}>
     {(args) => <FormProgress {...args} />}
   </Story>
 </Canvas>
@@ -35,7 +35,7 @@ import pkg from "../../package.json";
 ### Second Step
 
 <Canvas>
-  <Story name="Second Step" args={{ value: 2, max: 4 }}>
+  <Story name="Second Step" args={{ value: 2, max: 4, label: "Stap 2 van 4" }}>
     {(args) => <FormProgress {...args} />}
   </Story>
 </Canvas>

--- a/components/FormProgress/tsconfig.json
+++ b/components/FormProgress/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "src/**/*.stories.tsx"],
+  "references": []
+}

--- a/packages/components-react/src/index.tsx
+++ b/packages/components-react/src/index.tsx
@@ -11,6 +11,7 @@ export * from '@gemeente-denhaag/formcontrol';
 export * from '@gemeente-denhaag/formcontrollabel';
 export * from '@gemeente-denhaag/form-field';
 export * from '@gemeente-denhaag/formgroup';
+export * from '@gemeente-denhaag/form-progress';
 export * from '@gemeente-denhaag/inputlabel';
 export * from '@gemeente-denhaag/iconbutton';
 export * from '@gemeente-denhaag/link';

--- a/proprietary/Components/src/denhaag/form-progress.tokens.json
+++ b/proprietary/Components/src/denhaag/form-progress.tokens.json
@@ -1,0 +1,30 @@
+{
+  "denhaag": {
+    "form-progress": {
+      "header": {
+        "margin-block-end": {
+          "value": "20px"
+        }
+      },
+      "label": {
+        "color": { "value": "{denhaag.color.grey.4}" },
+        "font-weight": { "value": "{denhaag.typography.weight.regular}" },
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
+        "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" }
+      },
+      "progress": {
+        "height": {
+          "value": "2px"
+        },
+        "background-color": {
+          "value": "{denhaag.color.grey.2}"
+        },
+        "bar": {
+          "background-color": {
+            "value": "{denhaag.color.green.3}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
       "path": "components/FormField"
     },
     {
+      "path": "components/FormProgress"
+    },
+    {
       "path": "components/IconButton"
     },
     {


### PR DESCRIPTION
@bddjong a few questions about this solution, could you look at these once you have the time?

- Not sure about this label setup, feels quite annoying to have there `stepLabel` and `ofLabel` props. Any ideas on how to fix this nicely? I considered using perhaps some sort of format string a la python (e.g. `label="Stap {0} van {1}") in a label prop, or alternatively just provide one `label` prop with no formatting whatsoever and let the end-user deal with it, but curious whether you have any thoughts on this.
- the `htmlFor` and `id` on the `label` and `progress` are currently static, resulting in invalid HTML/duplicate id's when the component is used multiple times. 

**Closing issues**
- Closes #728 
