### PR TITLE
style(link-with-icon): add arrow alignment link icon in list item

### DIFF
--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -71,7 +71,7 @@
   width: var(--denhaag-link-icon-size);
 }
 
-li .denhaag-link--with-icon .denhaag-link__icon {
+li .denhaag-link__icon {
   align-self: start;
   flex: 1 0 auto;
 }

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -71,7 +71,7 @@
   width: var(--denhaag-link-icon-size);
 }
 
-li .denhaag-link--with-icon-start .denhaag-link__icon {
+li .denhaag-link--with-icon .denhaag-link__icon {
   align-self: start;
   flex: 1 0 auto;
 }

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -71,6 +71,11 @@
   width: var(--denhaag-link-icon-size);
 }
 
+li .denhaag-link--with-icon-start .denhaag-link__icon {
+  align-self: start;
+  flex: 1 0 auto;
+}
+
 .denhaag-link__icon > :first-child {
   aspect-ratio: 1 / 1;
   font-size: var(--denhaag-link-icon-font-size);


### PR DESCRIPTION
Ticket: https://acato-nl.atlassian.net/browse/GDH-610

Solving:

- vertical alignment of arrows in a list item
- horizontal space between arrow and text in a list item

Explanation:
I put it in a seperate list selector, because putting the css properties directly into the `.denhaag-link__icon` gave the vertical alignment of the link in the paragraph a different vertical alignment.

![Screenshot 2022-06-15 at 11 01 06](https://user-images.githubusercontent.com/95216123/173788968-21f4876e-a6d9-4e52-8729-4a0a4decca92.png)
![Screenshot 2022-06-15 at 11 01 36](https://user-images.githubusercontent.com/95216123/173788978-25a4a6fa-5861-4594-9a98-afa5f5824a5b.png)


closes #991