### PR TITLE
fix(anchor-navigation): remove spacing after link

### DIFF
--- a/components/AnchorNavigation/src/index.scss
+++ b/components/AnchorNavigation/src/index.scss
@@ -29,8 +29,8 @@
   line-height: var(--denhaag-anchor-navigation-link-line-height);
   padding-block-end: var(--denhaag-anchor-navigation-link-padding-block);
   padding-block-start: var(--denhaag-anchor-navigation-link-padding-block);
-  padding-inline-end: var(--denhaag-anchor-navigation-link-padding-inline);
-  padding-inline-start: var(--denhaag-anchor-navigation-link-padding-inline);
+  padding-inline-end: var(--denhaag-anchor-navigation-link-padding-inline-end);
+  padding-inline-start: var(--denhaag-anchor-navigation-link-padding-inline-start);
   outline: none;
   position: relative;
   text-decoration: var(--denhaag-anchor-navigation-link-text-decoration);

--- a/proprietary/Components/src/denhaag/anchor-navigation.tokens.json
+++ b/proprietary/Components/src/denhaag/anchor-navigation.tokens.json
@@ -39,10 +39,15 @@
         },
         "padding": {
           "block": {
-            "value": "0.5rem"
+            "value": "{denhaag.space.block.xs}"
           },
           "inline": {
-            "value": "1.125rem"
+            "end": {
+              "value": "0"
+            },
+            "start": {
+              "value": "1.125rem"
+            }
           }
         },
         "text-decoration": {


### PR DESCRIPTION
Removing spacing at link-items, otherwise u get gutter stacked on the inline padding. When the component is already rendered 2 columns, this decreases the readability a lot.

closes #857 