### PR TITLE
build: separate build target for component CSS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,19 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import svgr from '@svgr/rollup';
 import _ from 'lodash';
+import fs from 'fs';
 import path from 'path';
 import postcss from 'rollup-plugin-postcss';
 
 import tsconfig from './tsconfig.json';
+
+const inputExists = (config) => {
+  try {
+    return fs.existsSync(config.input);
+  } catch (e) {
+    return false;
+  }
+};
 
 const externalDependencies = [
   '@material-ui/core',
@@ -50,6 +59,21 @@ const createConfig = ({ dir, format }) => ({
 export const modernConfig = [
   createConfig({ format: 'cjs', dir: './dist/cjs' }),
   createConfig({ format: 'esm', dir: './dist/mjs' }),
-];
+  {
+    input: 'src/index.scss',
+    output: {
+      dir: './dist',
+      sourcemap: false,
+      format: 'esm',
+      compact: true,
+    },
+    plugins: [
+      postcss({
+        extensions: ['.css', '.scss'],
+        extract: true,
+      }),
+    ],
+  },
+].filter(inputExists);
 
 export default [createConfig({ format: 'esm', dir: './dist' })];


### PR DESCRIPTION
TLDR: my new approach (that replaces #907) is simply to build the CSS from rollup too, just like the build for `@gemeente-denhaag/components-css` already does. Since not every package has CSS files, I included a filter to check if the input actually exists, and just skip the build step otherwise.

---

An alternative approach was needed, compared to PR #907, to separately provide `dist/index.css` for every component that has CSS. My previous approach used command line `sass`, but importing CSS from `node_modules/` works differently in `sass` than in 

The `~` in `import "~@utrecht/components"` was giving me headaches: rollup requires it because [`rollup-plugin-postcss`](https://github.com/egoist/rollup-plugin-postcss#imports) has quite a simplistic resolving heuristic for references that start with `~`: https://github.com/egoist/rollup-plugin-postcss/blob/caf34295afed324d512841a5a81b229f7749cec8/src/sass-loader.js#L12 This behavior is not in line with the `sass-loader` recommendation.

[`sass-loader` says](https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules) (used by PostCSS) the `~` in `import "~@utrecht/components"` is deprecated and discouraged: 

> Using `~` is deprecated and can be removed from your code (**we recommend it**), but we still support it for historical reasons.
Why can you remove it? The loader will first try to resolve `@import` as a relative path. If it cannot be resolved, then the loader will try to resolve `@import` inside [`node_modules`](https://webpack.js.org/configuration/resolve/#resolvemodules).

Removing the `~` from the CSS code would mean we'd have to work around this loader mechanism and probably configure a SCSS loader ourselves from `rollup.config.js`, or rewrite everything to explicitly import from `../../../node_modules/`.

Removing the `~` would have meant we could have used `sass --load-path ../../node_modules src/index.scss:dist/index.css`. Oh well!