### PR TITLE
style(GDH-407): re-add tokens for headings

### DIFF
--- a/components/Typography/src/stories/heading2.bem.stories.mdx
+++ b/components/Typography/src/stories/heading2.bem.stories.mdx
@@ -35,7 +35,13 @@ import "../heading.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Heading + Paragraph">
-    <h1 class="utrecht-heading-2">This is a bit of text inside a Header 1 component.</h1>
+    <h2 class="utrecht-heading-2">This is a bit of text inside a Header 2 component.</h2>
+    <p class="utrecht-paragraph">
+      Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
+      repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus
+      illum. Beatae consequatur sint eveniet animi neque.
+    </p>
+    <h2 class="utrecht-heading-2">This is a bit of text inside a Header 2 component.</h2>
     <p class="utrecht-paragraph">
       Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
       repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus

--- a/components/Typography/src/stories/heading3.bem.stories.mdx
+++ b/components/Typography/src/stories/heading3.bem.stories.mdx
@@ -33,7 +33,13 @@ import "../heading.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Heading + Paragraph">
-    <h1 class="utrecht-heading-3">This is a bit of text inside a Header 1 component.</h1>
+    <h3 class="utrecht-heading-3">This is a bit of text inside a Header 3 component.</h3>
+    <p class="utrecht-paragraph">
+      Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
+      repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus
+      illum. Beatae consequatur sint eveniet animi neque.
+    </p>
+    <h3 class="utrecht-heading-3">This is a bit of text inside a Header 3 component.</h3>
     <p class="utrecht-paragraph">
       Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
       repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus

--- a/components/Typography/src/stories/heading4.bem.stories.mdx
+++ b/components/Typography/src/stories/heading4.bem.stories.mdx
@@ -33,7 +33,13 @@ import "../heading.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Heading + Paragraph">
-    <h1 class="utrecht-heading-4">This is a bit of text inside a Header 1 component.</h1>
+    <h4 class="utrecht-heading-4">This is a bit of text inside a Header 4 component.</h4>
+    <p class="utrecht-paragraph">
+      Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
+      repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus
+      illum. Beatae consequatur sint eveniet animi neque.
+    </p>
+    <h4 class="utrecht-heading-4">This is a bit of text inside a Header 4 component.</h4>
     <p class="utrecht-paragraph">
       Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
       repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus

--- a/components/Typography/src/stories/heading5.bem.stories.mdx
+++ b/components/Typography/src/stories/heading5.bem.stories.mdx
@@ -33,7 +33,13 @@ import "../heading.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Heading + Paragraph">
-    <h1 class="utrecht-heading-5">This is a bit of text inside a Header 1 component.</h1>
+    <h5 class="utrecht-heading-5">This is a bit of text inside a Header 5component.</h5>
+    <p class="utrecht-paragraph">
+      Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
+      repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus
+      illum. Beatae consequatur sint eveniet animi neque.
+    </p>
+    <h5 class="utrecht-heading-5">This is a bit of text inside a Header 5component.</h5>
     <p class="utrecht-paragraph">
       Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
       repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus

--- a/proprietary/Components/src/utrecht/heading-2.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-2.tokens.json
@@ -6,9 +6,8 @@
       "font-size": { "value": "{denhaag.typography.scale.2xl.font-size}" },
       "font-weight": {},
       "line-height": {},
-      "margin-block-end": {},
-      "margin-block-start": {},
-
+      "margin-block-end": { "value": "0.5rem" },
+      "margin-block-start": { "value": "1.775rem" },
       "distanced": {
         "margin-block-start": { "value": "0" },
         "margin-block-end": { "value": "0" }

--- a/proprietary/Components/src/utrecht/heading-3.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-3.tokens.json
@@ -6,9 +6,8 @@
       "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
       "font-weight": {},
       "line-height": {},
-      "margin-block-end": {},
-      "margin-block-start": {},
-
+      "margin-block-end": { "value": "0.375rem" },
+      "margin-block-start": { "value": "1.33125rem" },
       "distanced": {
         "margin-block-start": { "value": "0" },
         "margin-block-end": { "value": "0" }

--- a/proprietary/Components/src/utrecht/heading-4.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-4.tokens.json
@@ -6,9 +6,8 @@
       "font-size": { "value": "{denhaag.typography.scale.lg.font-size}" },
       "font-weight": {},
       "line-height": {},
-      "margin-block-end": {},
-      "margin-block-start": {},
-
+      "margin-block-end": { "value": "0.3125rem" },
+      "margin-block-start": { "value": "1.1125rem" },
       "distanced": {
         "margin-block-start": { "value": "0" },
         "margin-block-end": { "value": "0" }

--- a/proprietary/Components/src/utrecht/heading-5.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-5.tokens.json
@@ -6,9 +6,8 @@
       "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "font-weight": {},
       "line-height": {},
-      "margin-block-end": {},
-      "margin-block-start": {},
-
+      "margin-block-end": { "value": "0.28125rem" },
+      "margin-block-start": { "value": "1rem" },
       "distanced": {
         "margin-block-start": { "value": "0" },
         "margin-block-end": { "value": "0" }


### PR DESCRIPTION
Solve: headings tokens empty

Purpose: 
- re-add the tokens
- some bem corrections, the right html heading tags

closes #943