### PR TITLE
Feature/gdh 408 edit links

### DIFF
--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -2,25 +2,35 @@
   position: relative;
   color: var(--denhaag-link-color);
   cursor: var(--denhaag-link-cursor, pointer);
-  padding-block-start: var(--denhaag-link-padding);
-  padding-block-end: var(--denhaag-link-padding);
   font-family: inherit;
   font-weight: inherit;
   font-size: inherit;
   line-height: inherit;
+  padding-inline-start: var(--denhaag-link-padding-inline-start, 0);
+  padding-inline-end: var(--denhaag-link-padding-inline-end, 0);
   text-decoration: underline;
 }
 
 .denhaag-link--with-icon {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--denhaag-link-icon-gap);
   text-decoration: none;
+  vertical-align: var(--denhaag-link-with-icon-vertical-align, baseline);
+}
+
+.denhaag-link--with-small-icon {
+  --denhaag-link-icon-font-size: var(--denhaag-link-small-icon-font-size);
 }
 
 .denhaag-link--with-icon-start {
-  padding-inline-start: calc(var(--denhaag-link-icon-size) + var(--denhaag-link-icon-margin-start));
+  --denhaag-link-icon-order: 0;
+  --denhaag-link-padding-inline-start: 0;
 }
 
 .denhaag-link--with-icon-end {
-  padding-inline-end: calc(var(--denhaag-link-icon-size) + var(--denhaag-link-icon-margin-end));
+  --denhaag-link-icon-order: 2;
+  --denhaag-link-padding-inline-end: 0;
 }
 
 .denhaag-link--focus,
@@ -33,8 +43,7 @@
 .denhaag-link--hover,
 .denhaag-link:hover {
   --denhaag-link-color: var(--denhaag-link-hover-color);
-
-  cursor: pointer;
+  --denhaag-link-cursor: pointer;
 }
 
 .denhaag-link--disabled,
