### PR TITLE
refactor(card-news): refactor due to accessibility feedback

### DIFF
--- a/components/CardNews/src/index.scss
+++ b/components/CardNews/src/index.scss
@@ -2,46 +2,45 @@
   --denhaag-card-news-icon-display: none;
   --denhaag-card-news-paragraph-display: none;
 
+  border: var(--denhaag-card-news-border);
   display: flex;
+  gap: var(--denhaag-card-news-gap);
+  flex-direction: column;
   text-decoration: var(--denhaag-card-news-text-decoration);
+  padding-block-start: var(--denhaag-card-news-padding);
+  padding-block-end: var(--denhaag-card-news-padding);
+  padding-inline-start: var(--denhaag-card-news-padding);
+  padding-inline-end: var(--denhaag-card-news-padding);
+  margin-inline-start: var(--denhaag-card-news-margin);
+  margin-inline-end: var(--denhaag-card-news-margin);
+  margin-block-start: var(--denhaag-card-news-margin);
+  margin-block-end: var(--denhaag-card-news-margin);
+  width: var(--denhaag-card-news-width);
+  height: var(--denhaag-card-news-height);
+  position: relative;
 
   @media (min-width: 25.9375rem) {
     --denhaag-card-news-paragraph-display: block;
   }
 }
 
