### PR TITLE
refactor(link): cleanup unused css selectors

### DIFF
--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -30,10 +30,10 @@
 }
 
 .denhaag-link--external,
-.denhaag-link--with-icon--hover,
-.denhaag-link--with-icon:hover,
-.denhaag-link--with-icon--focus,
-.denhaag-link--with-icon:focus {
+.denhaag-link--hover,
+.denhaag-link:hover,
+.denhaag-link--focus,
+.denhaag-link:focus {
   text-decoration: var(--denhaag-link-text-decoration);
 }
 

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -109,7 +109,7 @@ import readme from "../../README.md";
     <a
       href="#example-link"
       tabindex="0"
-      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--with-icon--hover"
+      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--hover"
     >
       <span class="denhaag-link__icon">
         <svg
@@ -143,7 +143,7 @@ import readme from "../../README.md";
     <a
       href="#example-link"
       tabindex="0"
-      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--with-icon--focus"
+      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--focus"
     >
       <span class="denhaag-link__icon">
         <svg
@@ -207,7 +207,7 @@ import readme from "../../README.md";
     <a
       href="#example-link"
       tabindex="0"
-      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--with-icon--hover"
+      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--hover"
     >
       <span class="denhaag-link__icon">
         <svg
@@ -241,7 +241,7 @@ import readme from "../../README.md";
     <a
       href="#example-link"
       tabindex="0"
-      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--with-icon--focus"
+      class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--focus"
     >
       <span class="denhaag-link__icon">
         <svg


### PR DESCRIPTION
Solve: there still was clutter in the bem + css files (unused css selectors)

Purpose:

- remove unused css selectors in bem file
- remove unused css selectors in css file

closes #1020