@@ -47,28 +56,27 @@
 }
 
 .denhaag-link__icon {
-  position: absolute;
-  top: 0;
-  display: inline-flex;
-  justify-content: center;
   align-items: center;
+  display: inline-flex;
+  height: var(--denhaag-link-icon-size);
+  justify-content: center;
+  order: var(--denhaag-link-icon-order, 0);
+  position: relative;
   vertical-align: text-top;
   width: var(--denhaag-link-icon-size);
-  height: 100%;
-}
-
-.denhaag-link--with-icon-start .denhaag-link__icon {
-  left: 0;
-}
-
-.denhaag-link--with-icon-end .denhaag-link__icon {
-  right: 0;
 }
 
 .denhaag-link__icon > :first-child {
-  width: inherit;
-  height: var(--denhaag-link-icon-size);
-  font-size: inherit;
+  font-size: var(
+    --denhaag-link-icon-font-size,
+    calc(var(--denhaag-link-icon-size) - (var(--denhaag-link-icon-gap) / 2))
+  );
+  height: 1em;
+  width: 1em;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .denhaag-link__sr-only {

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -29,7 +29,7 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link">
     <a href="#example-link" class="denhaag-link">
-      Link
+      <span class="denhaag-link__label">Link</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -41,7 +41,7 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Disabled Link">
     <a href="#example-link" class="denhaag-link denhaag-link--disabled" tabindex="-1">
-      Disabled link
+      <span class="denhaag-link__label">Disabled link</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -53,7 +53,7 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hovered Link">
     <a href="#example-link" class="denhaag-link denhaag-link--hover">
-      Hovered link
+      <span class="denhaag-link__label">Hovered link</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -65,7 +65,7 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focused Link">
     <a href="#example-link" class="denhaag-link denhaag-link--focus">
-      Focused link
+      <span class="denhaag-link__label">Focused link</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -95,7 +95,7 @@ import readme from "../../README.md";
           ></path>
         </svg>
       </span>
-      <span>Link with icon before</span>
+      <span class="denhaag-link__label">Link with icon before</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -125,7 +125,7 @@ import readme from "../../README.md";
           ></path>
         </svg>
       </span>
-      <span>Link with icon after</span>
+      <span class="denhaag-link__label">Link with icon after</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -157,7 +157,7 @@ import readme from "../../README.md";
             ></path>
           </svg>
         </span>
-        a link
+        <span class="denhaag-link__label">a link</span>
       </a>{" "}
       in a Paragraph element.
     </p>
@@ -171,7 +171,7 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="External link">
     <a href="#example-link" class="denhaag-link" target="_blank">
-      External link
+      <span class="denhaag-link__label">External link</span>
       <span class="denhaag-link__sr-only">(External link)</span>
     </a>
   </Story>

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -170,7 +170,72 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="External link">
-    <a href="#example-link" class="denhaag-link" target="_blank">
+    <a href="#example-link" class="denhaag-link">
+      <span class="denhaag-link__label">External link</span>
+      <span class="denhaag-link__sr-only">(External link)</span>
+    </a>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### External link with icon
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="External link with icon">
+    <a href="#example-link" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end">
+      <span class="denhaag-link__icon">
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 18 18"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </span>
+      <span class="denhaag-link__label">External link</span>
+      <span class="denhaag-link__sr-only">(External link)</span>
+    </a>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### External link with icon small
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="External link with icon small">
+    <a
+      href="#example-link"
+      class="denhaag-link denhaag-link--with-icon denhaag-link--with-small-icon denhaag-link--with-icon-end"
+    >
+      <span class="denhaag-link__icon">
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 18 18"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </span>
       <span class="denhaag-link__label">External link</span>
       <span class="denhaag-link__sr-only">(External link)</span>
     </a>

--- a/components/UnorderedList/src/index.scss
+++ b/components/UnorderedList/src/index.scss
@@ -1,5 +1,4 @@
 @import "~@utrecht/components/unordered-list/css";
-@import "~@gemeente-denhaag/link/src/index";
 
 .denhaag-unordered-list {
   @extend .utrecht-unordered-list;
@@ -18,13 +17,6 @@
 
 .denhaag-unordered-list li::marker {
   font-size: var(--denhaag-unordered-list-marker-font-size);
-}
-
-.denhaag-unordered-list li > a {
-  @extend .denhaag-link;
-
-  padding-block-start: initial;
-  padding-block-end: initial;
 }
 
 .denhaag-unordered-list--lower-alpha {

--- a/components/UnorderedList/src/stories/bem.stories.mdx
+++ b/components/UnorderedList/src/stories/bem.stories.mdx
@@ -29,13 +29,19 @@ import "../index.scss";
   <Story name="Unordered list">
     <ul class="denhaag-unordered-list">
       <li>
-        Molestias <a href="https://www.denhaag.nl">assumenda</a> ratione in dolore aut consequatur accusantium corporis.
+        Molestias{" "}
+        <a href="https://www.denhaag.nl" class="denhaag-link">
+          <span class="denhaag-link__label">assumenda</span>
+        </a>{" "}
+        ratione in dolore aut consequatur accusantium corporis.
       </li>
       <li>
         Cheese:
         <ul class="denhaag-unordered-list denhaag-unordered-list--lower-alpha">
           <li>
-            <a href="https://www.denhaag.nl">Blue cheese</a>
+            <a href="https://www.denhaag.nl" class="denhaag-link">
+              <span class="denhaag-link__label">Blue cheese</span>
+            </a>
           </li>
           <li>Feta</li>
           <li>Brie</li>

--- a/proprietary/Components/src/denhaag/link.tokens.json
+++ b/proprietary/Components/src/denhaag/link.tokens.json
@@ -1,22 +1,51 @@
 {
   "denhaag": {
     "link": {
-      "color": { "value": "{denhaag.color.blue.3}" },
-      "padding": { "value": "8px" },
+      "color": {
+        "value": "{denhaag.color.blue.3}"
+      },
       "focus": {
-        "color": { "value": "{denhaag.color.blue.4}" },
-        "outline": { "value": "{denhaag.focus.border}" }
+        "color": {
+          "value": "{denhaag.color.blue.4}"
+        },
+        "outline": {
+          "value": "{denhaag.focus.border}"
+        }
       },
       "hover": {
-        "color": { "value": "{denhaag.color.blue.4}" }
+        "color": {
+          "value": "{denhaag.color.blue.4}"
+        }
       },
       "disabled": {
-        "color": { "value": "{denhaag.color.grey.2}" }
+        "color": {
+          "value": "{denhaag.color.grey.2}"
+        }
       },
       "icon": {
-        "margin-start": { "value": "8px" },
-        "margin-end": { "value": "8px" },
-        "size": { "value": "1.25em" }
+        "margin-start": {
+          "value": "{denhaag.space.inline.xs}"
+        },
+        "margin-end": {
+          "value": "{denhaag.space.inline.xs}"
+        },
+        "font-size": {
+          "value": "1em"
+        },
+        "size": {
+          "value": "1.25rem"
+        },
+        "gap": {
+          "value": "{denhaag.space.inline.2xs}"
+        }
+      },
+      "with-icon": {
+        "vertical-align": { "value": "bottom" }
+      },
+      "small": {
+        "icon": {
+          "font-size": { "value": "{denhaag.space.block.xs}" }
+        }
       }
     }
   }


### PR DESCRIPTION
Applied HTML of denhaag-link to denhaag-list component. Therefor we could remove duplicate .denhaag-link styles.

Also added some stories for external links.

Refactor of link-styles, which were colliding (also due to duplicate application with @extend). 