### PR TITLE
style(link-group-extended): additional style

### DIFF
--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -39,11 +39,19 @@
 }
 
 .denhaag-link-group .denhaag-link--with-icon-start {
+  display: var(--denhaag-link-group-denhaag-link-with-icon-start-display);
   padding-inline-start: var(--denhaag-link-group-denhaag-link-with-icon-start-padding-inline-start);
+  padding-block-start: var(--denhaag-link-group-denhaag-link-with-icon-start-padding-block-start);
+  padding-block-end: var(--denhaag-link-group-denhaag-link-with-icon-start-padding-block-end);
 }
 
 .denhaag-link-group .denhaag-link__icon {
   font-size: var(--denhaag-link-group-denhaag-link-icon-font-size);
+}
+
+.denhaag-link-group .denhaag-link__icon .denhaag-icon {
+  align-self: var(--denhaag-link-group-denhaag-link-icon-denhaag-icon-align-self);
+  padding-block-start: var(--denhaag-link-group-denhaag-link-icon-denhaag-icon-padding-block-start);
 }
 
 .denhaag-link-group--dark .denhaag-link-group__caption {

--- a/components/LinkGroup/src/stories/bem.stories.mdx
+++ b/components/LinkGroup/src/stories/bem.stories.mdx
@@ -208,7 +208,10 @@ import readme from "../../README.md";
                   ></path>
                 </svg>
               </span>
-              <span>Paspoort en identiteitskaart</span>
+              <span>
+                Paspoort en identiteitskaart. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non
+                dignissimos. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non dignissimos.
+              </span>
             </a>
           </li>
           <li class="denhaag-link-group__navigation-list-item">

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -28,10 +28,17 @@
         "text-decoration": { "value": "underline" }
       },
       "denhaag-link-with-icon-start": {
-        "padding-inline-start": { "value": "{denhaag.space.inline.xl}" }
+        "padding-inline-start": { "value": "{denhaag.space.inline.xl}" },
+        "display": { "value": "inline-flex" },
+        "padding-block-start": { "value": "0" },
+        "padding-block-end": { "value": "0" }
       },
       "denhaag-link-icon": {
         "font-size": { "value": "0.75rem" }
+      },
+      "denhaag-link-icon-denhaag-icon": {
+        "align-self": { "value": "start" },
+        "padding-block-start": { "value": "{denhaag.space.block.3xs}" }
       }
     }
   }


### PR DESCRIPTION
Solve: https://github.com/nl-design-system/denhaag/issues/837

Purpose:
- additional style for correct list text alignment (pfreviously text was wrapping around the arrow icon):
<img width="278" alt="Screenshot 2022-04-11 at 15 46 40" src="https://user-images.githubusercontent.com/95216123/162754021-cab7a278-d1c1-4f90-9884-a9d10e1b07ae.png">

closes