### PR TITLE
style(headings): heading style removed, already defined in typography…

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -49,8 +49,6 @@
 }
 
 .denhaag-accordion__title {
-  --utrecht-heading-font-weight: var(--denhaag-accordion-title-font-weight);
-  --denhaag-heading-color: var(--denhaag-accordion-title-color);
   --utrecht-heading-5-margin-block-start: 0;
   --utrecht-heading-5-margin-block-end: 0;
 

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -6,8 +6,6 @@
 }
 
 .denhaag-link-group__caption {
-  color: var(--denhaag-link-group-caption-color);
-  font-weight: var(--denhaag-link-group-caption-font-weight);
   margin-block-start: var(--denhaag-link-group-caption-margin-block);
   margin-block-end: var(--denhaag-link-group-caption-margin-block);
 }

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -33,9 +33,7 @@
         "width": { "value": "100%" }
       },
       "title": {
-        "color": { "value": "{denhaag.color.grey.4}" },
         "flex-grow": { "value": "1" },
-        "font-weight": { "value": "{denhaag.typography.weight.regular}" },
         "border": { "value": "0" },
         "background": { "value": "none" },
         "text-align": { "value": "left" },

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -7,8 +7,6 @@
         "object-fit": { "value": "cover" }
       },
       "caption": {
-        "color": { "value": "{denhaag.color.grey.5}" },
-        "font-weight": { "value": "{denhaag.typography.weight.bold}" },
         "margin-block": { "value": "0" }
       },
       "navigation-list": {


### PR DESCRIPTION
Ticket: https://acato-nl.atlassian.net/browse/GDH-518

Solve: differences in heading styling.

- Remove heading styles from accordion and link group components (tokens + scss).
- h2, h3, h4 heading styles already defined in the typography component with classes: utrecht-heading-2, utrecht-heading-3 and utrecht-heading-4.

closes #996