### PR TITLE
Fix/accordion styling

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -24,14 +24,6 @@
   border-top: var(--denhaag-accordion-container-border-top);
 }
 
-.denhaag-accordion .denhaag-icon {
-  color: var(--denhaag-accordion-denhaag-icon-color);
-  position: var(--denhaag-accordion-denhaag-icon-position);
-  top: var(--denhaag-accordion-denhaag-icon-top);
-  right: var(--denhaag-accordion-denhaag-icon-right);
-  transform: var(--denhaag-accordion-denhaag-icon-transform);
-}
-
 .denhaag-accordion__panel {
   outline: var(--denhaag-accordion-panel-outline);
   align-items: var(--denhaag-accordion-panel-align-items);
@@ -46,6 +38,14 @@
   margin-block-start: var(--denhaag-accordion-panel-margin-block);
   margin-block-end: var(--denhaag-accordion-panel-margin-block);
   width: var(--denhaag-accordion-panel-width);
+}
+
+.denhaag-accordion__panel > .denhaag-icon {
+  color: var(--denhaag-accordion-denhaag-icon-color);
+  position: var(--denhaag-accordion-denhaag-icon-position);
+  top: var(--denhaag-accordion-denhaag-icon-top);
+  right: var(--denhaag-accordion-denhaag-icon-right);
+  transform: var(--denhaag-accordion-denhaag-icon-transform);
 }
 
 .denhaag-accordion__title {

--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -34,6 +34,7 @@
   padding-block-start: var(--denhaag-accordion-panel-padding-block);
   padding-block-end: var(--denhaag-accordion-panel-padding-block);
   padding-inline-end: var(--denhaag-accordion-panel-padding-inline);
+  position: relative;
   min-height: var(--denhaag-accordion-panel-min-height);
   margin-block-start: var(--denhaag-accordion-panel-margin-block);
   margin-block-end: var(--denhaag-accordion-panel-margin-block);
@@ -41,23 +42,28 @@
 }
 
 .denhaag-accordion__panel > .denhaag-icon {
-  color: var(--denhaag-accordion-denhaag-icon-color);
-  position: var(--denhaag-accordion-denhaag-icon-position);
-  top: var(--denhaag-accordion-denhaag-icon-top);
-  right: var(--denhaag-accordion-denhaag-icon-right);
-  transform: var(--denhaag-accordion-denhaag-icon-transform);
+  color: var(--denhaag-accordion-icon-color);
+  position: var(--denhaag-accordion-icon-position);
+  top: var(--denhaag-accordion-icon-top);
+  right: var(--denhaag-accordion-icon-right);
+  transform: var(--denhaag-accordion-icon-transform);
 }
 
 .denhaag-accordion__title {
   --utrecht-heading-5-margin-block-start: 0;
   --utrecht-heading-5-margin-block-end: 0;
 
-  flex-grow: var(--denhaag-accordion-title-flex-grow);
-  border: var(--denhaag-accordion-title-border);
   background: var(--denhaag-accordion-title-background);
+  border: var(--denhaag-accordion-title-border);
+  flex-grow: var(--denhaag-accordion-title-flex-grow);
+  hyphens: auto;
+  padding-block-start: var(--denhaag-accordion-title-padding-block);
+  padding-block-end: var(--denhaag-accordion-title-padding-block);
+  padding-inline-start: var(--denhaag-accordion-title-padding-inline);
+  padding-inline-end: calc(
+    (var(--denhaag-accordion-title-padding-inline) * 2) + var(--denhaag-accordion-icon-width, 0)
+  );
   text-align: var(--denhaag-accordion-title-text-align);
-  padding-inline-start: var(--denhaag-accordion-title-padding-inline-start);
-  padding-inline-end: var(--denhaag-accordion-title-padding-inline-end);
 }
 
 .denhaag-accordion__panel--focus .denhaag-accordion__title,
@@ -87,32 +93,40 @@
 }
 
 .denhaag-accordion__title:focus-visible,
