### PR TITLE
fix: use react supported shapeRendering instead of shape-rendering

### DIFF
--- a/components/Icons/src/SvgIcon.tsx
+++ b/components/Icons/src/SvgIcon.tsx
@@ -29,7 +29,7 @@ const SvgIcon: React.FC<SvgIconProps> = ({
       className={iconClassName}
       focusable={focusable}
       aria-hidden={props['aria-hidden'] ?? true}
-      shape-rendering={shapeRendering}
+      shapeRendering={shapeRendering}
       {...props}
     >
       {props.children}


### PR DESCRIPTION
While using components like `FormProgress` and `Datepicker` in our demo apps I'm getting an error about the Icons as they are using the `shape-rendering` property in React. I assume other people will run into the same issue and think its super simple to use `shapeRendering` instead ☺️

I went rogue and didn't create an issue as I think it's a super simple fix. @bddjong @mjcarsjens what do you prefer? Is this PR good enough or should I still create an issue for it?