### PR TITLE
style(ordered-list): add fallback styling nested list

### DIFF
--- a/components/OrderedList/src/index.scss
+++ b/components/OrderedList/src/index.scss
@@ -3,3 +3,7 @@
 .denhaag-ordered-list {
   @extend .denhaag-unordered-list;
 }
+
+.denhaag-ordered-list .denhaag-unordered-list {
+  @extend .denhaag-unordered-list--lower-alpha;
+}


### PR DESCRIPTION
Solve: https://github.com/nl-design-system/denhaag/issues/814

Purpose:
- add fallback styling for child list of ordered list

closes #815