### PR TITLE
feat: add sidenav component

### DIFF
--- a/components/HighlightedLinks/package.json
+++ b/components/HighlightedLinks/package.json
@@ -22,6 +22,6 @@
   },
   "bugs": "https://github.com/nl-design-system/denhaag/issues",
   "devDependencies": {
-    "@gemeente-denhaag/icons": "0.2.3-alpha.171"
+    "@gemeente-denhaag/icons": "0.2.3-alpha.181"
   }
 }

--- a/components/Subnavigation/README.md
+++ b/components/Subnavigation/README.md
@@ -1,10 +1,10 @@
-# Subnavigation
+# Sidenav
 
 The subnavigation is used as navigational element. This appears as an overlay on mobile and in the sidebar on a desktop.
 
 ## When to use
 
-Subnavigation refers to the navigation UI that helps users access lower-level categories in the site’s information architecture. Those categories, or pages, are separate from the main menu. The user can navigate to those pages by clicking on the name of the category.
+Sidenav refers to the navigation UI that helps users access lower-level categories in the site’s information architecture. Those categories, or pages, are separate from the main menu. The user can navigate to those pages by clicking on the name of the category.
 
 The goals are:
 

--- a/components/Subnavigation/package.json
+++ b/components/Subnavigation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@gemeente-denhaag/subnavigation",
+  "version": "0.1.0-alpha.0",
+  "description": "A subnavigation component",
+  "bugs": "https://github.com/nl-design-system/denhaag/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nl-design-system/denhaag.git",
+    "directory": "components/Subnavigation"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": "./dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c ../../rollup.config.js",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0"
+  }
+}

