### PR TITLE
fix(authentication-block-token): set correct token name

### DIFF
--- a/proprietary/Components/src/denhaag/authentication-block.tokens.json
+++ b/proprietary/Components/src/denhaag/authentication-block.tokens.json
@@ -14,7 +14,7 @@
         "value": "{denhaag.space.block.2xl}"
       },
       "item": {
-        "image-size": {
+        "image-width": {
           "value": "2.375rem"
         },
         "gap": {


### PR DESCRIPTION
Renamed token, since value was ignored.