### PR TITLE
style(cta-image-content): add styling correction

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -4,6 +4,7 @@
   background-color: var(--denhaag-cta-image-content-background-color);
   border: var(--denhaag-cta-image-content-border-width, 1px) solid var(--denhaag-cta-image-content-border-color);
   border-radius: var(--denhaag-cta-image-content-border-radius);
+  overflow: hidden;
 }
 
 .denhaag-cta-image-content--filled {


### PR DESCRIPTION
Solve:
https://github.com/nl-design-system/denhaag/issues/810

Purpose:
- preventing the image from sticking out of the border radius

closes #811