-.denhaag-accordion__title:focus,
 .denhaag-accordion__title--focus {
-  outline: var(--denhaag-accordion-title-focus-outline);
-  height: var(--denhaag-accordion-title-focus-height);
+  outline: none;
+}
+
+.denhaag-accordion__title:focus-visible::after,
+.denhaag-accordion__title--focus::after {
   border-radius: var(--denhaag-accordion-title-focus-border-radius);
-  width: var(--denhaag-accordion-title-focus-width);
+  content: "";
+  height: 100%;
+  left: 0;
+  outline: var(--denhaag-accordion-title-focus-outline);
+  position: absolute;
+  top: 0;
+  width: 100%;
 }
 
 .denhaag-accordion__container--open {
   --denhaag-accordion-details-display: var(--denhaag-accordion-details-open-display);
   --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-title-color);
-  --denhaag-accordion-denhaag-icon-color: var(--denhaag-accordion-container-open-denhaag-icon-color);
-  --denhaag-accordion-denhaag-icon-transform: var(--denhaag-accordion-container-open-denhaag-icon-transform);
+  --denhaag-accordion-icon-color: var(--denhaag-accordion-container-open-icon-color);
+  --denhaag-accordion-icon-transform: var(--denhaag-accordion-container-open-icon-transform);
   --utrecht-heading-font-weight: var(--denhaag-accordion-container-open-title-font-weight);
 }
 
-.denhaag-accordion__panel:focus .denhaag-accordion__title,
-.denhaag-accordion__panel:focus .denhaag-icon,
-.denhaag-accordion__panel:hover .denhaag-accordion__title,
-.denhaag-accordion__panel:hover .denhaag-icon {
-  color: var(--denhaag-accordion-panel-color);
+.denhaag-accordion__container--open .denhaag-accordion__panel:hover,
+.denhaag-accordion__container--open .denhaag-accordion__panel > .denhaag-icon:hover {
+  --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-color);
 }
 
