### PR TITLE
fix(list): add className prop support

### DIFF
--- a/components/List/src/List.tsx
+++ b/components/List/src/List.tsx
@@ -15,9 +15,13 @@ export interface ListProps extends HTMLAttributes<HTMLDivElement> {
  * Primary UI component for user interaction
  */
 export const List: React.FC<ListProps> = ({ subheader, ...props }: ListProps) => {
-  const rootClassNames = clsx('denhaag-list__wrapper', {
-    'denhaag-list__wrapper--with-subheader': subheader,
-  });
+  const rootClassNames = clsx(
+    'denhaag-list__wrapper',
+    {
+      'denhaag-list__wrapper--with-subheader': subheader,
+    },
+    props.className,
+  );
   return (
     <div {...props} className={rootClassNames}>
       {subheader}

--- a/components/List/src/ListItem.tsx
+++ b/components/List/src/ListItem.tsx
@@ -54,10 +54,14 @@ export const ListItem: React.FC<ListItemProps> = ({
   secondaryText,
   ...props
 }: ListItemProps) => {
-  const rootClassNames = clsx('denhaag-list__item', {
-    'denhaag-list__item--with-secondary': secondaryText,
-    'denhaag-list__item--nav': actionType && actionType === 'nav',
-  });
+  const rootClassNames = clsx(
+    'denhaag-list__item',
+    {
+      'denhaag-list__item--with-secondary': secondaryText,
+      'denhaag-list__item--nav': actionType && actionType === 'nav',
+    },
+    props.className,
+  );
 
   const children = [];
 

--- a/components/List/src/ListItemIcon.tsx
+++ b/components/List/src/ListItemIcon.tsx
@@ -1,6 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 
 import './list-item-icon.scss';
+import clsx from 'clsx';
 
 export type ListItemIconProps = HTMLAttributes<HTMLDivElement>;
 
@@ -9,7 +10,7 @@ export type ListItemIconProps = HTMLAttributes<HTMLDivElement>;
  */
 export const ListItemIcon: React.FC<ListItemIconProps> = (props: ListItemIconProps) => {
   return (
-    <div {...props} className="denhaag-list__item-icon">
+    <div {...props} className={clsx('denhaag-list__item-icon', props.className)}>
       {props.children}
     </div>
   );

--- a/components/List/src/ListItemSecondaryAction.tsx
+++ b/components/List/src/ListItemSecondaryAction.tsx
@@ -1,6 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 
 import './list-item-secondary-action.scss';
+import clsx from 'clsx';
 
 export type ListItemSecondaryActionProps = HTMLAttributes<HTMLDivElement>;
 
@@ -11,7 +12,7 @@ export const ListItemSecondaryAction: React.FC<ListItemSecondaryActionProps> = (
   props: ListItemSecondaryActionProps,
 ) => {
   return (
-    <div {...props} className="denhaag-list__secondary-action">
+    <div {...props} className={clsx('denhaag-list__secondary-action', props.className)}>
       {props.children}
     </div>
   );

--- a/components/List/src/ListItemText.tsx
+++ b/components/List/src/ListItemText.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes } from 'react';
 import clsx from 'clsx';
 
 import './list-item-text.scss';
+
 export interface ListItemTextProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The main content text, alias for children.
@@ -18,9 +19,13 @@ export interface ListItemTextProps extends HTMLAttributes<HTMLDivElement> {
  * Primary UI component for user interaction
  */
 export const ListItemText: React.FC<ListItemTextProps> = ({ primary, secondary, ...props }: ListItemTextProps) => {
-  const rootClassNames = clsx('denhaag-list__item-text', {
-    'denhaag-list__item-text--with-secondary': secondary,
-  });
+  const rootClassNames = clsx(
+    'denhaag-list__item-text',
+    {
+      'denhaag-list__item-text--with-secondary': secondary,
+    },
+    props.className,
+  );
 
   return (
     <div {...props} className={rootClassNames}>

--- a/components/List/src/ListSubheader.tsx
+++ b/components/List/src/ListSubheader.tsx
@@ -1,6 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 
 import './list-subheader.scss';
+import clsx from 'clsx';
 
 export type ListSubheaderProps = HTMLAttributes<HTMLParagraphElement>;
 
@@ -9,7 +10,7 @@ export type ListSubheaderProps = HTMLAttributes<HTMLParagraphElement>;
  */
 export const ListSubheader: React.FC<ListSubheaderProps> = (props: ListSubheaderProps) => {
   return (
-    <p {...props} className="denhaag-list__subheader">
+    <p {...props} className={clsx('denhaag-list__subheader', props.className)}>
       {props.children}
     </p>
   );


### PR DESCRIPTION
In the List component, `props.className` was not properly passed to the underlying component. This PR fixes this by adding it to the `clsx` parameters