### PR TITLE
fix(hero-overflow): remove overflow properties, since they're redundant

### DIFF
--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -14,7 +14,6 @@
   color: var(--denhaag-hero-color);
   display: flex;
   min-height: var(--denhaag-hero-min-height);
-  overflow-x: hidden;
   position: relative;
 }
 
@@ -62,8 +61,6 @@
   --denhaag-hero-theme-page-content-padding-inline: calc(
     (var(--denhaag-hero-container-max-width) / var(--denhaag-hero-columns, 12)) * 1
   );
-
-  overflow: var(--denhaag-hero-theme-page-overflow);
 }
 
 .denhaag-hero__container {

--- a/proprietary/Components/src/denhaag/hero.tokens.json
+++ b/proprietary/Components/src/denhaag/hero.tokens.json
@@ -211,7 +211,6 @@
       },
       "theme-page": {
         "min-height": { "value": 0 },
-        "overflow": { "value": "initial" },
         "image": {
           "path": {
             "value": "11.25rem"


### PR DESCRIPTION
Remove overflow-hidden. Not needed anymore since there aren't any SVG patterns added.
Currently it's only causing issues (with searchbox) 