### PR TITLE
fix(anchor-navigation): fix margins, give button margin if is behind …

### DIFF
--- a/components/AnchorNavigation/src/index.scss
+++ b/components/AnchorNavigation/src/index.scss
@@ -13,6 +13,12 @@
 .denhaag-anchor-navigation__list {
   list-style: var(--denhaag-anchor-navigation-list-list-style);
   padding-inline-start: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
+}
+
+.denhaag-anchor-navigation__list + .denhaag-button {
+  margin-block-start: var(--denhaag-anchor-navigation-button-margin-block-start, 1em);
 }
 
 .denhaag-anchor-navigation__link {

--- a/proprietary/Components/src/denhaag/anchor-navigation.tokens.json
+++ b/proprietary/Components/src/denhaag/anchor-navigation.tokens.json
@@ -1,6 +1,15 @@
 {
   "denhaag": {
     "anchor-navigation": {
+      "button": {
+        "margin": {
+          "block": {
+            "start": {
+              "value": "1.875rem"
+            }
+          }
+        }
+      },
       "list": {
         "list-style": {
           "value": "none"


### PR DESCRIPTION
Fixing the block-margin, it used the default browser margins which were 1em. Simply unwanted styles.