### PR TITLE
build: generate `dist/index.css` for components

### DIFF
--- a/components/ProcessSteps/package.json
+++ b/components/ProcessSteps/package.json
@@ -18,7 +18,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup -c ../../rollup.config.js",
+    "build": "npm-run-all build:**",
+    "build:css": "sass --no-source-map src/index.scss:dist/index.css",
+    "build:js": "rollup -c ../../rollup.config.js",
     "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {


### PR DESCRIPTION
In addition to the CSS that is bundled with the React component and automatically injected in the page, we can provide the CSS files for projects that don't use the React framework. This draft PR contains a proposal for how to add `dist/index.css` to the npm package. When we agree on an approach, I can update the PR to update the build script for all components.