--- a/components/Subnavigation/src/Sidenav.tsx
+++ b/components/Subnavigation/src/Sidenav.tsx
@@ -1,0 +1,16 @@
+import React, { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export type SubnavigationProps = HTMLAttributes<HTMLDivElement>;
+
+export const Sidenav: React.FC<SubnavigationProps> = (props: SubnavigationProps) => {
+  const className = clsx('denhaag-sidenav', props.className);
+
+  return (
+    <nav {...props} className={className}>
+      {props.children}
+    </nav>
+  );
+};
+
+export default Sidenav;

--- a/components/Subnavigation/src/SidenavItem.tsx
+++ b/components/Subnavigation/src/SidenavItem.tsx
@@ -1,0 +1,16 @@
+import React, { LiHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export type SubnavigationItemProps = LiHTMLAttributes<HTMLLIElement>;
+
+export const SidenavItem: React.FC<SubnavigationItemProps> = (props: SubnavigationItemProps) => {
+  const className = clsx('denhaag-sidenav__item', props.className);
+
+  return (
+    <li {...props} className={className}>
+      {props.children}
+    </li>
+  );
+};
+
+export default SidenavItem;

--- a/components/Subnavigation/src/SidenavLink.tsx
+++ b/components/Subnavigation/src/SidenavLink.tsx
@@ -7,9 +7,8 @@ export interface SidenavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement
 
 export const SidenavLink: React.FC<SidenavLinkProps> = ({ current, ...props }: SidenavLinkProps) => {
   const className = clsx('denhaag-sidenav__link', current && 'denhaag-sidenav__link--current', props.className);
-
   return (
-    <a {...props} className={className}>
+    <a {...props} aria-current={current || props['aria-current'] ? 'page' : undefined} className={className}>
       {props.children}
     </a>
   );

--- a/components/Subnavigation/src/SidenavLink.tsx
+++ b/components/Subnavigation/src/SidenavLink.tsx
@@ -1,0 +1,18 @@
+import React, { AnchorHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export interface SidenavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  current?: boolean;
+}
+
+export const SidenavLink: React.FC<SidenavLinkProps> = ({ current, ...props }: SidenavLinkProps) => {
+  const className = clsx('denhaag-sidenav__link', current && 'denhaag-sidenav__link--current', props.className);
+
+  return (
+    <a {...props} className={className}>
+      {props.children}
+    </a>
+  );
+};
+
+export default SidenavLink;

--- a/components/Subnavigation/src/SidenavList.tsx
+++ b/components/Subnavigation/src/SidenavList.tsx
@@ -1,0 +1,16 @@
+import React, { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export type SidenavListProps = HTMLAttributes<HTMLUListElement>;
+
+export const SidenavList: React.FC<SidenavListProps> = (props: SidenavListProps) => {
+  const className = clsx('denhaag-sidenav__list', props.className);
+
+  return (
+    <ul {...props} className={className}>
+      {props.children}
+    </ul>
+  );
+};
+
+export default SidenavList;

--- a/components/Subnavigation/src/index.scss
+++ b/components/Subnavigation/src/index.scss
@@ -1,0 +1,59 @@
+.denhaag-sidenav {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--denhaag-sidenav-row-gap);
+}
+
+.denhaag-sidenav__list {
+  list-style: none;
+  margin-block-end: 0;
+  margin-block-start: 0;
+  padding-block-end: 0;
+  padding-block-start: 0;
+  padding-inline-start: 0;
+}
+
+.denhaag-sidenav__list--child {
+  margin-inline-start: var(--denhaag-sidenav-list-child-margin-inline-start);
+}
+
+.denhaag-sidenav__item {
+  font-family: var(--denhaag-sidenav-item-font-family, sans-serif);
+  font-size: var(--denhaag-sidenav-item-font-size);
+  font-weight: var(--denhaag-sidenav-item-font-weight, normal);
+  line-height: 1.5;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.denhaag-sidenav__link {
+  text-decoration: none;
+  color: var(--denhaag-sidenav-link-color);
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  align-items: center;
+  column-gap: 16px;
+  padding-block-start: var(--denhaag-sidenav-link-padding-block-start);
+  padding-block-end: var(--denhaag-sidenav-link-padding-block-end);
+}
+
+.denhaag-sidenav__link:hover,
+.denhaag-sidenav__link--hover {
+  color: var(--denhaag-sidenav-link-hover-color);
+  cursor: pointer;
+}
+
+.denhaag-sidenav__link:focus,
+.denhaag-sidenav__link--focus {
+  outline: var(--denhaag-focus-border);
+}
+
+.denhaag-sidenav__link--current {
+  color: var(--denhaag-sidenav-link-active-color);
+}
+
+.denhaag-sidenav__link--child {
+  padding-inline-start: var(--denhaag-sidenav-link-child-padding-inline-start);
+}

--- a/components/Subnavigation/src/index.tsx
+++ b/components/Subnavigation/src/index.tsx
@@ -1,0 +1,6 @@
+import './index.scss';
+
+export * from './Sidenav';
+export * from './SidenavItem';
+export * from './SidenavList';
+export * from './SidenavLink';

--- a/components/Subnavigation/src/stories/bem.stories.mdx
+++ b/components/Subnavigation/src/stories/bem.stories.mdx
@@ -1,0 +1,82 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import pkg from "../../package.json";
+import { ArchiveIcon, DocumentIcon, GridIcon, InboxIcon, SettingsIcon } from "@gemeente-denhaag/icons";
+
+<Meta
+  title="CSS/Navigation/Sidenav"
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: "ALPHA",
+    },
+  }}
+/>
+
+## Stories
+
+### Default
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Default">
+    {() => (
+      <nav>
+        <ul class={"denhaag-sidenav__list"}>
+          <li class={"denhaag-sidenav__item"}>
+            <a href={"/#"} class={"denhaag-sidenav__link"}>
+              <GridIcon />
+              Overzicht
+            </a>
+          </li>
+          <li class={"denhaag-sidenav__item"}>
+            <a href={"/#"} class={"denhaag-sidenav__link"}>
+              <InboxIcon />
+              Mijn berichten
+            </a>
+          </li>
+          <li class={"denhaag-sidenav__item--parent"}>
+            <a href={"/#"} class={"denhaag-sidenav__link denhaag-sidenav__link--parent"}>
+              <DocumentIcon />
+              Thema&apos;s
+            </a>
+            <ul class={"denhaag-sidenav__list denhaag-sidenav__list--child"}>
+              <li class={"denhaag-sidenav__item denhaag-sidenav__item--child"}>
+                <a href={"/#"} class={"denhaag-sidenav__link denhaag-sidenav__link--child"}>
+                  Geldzaken
+                </a>
+              </li>
+              <li class={"denhaag-sidenav__item denhaag-sidenav__item--child"}>
+                <a href={"/#"} class={"denhaag-sidenav__link denhaag-sidenav__link--child"}>
+                  Wonen
+                </a>
+              </li>
+              <li class={"denhaag-sidenav__item denhaag-sidenav__item--child"}>
+                <a href={"/#"} class={"denhaag-sidenav__link denhaag-sidenav__link--child"}>
+                  Vervoer
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li class={"denhaag-sidenav__item"}>
+            <a href={"/#"} class={"denhaag-sidenav__link"}>
+              <ArchiveIcon />
+              Lopende zaken
+            </a>
+          </li>
+        </ul>
+        <div class={"denhaag-divider"}></div>
+        <ul class={"denhaag-sidenav__list"}>
+          <li class={"denhaag-sidenav__item"}>
+            <a href={"/#"} className={"denhaag-sidenav__link"}>
+              <SettingsIcon />
+              Instellingen
+            </a>
+          </li>
+        </ul>
+      </nav>
+    )}
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>

--- a/components/Subnavigation/src/stories/react.stories.mdx
+++ b/components/Subnavigation/src/stories/react.stories.mdx
@@ -1,0 +1,64 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { Sidenav, SidenavItem, SidenavLink, SidenavList } from "../index";
+import pkg from "../../package.json";
+import { ArchiveIcon, GridIcon, InboxIcon } from "@gemeente-denhaag/icons";
+import Divider from "@gemeente-denhaag/divider";
+import BadgeCounter from "@gemeente-denhaag/badge-counter";
+
+<Meta
+  title="React/Navigation/Sidenav"
+  component={Sidenav}
+  parameters={{
+    componentSubtitle: `${pkg.name} - ${pkg.version}`,
+    docs: { source: { type: "dynamic" } },
+    status: {
+      type: "ALPHA",
+    },
+  }}
+/>
+
+## Stories
+
+### Default
+
+<Canvas>
+  <Story name="Default">
+    {(args) => (
+      <Sidenav {...args}>
+        <SidenavList>
+          <SidenavItem>
+            <SidenavLink current>
+              <GridIcon />
+              Overzicht
+            </SidenavLink>
+          </SidenavItem>
+          <SidenavItem>
+            <SidenavLink>
+              <InboxIcon />
+              Mijn berichten
+              <BadgeCounter>2</BadgeCounter>
+            </SidenavLink>
+          </SidenavItem>
+          <SidenavItem>
+            <SidenavLink>
+              <ArchiveIcon />
+              Lopende zaken
+            </SidenavLink>
+          </SidenavItem>
+        </SidenavList>
+        <Divider />
+        <SidenavList>
+          <SidenavItem>
+            <SidenavLink>
+              <ArchiveIcon />
+              Lopende zaken
+            </SidenavLink>
+          </SidenavItem>
+        </SidenavList>
+      </Sidenav>
+    )}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Sidenav} />

