### PR TITLE
docs: use fixed storybook images

### DIFF
--- a/components/AuthenticationBlock/src/stories/bem.stories.mdx
+++ b/components/AuthenticationBlock/src/stories/bem.stories.mdx
@@ -4,6 +4,9 @@ import "../index.scss";
 import pkg from "../../package.json";
 import readme from "../../README.md";
 
+export const brandImage = (h, w) =>
+  `https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=${w}&h=${h}`;
+
 <Meta
   title="CSS/Actions/Authentication Block"
   parameters={{
@@ -122,9 +125,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -183,9 +186,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -241,9 +244,9 @@ import readme from "../../README.md";
             <img
               width="40"
               height="40"
-              src="https://source.unsplash.com/40x40/?brand"
+              src={brandImage(40, 40)}
               class="denhaag-authentication-item__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
             Gebruik een Europees erkend middel
@@ -281,9 +284,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -324,9 +327,9 @@ import readme from "../../README.md";
             <img
               width="40"
               height="40"
-              src="https://source.unsplash.com/40x40/?brand"
+              src={brandImage(40, 40)}
               class="denhaag-authentication-item__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
             Gebruik een Europees erkend middel
@@ -364,9 +367,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -407,9 +410,9 @@ import readme from "../../README.md";
             <img
               width="40"
               height="40"
-              src="https://source.unsplash.com/40x40/?brand"
+              src={brandImage(40, 40)}
               class="denhaag-authentication-item__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
             Gebruik een Europees erkend middel
@@ -436,9 +439,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -479,9 +482,9 @@ import readme from "../../README.md";
             <img
               width="40"
               height="40"
-              src="https://source.unsplash.com/40x40/?brand"
+              src={brandImage(40, 40)}
               class="denhaag-authentication-item__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
             Gebruik een Europees erkend middel
@@ -508,9 +511,9 @@ import readme from "../../README.md";
             <img
               width="80"
               height="80"
-              src="https://source.unsplash.com/80x80/?brand"
+              src={brandImage(80, 80)}
               class="denhaag-image__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
           </figure>
@@ -551,9 +554,9 @@ import readme from "../../README.md";
             <img
               width="40"
               height="40"
-              src="https://source.unsplash.com/40x40/?brand"
+              src={brandImage(40, 40)}
               class="denhaag-authentication-item__image"
-              alt=""
+              alt="regenboog merk"
               loading="lazy"
             />
             Gebruik een Europees erkend middel

--- a/components/CtaDownload/src/stories/bem.stories.mdx
+++ b/components/CtaDownload/src/stories/bem.stories.mdx
@@ -5,6 +5,9 @@ import "../index.scss";
 import pkg from "../../package.json";
 import readme from "../../README.md";
 
+export const fileImage = (h, w) =>
+  `https://images.unsplash.com/photo-1569235186275-626cb53b83ce?fit=crop&w=${w}&h=${h}`;
+
 <Meta
   title="CSS/Actions/CTA Download"
   parameters={{
@@ -30,7 +33,7 @@ import readme from "../../README.md";
   <Story name="Default">
     <a
       class="denhaag-cta-download"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="application/pdf"
       aria-label="Download: [READABLE_FILENAME] (PDF, 763,8 kB)"
@@ -71,7 +74,7 @@ import readme from "../../README.md";
   <Story name="Hovered">
     <a
       class="denhaag-cta-download denhaag-cta-download--hover"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="application/pdf"
       aria-label="Download: [READABLE_FILENAME] (PDF, 763,8 kB)"
@@ -112,7 +115,7 @@ import readme from "../../README.md";
   <Story name="Focused">
     <a
       class="denhaag-cta-download denhaag-cta-download--focus"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="application/pdf"
       aria-label="Download: [READABLE_FILENAME] (PDF, 763,8 kB)"
@@ -153,7 +156,7 @@ import readme from "../../README.md";
   <Story name="Grouped">
     <a
       class="denhaag-cta-download"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="application/pdf"
       aria-label="Download: Verslag dienstreis naar Delhi (PDF, 126,5 kB)"
@@ -185,7 +188,7 @@ import readme from "../../README.md";
     </a>
     <a
       class="denhaag-cta-download"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="application/msword"
       aria-label="Download: [READABLE_FILENAME] (DOC, 763,8 kB)"
@@ -217,7 +220,7 @@ import readme from "../../README.md";
     </a>
     <a
       class="denhaag-cta-download"
-      href="https://source.unsplash.com/800x800/?file"
+      href={fileImage(800, 800)}
       download="pretty-file-name-without-spaces"
       type="image/jpeg"
       aria-label="Download: [READABLE_FILENAME] (JPG, 600 kB)"

--- a/components/Hero/src/stories/bem.stories.mdx
+++ b/components/Hero/src/stories/bem.stories.mdx
@@ -5,6 +5,9 @@ import readme from "../../README.md";
 import "../index.scss";
 import "../storybook.scss";
 
+export const heroImage = (h, w, id = "photo-1513384312027-9fa69a360337") =>
+  `https://images.unsplash.com/${id}?fit=crop&w=${w}&h=${h}`;
+
 <Meta
   title="CSS/Page Elements/Hero"
   parameters={{
@@ -35,7 +38,11 @@ import "../storybook.scss";
           <h1 class="denhaag-hero__title utrecht-heading-1">Parkeren</h1>
         </div>
       </div>
-      <img class="denhaag-hero__image" src="https://source.unsplash.com/560x400/?parking" alt="" />
+      <img
+        class="denhaag-hero__image"
+        src={heroImage(400, 560, "photo-1470224114660-3f6686c562eb")}
+        alt="auto in parkeervak"
+      />
     </section>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -52,7 +59,11 @@ import "../storybook.scss";
           <h1 class="denhaag-hero__title utrecht-heading-1">Betalen, wijzigen of opzeggen</h1>
         </div>
       </div>
-      <img class="denhaag-hero__image" src="https://source.unsplash.com/560x400/?payment" alt="" />
+      <img
+        class="denhaag-hero__image"
+        src={heroImage(400, 560, "photo-1634733988138-bf2c3a2a13fa")}
+        alt="pinautomaat"
+      />
     </section>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -71,7 +82,7 @@ import "../storybook.scss";
           </h1>
         </div>
       </div>
-      <img class="denhaag-hero__image" src="https://source.unsplash.com/560x400/?parking" alt="" />
+      <img class="denhaag-hero__image" src={heroImage(800, 800)} alt="hero" />
     </section>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -108,7 +119,11 @@ import "../storybook.scss";
           </button>
         </div>
       </div>
-      <img class="denhaag-hero__image" src="https://source.unsplash.com/560x400/?parking" alt="" />
+      <img
+        class="denhaag-hero__image"
+        src={heroImage(400, 560, "photo-1470224114660-3f6686c562eb")}
+        alt="auto in parkeervak"
+      />
     </section>
   </Story>
   {/* eslint-enable react/no-unknown-property */}


### PR DESCRIPTION
Lets use fixed images instead of random images for a topic, to prevent regression notices every time a random image is used in the build.