### PR TITLE
fix(cta-image-content): fix overlay issue, where focus is not visible…

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -4,7 +4,6 @@
   background-color: var(--denhaag-cta-image-content-background-color);
   border: var(--denhaag-cta-image-content-border-width, 1px) solid var(--denhaag-cta-image-content-border-color);
   border-radius: var(--denhaag-cta-image-content-border-radius);
-  overflow: hidden;
 }
 
 .denhaag-cta-image-content--filled {


### PR DESCRIPTION
Removed overflow-hidden, due to the overflow:hidden on the parent element the focus isn't visible.