-.denhaag-accordion__container--open .denhaag-accordion__panel:hover,
-.denhaag-accordion__container--open .denhaag-icon:hover {
-  --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-color);
+.denhaag-accordion__panel:focus .denhaag-accordion__title:not([disabled]),
+.denhaag-accordion__panel:focus .denhaag-accordion__title:not([disabled]) + .denhaag-icon,
+.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
+.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]) + .denhaag-icon {
+  color: var(--denhaag-accordion-panel-color);
 }
 
 .denhaag-accordion__details {

--- a/components/Accordion/src/stories/bem.stories.mdx
+++ b/components/Accordion/src/stories/bem.stories.mdx
@@ -121,7 +121,7 @@ import readme from "../../README.md";
             class="utrecht-heading-5 denhaag-accordion__title"
             id="default-accordion3id"
           >
-            Accordion
+            Integer blandit libero quis risus maximus auctor. Proin ullamcorper, metus.
           </button>
           <svg
             class="denhaag-icon"

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -1,67 +1,148 @@
 {
   "denhaag": {
     "accordion": {
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-family": {
+        "value": "{denhaag.typography.sans-serif.font-family}"
+      },
       "container": {
-        "border": { "value": "1px solid {denhaag.color.grey.3}" },
-        "border-radius": { "value": "{denhaag.border-radius}" },
-        "border-top": { "value": "0" },
-        "position": { "value": "relative" },
+        "border": {
+          "value": "1px solid {denhaag.color.grey.3}"
+        },
+        "border-radius": {
+          "value": "{denhaag.border-radius}"
+        },
+        "border-top": {
+          "value": 0
+        },
+        "position": {
+          "value": "relative"
+        },
         "open": {
-          "color": { "value": "{denhaag.color.green.4}" },
-          "title": {
-            "font-weight": { "value": "{denhaag.typography.weight.bold}" },
-            "color": { "value": "{denhaag.color.green.3}" }
+          "color": {
+            "value": "{denhaag.color.green.4}"
           },
-          "denhaag-icon": {
-            "color": { "value": "{denhaag.color.green.3}" },
-            "transform": { "value": "rotate(180deg)" }
+          "title": {
+            "color": {
+              "value": "{denhaag.color.green.3}"
+            },
+            "font-weight": {
+              "value": "{denhaag.typography.weight.bold}"
+            }
+          },
+          "icon": {
+            "color": {
+              "value": "{denhaag.color.green.3}"
+            },
+            "transform": {
+              "value": "rotate(180deg)"
+            }
           }
         }
       },
       "panel": {
-        "outline": { "value": "0" },
-        "align-items": { "value": "center" },
-        "border-radius": { "value": "0" },
-        "color": { "value": "{denhaag.color.green.3}" },
-        "text-decoration": { "value": "none" },
-        "background-color": { "value": "transparent" },
-        "display": { "value": "flex" },
-        "margin-block": { "value": "0" },
-        "padding-block": { "value": "0" },
-        "min-height": { "value": "calc(4 * 0.75rem)" },
-        "width": { "value": "100%" }
-      },
-      "title": {
-        "flex-grow": { "value": "1" },
-        "border": { "value": "0" },
-        "background": { "value": "none" },
-        "text-align": { "value": "left" },
-        "padding-inline-start": { "value": "{denhaag.space.inline.md}" },
-        "padding-inline-end": { "value": "0" },
-        "focus": {
-          "outline": { "value": "2px dashed {denhaag.color.ocher.5}" },
-          "height": { "value": "2.875rem" },
-          "border-radius": { "value": "{denhaag.border-radius}" },
-          "width": { "value": "100%" }
+        "align-items": {
+          "value": "center"
         },
-        "disabled": {
-          "background-color": { "value": "{denhaag.color.grey.1}" }
+        "background-color": {
+          "value": "transparent"
+        },
+        "border-radius": {
+          "value": 0
+        },
+        "color": {
+          "value": "{denhaag.color.green.3}"
+        },
+        "display": {
+          "value": "flex"
+        },
+        "outline": {
+          "value": 0
+        },
+        "margin-block": {
+          "value": 0
+        },
+        "min-height": {
+          "value": "calc(4 * 0.75rem)"
+        },
+        "padding-block": {
+          "value": 0
+        },
+        "text-decoration": {
+          "value": "none"
+        },
+        "width": {
+          "value": "100%"
         }
       },
-      "denhaag-icon": {
-        "color": { "value": "{denhaag.color.grey.4}" },
-        "position": { "value": "absolute" },
-        "top": { "value": "0.75rem" },
-        "right": { "value": "0.5rem" }
+      "title": {
+        "background": {
+          "value": "none"
+        },
+        "border": {
+          "value": 0
+        },
+        "flex-grow": {
+          "value": 1
+        },
+        "text-align": {
+          "value": "left"
+        },
+        "padding-inline": {
+          "value": "{denhaag.space.inline.md}"
+        },
+        "padding-block": {
+          "value": "0.75rem"
+        },
+        "focus": {
+          "border-radius": {
+            "value": "{denhaag.border-radius}"
+          },
+          "outline": {
+            "value": "2px dashed {denhaag.color.ocher.5}"
+          }
+        },
+        "disabled": {
+          "background-color": {
+            "value": "{denhaag.color.grey.1}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "value": "{denhaag.color.grey.4}"
+        },
+        "position": {
+          "value": "absolute"
+        },
+        "top": {
+          "value": "0.75rem"
+        },
+        "right": {
+          "value": "{denhaag.space.inline.md}"
+        },
+        "width": {
+          "value": "1.5rem"
+        }
       },
       "details": {
-        "padding-block-start": { "value": "0" },
-        "padding-block-end": { "value": "1rem" },
-        "padding-inline": { "value": "1rem" },
-        "margin-inline-end": { "value": "calc((2 * 1rem) + (2 * 0.75rem))" },
-        "display": { "value": "none" },
-        "open-display": { "value": "block" }
+        "padding-block-start": {
+          "value": 0
+        },
+        "padding-block-end": {
+          "value": "1rem"
+        },
+        "padding-inline": {
+          "value": "1rem"
+        },
+        "margin-inline-end": {
+          "value": "calc((2 * 1rem) + (2 * 0.75rem))"
+        },
+        "display": {
+          "value": "none"
+        },
+        "open-display": {
+          "value": "block"
+        }
       }
     }
   }


### PR DESCRIPTION
The fix:
- Make sure the icon don't goes though the text;
- Disabled tabs got hover and focus statement;
- denhaag-link icons in the accordion-content where targeted and increased in size and color.

Before:
![Screenshot 2022-07-06 at 15 23 10](https://user-images.githubusercontent.com/94894596/177560363-796ce74d-3b2e-4c37-acc7-95592b43ecff.png)

Result:
![Screenshot 2022-07-06 at 15 20 55](https://user-images.githubusercontent.com/94894596/177559885-ea2ab34f-6781-48fa-acbe-9f0b5d4781e9.png)


Checked the design for the panel-title and focus https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=0%3A1