### PR TITLE
style(cta-content-image): fix accessibility issue with button style

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -1,4 +1,6 @@
 .denhaag-cta-image-content {
+  --denhaag-button-cursor: var(--denhaag-cta-image-content-cursor);
+
   display: block;
   text-decoration: none;
   background-color: var(--denhaag-cta-image-content-background-color);

--- a/proprietary/Components/src/denhaag/cta-image-content.tokens.json
+++ b/proprietary/Components/src/denhaag/cta-image-content.tokens.json
@@ -5,6 +5,7 @@
       "border-color": { "value": "{denhaag.color.grey.2}" },
       "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
+      "cursor": { "value": "pointer" },
       "hover": {
         "box-shadow": { "value": "0px 4px 16px 0px rgba(0, 0, 0, 0.16)" }
       },


### PR DESCRIPTION
Set cursor of cta-image-content button to a pointer instead of defautl arrow on request of accessibility expert.