### PR TITLE
style(authentication-block-item-image): tweak, svgs without clasname …

### DIFF
--- a/components/AuthenticationBlock/src/index.scss
+++ b/components/AuthenticationBlock/src/index.scss
@@ -182,6 +182,7 @@
     }
   }
 
+  &-item svg,
   &-item__image {
     height: auto;
     max-width: var(--denhaag-authentication-item-image-width);


### PR DESCRIPTION
Since the authenticatio-block-item image can now also be an SVG we needed to extend the css. Since we can't add classes to SVG's in uploads.