### PR TITLE
fix(floating contact): added keyboard events

### DIFF
--- a/components/FloatingContact/src/FloatingContact.js
+++ b/components/FloatingContact/src/FloatingContact.js
@@ -19,8 +19,8 @@ export default class FloatingContact {
     }
 
     this.links = [...this.element.getElementsByClassName(`${id}__item-link`)];
-
     this.toggle.onclick = () => this.toggleEvents();
+    this.element.addEventListener('keydown', (event) => this.keyBoardEvents(event));
   }
 
   /**
@@ -33,5 +33,48 @@ export default class FloatingContact {
       ? this.toggle?.dataset?.labelClose || 'Close'
       : this.toggle?.dataset?.labelOpen || 'Open';
     this.links.forEach((link) => (link.tabIndex = state ? 0 : -1));
+  }
+
+  keyBoardEvents(event) {
+    const floatingContactSwitchExpanded = this.element
+      .querySelector('.denhaag-floating-contact-switch')
+      .getAttribute('aria-expanded');
+
+    // escape key
+    if (event.key === 'Escape' && floatingContactSwitchExpanded === 'true') {
+      setTimeout(() => {
+        this.toggleEvents();
+        this.toggle.focus();
+      }, 1);
+    }
+
+    // tab forwards
+    if (!event.shiftKey && event.key === 'Tab' && floatingContactSwitchExpanded === 'true') {
+      setTimeout(() => {
+        // this must be located inside timeout, because of the key event delay
+        const floatingContactItemLinkFocus = document.activeElement.classList.contains(
+          'denhaag-floating-contact__item-link',
+        );
+
+        if (!floatingContactItemLinkFocus) {
+          this.toggleEvents();
+        }
+      }, 1);
+    }
+
+    // tab backwards
+    if (event.shiftKey && event.key === 'Tab') {
+      setTimeout(() => {
+        // this must be located inside timeout, because of the key event delay
+        const floatingContactSwitchFocus = document.activeElement.classList.contains('denhaag-floating-contact-switch');
+        const floatingContactItemLinkFocus = document.activeElement.classList.contains(
+          'denhaag-floating-contact__item-link',
+        );
+
+        if (!floatingContactSwitchFocus && floatingContactSwitchExpanded === 'true' && !floatingContactItemLinkFocus) {
+          this.toggleEvents();
+        }
+      }, 1);
+    }
   }
 }

--- a/components/FloatingContact/src/stories/bem.stories.mdx
+++ b/components/FloatingContact/src/stories/bem.stories.mdx
@@ -54,7 +54,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -210,7 +210,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--hover"
           aria-expanded="false"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -366,7 +366,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--focus"
           aria-expanded="false"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -522,7 +522,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -676,7 +676,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -832,7 +832,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -988,7 +988,7 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           data-label-open="Contact"
-          data-label-close="Sluiten"
+          data-label-close="Contact"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact

--- a/components/FloatingContact/src/stories/bem.stories.mdx
+++ b/components/FloatingContact/src/stories/bem.stories.mdx
@@ -53,8 +53,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -209,8 +210,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--hover"
           aria-expanded="false"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -365,8 +367,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--focus"
           aria-expanded="false"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -521,8 +524,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -675,8 +679,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -831,8 +836,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -987,8 +993,9 @@ import { useEffect, useMemo } from "@storybook/client-api";
           id="denhaag-floating-contact-switch"
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
+          aria-label="Contact"
           data-label-open="Contact"
-          data-label-close="Contact"
+          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact


### PR DESCRIPTION
Ticket: https://acato-nl.atlassian.net/browse/GDH-58

Solve

When the foldout is open, close it: 
- If you tab out of the fold-out (so if you tap away from 'info@denhaag.nl'); 
- If you shift-tab from the 'Contact' button; 
- With ESC.

https://user-images.githubusercontent.com/95216123/173815058-49af1ad1-100c-4a84-9825-d69237e36128.mov


closes #990