--- a/components/Subnavigation/src/stories/react.stories.mdx
+++ b/components/Subnavigation/src/stories/react.stories.mdx
@@ -28,20 +28,20 @@ import BadgeCounter from "@gemeente-denhaag/badge-counter";
       <Sidenav {...args}>
         <SidenavList>
           <SidenavItem>
-            <SidenavLink current>
+            <SidenavLink href={"/#"} current>
               <GridIcon />
               Overzicht
             </SidenavLink>
           </SidenavItem>
           <SidenavItem>
-            <SidenavLink>
+            <SidenavLink href={"/#"}>
               <InboxIcon />
               Mijn berichten
               <BadgeCounter>2</BadgeCounter>
             </SidenavLink>
           </SidenavItem>
           <SidenavItem>
-            <SidenavLink>
+            <SidenavLink href={"/#"}>
               <ArchiveIcon />
               Lopende zaken
             </SidenavLink>
@@ -50,7 +50,7 @@ import BadgeCounter from "@gemeente-denhaag/badge-counter";
         <Divider />
         <SidenavList>
           <SidenavItem>
-            <SidenavLink>
+            <SidenavLink href={"/#"}>
               <ArchiveIcon />
               Lopende zaken
             </SidenavLink>

--- a/components/Subnavigation/tsconfig.json
+++ b/components/Subnavigation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "src/**/*.stories.tsx"],
+  "references": []
+}

--- a/proprietary/Components/src/denhaag/sidenav.tokens.json
+++ b/proprietary/Components/src/denhaag/sidenav.tokens.json
@@ -1,0 +1,36 @@
+{
+  "denhaag": {
+    "sidenav": {
+      "item": {
+        "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+        "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
+        "font-weight": { "value": "{denhaag.typography.weight.regular}" },
+        "height": { "value": "48px" },
+        "line-height": { "value": "1.5" },
+        "margin-block-start": { "value": "0" },
+        "margin-block-end": { "value": "0" },
+        "margin-inline-start": { "value": "0" },
+        "margin-inline-end": { "value": "0" }
+      },
+      "link": {
+        "padding-block-start": { "value": "12px" },
+        "padding-block-end": { "value": "12px" },
+        "color": { "value": "{denhaag.color.grey.4}" },
+        "hover": {
+          "color": { "value": "{denhaag.color.blue.3}" }
+        },
+        "active": {
+          "color": { "value": "{denhaag.color.blue.3}" }
+        },
+        "child": {
+          "padding-inline-start": { "value": "16px" }
+        }
+      },
+      "list": {
+        "child": {
+          "margin-inline-start": { "value": "24px" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the sidenav component as seen in the portal libraries. Design tokens and BEM naming copied from `utrecht-sidenav` with a few changes to the design tokens. 

- [x] Hover styling missing cursor style pointer
- [x] Focus not visible
- [x] Missing prop on `SidenavLink` to mark it as current