+.denhaag-card-news--hover,
+.denhaag-card-news:hover {
+  box-shadow: var(--denhaag-card-news-box-shadow);
+}
+
 .denhaag-card-news:focus-visible,
 .denhaag-card-news--focus {
-  --denhaag-card-news-figure-box-shadow: none;
+  --denhaag-card-news-box-shadow: none;
   --denhaag-card-news-icon-display: inline-block;
 
-  outline: var(--denhaag-card-news-figure-outline);
+  outline: var(--denhaag-card-news-outline);
 }
 
 .denhaag-card-news:focus:not(:focus-visible) {
-  --denhaag-card-news-figure-box-shadow: none;
-  --denhaag-card-news-figure-outline: none;
+  --denhaag-card-news-box-shadow: none;
+  --denhaag-card-news-outline: none;
   --denhaag-card-news-icon-display: inline-block;
-}
-
-.denhaag-card-news__figure {
-  border: var(--denhaag-card-news-figure-border);
-  padding-block-start: var(--denhaag-card-news-figure-padding);
-  padding-block-end: var(--denhaag-card-news-figure-padding);
-  padding-inline-start: var(--denhaag-card-news-figure-padding);
-  padding-inline-end: var(--denhaag-card-news-figure-padding);
-  margin-inline-start: var(--denhaag-card-news-figure-margin);
-  margin-inline-end: var(--denhaag-card-news-figure-margin);
-  margin-block-start: var(--denhaag-card-news-figure-margin);
-  margin-block-end: var(--denhaag-card-news-figure-margin);
-  width: var(--denhaag-card-news-figure-width);
-  height: var(--denhaag-card-news-figure-height);
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.denhaag-card-news--hover .denhaag-card-news__figure,
-.denhaag-card-news:hover .denhaag-card-news__figure {
-  box-shadow: var(--denhaag-card-news-figure-box-shadow);
 }
 
 .denhaag-card-news__icon .denhaag-icon {
@@ -53,12 +52,11 @@
 .denhaag-card-news__image {
   aspect-ratio: var(--denhaag-card-news-image-aspect-ratio);
   height: var(--denhaag-card-news-image-height);
-  margin-block-end: var(--denhaag-card-news-image-margin-block-end);
   object-fit: var(--denhaag-card-news-image-object-fit);
   width: var(--denhaag-card-news-image-width);
 }
 
-.denhaag-card-news__figcaption {
+.denhaag-card-news__content {
   @media (min-width: 25.9375rem) {
     padding-block-start: var(--denhaag-card-news-figcaption-padding);
     padding-block-end: var(--denhaag-card-news-figcaption-padding);
@@ -80,4 +78,17 @@
   height: var(--denhaag-card-news-icon-height);
   text-align: var(--denhaag-card-news-icon-text-align);
   color: var(--denhaag-card-news-icon-color);
+}
+
+.denhaag-card-news__link {
+  color: inherit;
+  text-decoration: inherit;
+}
+.denhaag-card-news__link::after {
+  bottom: 0;
+  content: "";
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }

--- a/components/CardNews/src/stories/bem.stories.mdx
+++ b/components/CardNews/src/stories/bem.stories.mdx
@@ -3,6 +3,7 @@ import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
 import pkg from "../../package.json";
 import readme from "../../README.md";
 import "../index.scss";
+import "../storybook.scss";
 
 <Meta
   title="CSS/Cards/News Card"
@@ -28,33 +29,35 @@ import "../index.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
-    <a class="denhaag-card-news" href="#example-url">
-      <figure class="denhaag-card-news__figure">
-        <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
-        <figcaption class="denhaag-card-news__figcaption">
-          <h4 class="utrecht-heading-4 denhaag-card-news__heading">Fietsflat Rijnstraat: opknappen fietsenstalling</h4>
-          <p class="utrecht-paragraph denhaag-card-news__paragraph">
-            Het weekend van 15 en 16 januari in beide richtingen dicht.
-          </p>
-          <div className="denhaag-card-news__icon">
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              />
-            </svg>
-          </div>
-        </figcaption>
-      </figure>
-    </a>
+    <div class="denhaag-card-news">
+      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <div class="denhaag-card-news__content">
+        <h4 class="utrecht-heading-4 denhaag-card-news__heading">
+          <a class="denhaag-card-news__link" href="#example-url">
+            Fietsflat Rijnstraat: opknappen fietsenstalling
+          </a>
+        </h4>
+        <p class="utrecht-paragraph denhaag-card-news__paragraph">
+          Het weekend van 15 en 16 januari in beide richtingen dicht.
+        </p>
+        <div className="denhaag-card-news__icon">
+          <svg
+            aria-hidden="true"
+            class="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -64,33 +67,35 @@ import "../index.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hover">
-    <a class="denhaag-card-news denhaag-card-news--hover" href="#example-url">
-      <figure class="denhaag-card-news__figure">
-        <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
-        <figcaption class="denhaag-card-news__figcaption">
-          <h4 class="utrecht-heading-4 denhaag-card-news__heading">Fietsflat Rijnstraat: opknappen fietsenstalling</h4>
-          <p class="utrecht-paragraph denhaag-card-news__paragraph">
-            Het weekend van 15 en 16 januari in beide richtingen dicht.
-          </p>
-          <div className="denhaag-card-news__icon">
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              />
-            </svg>
-          </div>
-        </figcaption>
-      </figure>
-    </a>
+    <div class="denhaag-card-news denhaag-card-news--hover">
+      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <div class="denhaag-card-news__content">
+        <h4 class="utrecht-heading-4 denhaag-card-news__heading">
+          <a class="denhaag-card-news__link" href="#example-url">
+            Fietsflat Rijnstraat: opknappen fietsenstalling
+          </a>
+        </h4>
+        <p class="utrecht-paragraph denhaag-card-news__paragraph">
+          Het weekend van 15 en 16 januari in beide richtingen dicht.
+        </p>
+        <div className="denhaag-card-news__icon">
+          <svg
+            aria-hidden="true"
+            class="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -100,33 +105,35 @@ import "../index.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
-    <a class="denhaag-card-news denhaag-card-news--focus" href="#example-url">
-      <figure class="denhaag-card-news__figure">
-        <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
-        <figcaption class="denhaag-card-news__figcaption">
-          <h4 class="utrecht-heading-4 denhaag-card-news__heading">Fietsflat Rijnstraat: opknappen fietsenstalling</h4>
-          <p class="utrecht-paragraph denhaag-card-news__paragraph">
-            Het weekend van 15 en 16 januari in beide richtingen dicht.
-          </p>
-          <div className="denhaag-card-news__icon">
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              />
-            </svg>
-          </div>
-        </figcaption>
-      </figure>
-    </a>
+    <div class="denhaag-card-news denhaag-card-news--focus">
+      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <div class="denhaag-card-news__content">
+        <h4 class="utrecht-heading-4 denhaag-card-news__heading">
+          <a class="denhaag-card-news__link" href="#example-url">
+            Fietsflat Rijnstraat: opknappen fietsenstalling
+          </a>
+        </h4>
+        <p class="utrecht-paragraph denhaag-card-news__paragraph">
+          Het weekend van 15 en 16 januari in beide richtingen dicht.
+        </p>
+        <div className="denhaag-card-news__icon">
+          <svg
+            aria-hidden="true"
+            class="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>

--- a/components/CardNews/src/storybook.scss
+++ b/components/CardNews/src/storybook.scss
@@ -1,0 +1,4 @@
+/* This file is meant only for storybook overwrites. NOT FOR EXPORT! */
+.denhaag-card-news {
+  max-width: 320px;
+}

--- a/proprietary/Components/src/denhaag/card-news.tokens.json
+++ b/proprietary/Components/src/denhaag/card-news.tokens.json
@@ -1,31 +1,27 @@
 {
   "denhaag": {
     "card-news": {
+      "border": { "value": "1px solid {denhaag.color.grey.2}" },
+      "box-shadow": { "value": "0 0 0.5rem {denhaag.color.grey.2}" },
+      "gap": { "value": "{denhaag.space.block.md}" },
       "text-decoration": { "value": "none" },
-      "figure": {
-        "border": { "value": "1px solid {denhaag.color.grey.2}" },
-        "padding": { "value": "1rem" },
-        "margin": { "value": "0" },
-        "width": { "value": "100%" },
-        "height": { "value": "100%" },
-        "box-shadow": { "value": "0 0 0.5rem {denhaag.color.grey.2}" },
-        "outline": { "value": "{denhaag.link.focus.outline}" }
-      },
+      "padding": { "value": "{denhaag.space.block.md}" },
+      "margin": { "value": "0" },
+      "outline": { "value": "{denhaag.link.focus.outline}" },
       "image": {
         "width": { "value": "100%" },
         "height": { "value": "auto" },
         "object-fit": { "value": "cover" },
-        "aspect-ratio": { "value": "16 / 9" },
-        "margin-block-end": { "value": "{denhaag.space.block.md}" }
+        "aspect-ratio": { "value": "16 / 9" }
       },
-      "figcaption": {
+      "content": {
         "padding": { "value": "0.75rem" }
       },
       "text": {
         "margin-block-end": { "value": "{denhaag.space.block.xs}" }
       },
       "icon": {
-        "height": { "value": "1rem" },
+        "height": { "value": "{denhaag.space.block.md}" },
         "text-align": { "value": "right" },
         "color": { "value": "{denhaag.color.blue.3}" }
       }


### PR DESCRIPTION
**GDH-507:**

Edit HTML of the card, for accessibility screenreaders.

Link must only be inside of the heading, removing the figcaption.

**See ticket below:**


> On the homepage, under 'News items', there are cards that are formatted in a separate way: with figure and figcaption.
>
> Figure/figcaption are primarily intended to semantically link a caption and an image. (By the way, the image must have a filled alt attribute, otherwise you will have a caption of a non-existent image.)
>
> When a screen reader encounters a figure/figcaption, it indicates it with: 'grouping', 'caption'.
>
> But as it is now intended, this is not an image/caption relationship, but a 'simple' card:
>
> Steps to reproduce:
>
> View the source code of the news items.
>
> Result:
>
> A screen reader (in this case NVDA) reads this like this (emphasis mine):
> 
> “In action for a safe and livable Regentesse and Valkenboskwartier group In action for a safe and livable Regentesse and Valkenboskwartier headline level 4 caption link”
>
> So: “grouping” and “caption”. I don't think that's the intent for the current implementation.
>
> Proposal:
>
> Prepare the card, just like on https://www.eur.nl/ , Under the heading 'News':
>
> Important: Put only the head in an <a>, not the whole card (as is now the case). Rode:
>
> screen reader users can access a list of all the links on a page. If the whole card is included in an <a>, the link will be very long.
>
> Screen readers first read the content of a link and only at the end do they say that it is a link. So it takes a very long time for a screen reader user to know it's a link.
>
> If there is a need to increase the click area, there are other ways to do this. (for example the one that uses https://www.eur.nl/: with the pseudo element).