### PR TITLE
refactor(links): remove unnecesary nav tags, add link gro…

### DIFF
--- a/components/HighlightedLinks/src/index.scss
+++ b/components/HighlightedLinks/src/index.scss
@@ -5,31 +5,31 @@
   width: var(--denhaag-highlighted-links-width);
 }
 
-.denhaag-highlighted-links__navigation-list {
+.denhaag-highlighted-links__list {
   --denhaag-link-group-navigation-list-margin-block-end: 0;
 
-  display: var(--denhaag-highlighted-links-navigation-list-display);
-  gap: var(--denhaag-highlighted-links-navigation-list-gap);
+  display: var(--denhaag-highlighted-links-list-display);
+  gap: var(--denhaag-highlighted-links-list-gap);
 }
 
 @media (min-width: 48rem) {
-  .denhaag-highlighted-links__navigation-list {
-    grid-template-columns: var(--denhaag-highlighted-links-navigation-list-grid-template-columns);
+  .denhaag-highlighted-links__list {
+    grid-template-columns: var(--denhaag-highlighted-links-list-grid-template-columns);
   }
 }
 
 @media (min-width: 68.875rem) {
-  .denhaag-highlighted-links__navigation-list {
-    --denhaag-highlighted-links-navigation-list-grid-template-columns: var(
-      --denhaag-highlighted-links-navigation-list-grid-template-columns-2
+  .denhaag-highlighted-links__list {
+    --denhaag-highlighted-links-list-grid-template-columns: var(
+      --denhaag-highlighted-links-list-grid-template-columns-2
     );
   }
 }
 
 @media (min-width: 80rem) {
-  .denhaag-highlighted-links__navigation-list {
-    --denhaag-highlighted-links-navigation-list-grid-template-columns: var(
-      --denhaag-highlighted-links-navigation-list-grid-template-columns-3
+  .denhaag-highlighted-links__list {
+    --denhaag-highlighted-links-list-grid-template-columns: var(
+      --denhaag-highlighted-links-list-grid-template-columns-3
     );
   }
 }

--- a/components/HighlightedLinks/src/stories/bem.stories.mdx
+++ b/components/HighlightedLinks/src/stories/bem.stories.mdx
@@ -30,146 +30,138 @@ import readme from "../../README.md";
   <Story name="Default">
     <div class="denhaag-link-group denhaag-highlighted-links">
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <nav
-        class="denhaag-link-group__navigation denhaag-highlighted-links__navigation"
-        aria-labelledby="denhaag-highlighted-links-navigation"
-      >
-        <ul
-          id="denhaag-highlighted-links-navigation"
-          class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list denhaag-highlighted-links__navigation-list"
-        >
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span>Paspoort en identiteitskaart. Repudiandae rem voluptate ex.</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span>Rijbewijs</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span>Inburgeren en naturaliseren</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span>Akten</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span>Verklaringen</span>
-            </a>
-          </li>
-        </ul>
-      </nav>
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list denhaag-highlighted-links__navigation-list">
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span>Paspoort en identiteitskaart. Repudiandae rem voluptate ex.</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span>Rijbewijs</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span>Inburgeren en naturaliseren</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span>Akten</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span>Verklaringen</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}

--- a/components/HighlightedLinks/src/stories/bem.stories.mdx
+++ b/components/HighlightedLinks/src/stories/bem.stories.mdx
@@ -30,8 +30,8 @@ import readme from "../../README.md";
   <Story name="Default">
     <div class="denhaag-link-group denhaag-highlighted-links">
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list denhaag-highlighted-links__list">
-        <li class="denhaag-link-group__navigation-list-item">
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__list denhaag-highlighted-links__list">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -57,7 +57,7 @@ import readme from "../../README.md";
             <span>Paspoort en identiteitskaart. Repudiandae rem voluptate ex.</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -83,7 +83,7 @@ import readme from "../../README.md";
             <span>Rijbewijs</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -109,7 +109,7 @@ import readme from "../../README.md";
             <span>Inburgeren en naturaliseren</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -135,7 +135,7 @@ import readme from "../../README.md";
             <span>Akten</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"

--- a/components/HighlightedLinks/src/stories/bem.stories.mdx
+++ b/components/HighlightedLinks/src/stories/bem.stories.mdx
@@ -30,7 +30,7 @@ import readme from "../../README.md";
   <Story name="Default">
     <div class="denhaag-link-group denhaag-highlighted-links">
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list denhaag-highlighted-links__navigation-list">
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list denhaag-highlighted-links__list">
         <li class="denhaag-link-group__navigation-list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -10,29 +10,29 @@
   margin-block-end: var(--denhaag-link-group-caption-margin-block);
 }
 
-.denhaag-link-group__navigation-list {
-  margin-block-start: var(--denhaag-link-group-navigation-list-margin-block-start);
-  margin-block-end: var(--denhaag-link-group-navigation-list-margin-block-end);
-  list-style: var(--denhaag-link-group-navigation-list-list-style);
-  padding-inline-start: var(--denhaag-link-group-navigation-list-padding-inline-start);
+.denhaag-link-group__list {
+  margin-block-start: var(--denhaag-link-group-list-margin-block-start);
+  margin-block-end: var(--denhaag-link-group-list-margin-block-end);
+  list-style: var(--denhaag-link-group-list-list-style);
+  padding-inline-start: var(--denhaag-link-group-list-padding-inline-start);
 
   @media (min-width: 1114px) {
     margin-block-start: var(--denhaag-space-block-sm);
   }
 }
 
-.denhaag-link-group__navigation-list-item {
-  padding-block-start: var(--denhaag-link-group-navigation-list-item-padding-block);
-  padding-block-end: var(--denhaag-link-group-navigation-list-item-padding-block);
+.denhaag-link-group__list-item {
+  padding-block-start: var(--denhaag-link-group-list-item-padding-block);
+  padding-block-end: var(--denhaag-link-group-list-item-padding-block);
 }
 
 .denhaag-link-group--dark .denhaag-link,
 .denhaag-link-group--dark .denhaag-link:hover,
-.denhaag-link-group--dark .denhaag-link:focus {
+.denhaag-link-group--dark .denhaag-link:focus-visible {
   color: var(--denhaag-link-group-dark-denhaag-link-color);
 }
 
-.denhaag-link-group--dark .denhaag-link:focus {
+.denhaag-link-group--dark .denhaag-link:focus-visible {
   outline-color: var(--denhaag-link-group-dark-denhaag-link-focus-outline-color);
 }
 

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -29,36 +29,32 @@
 .denhaag-link-group--dark .denhaag-link,
 .denhaag-link-group--dark .denhaag-link:hover,
 .denhaag-link-group--dark .denhaag-link:focus-visible {
-  color: var(--denhaag-link-group-dark-denhaag-link-color);
+  color: var(--denhaag-link-group-dark-link-color);
 }
 
 .denhaag-link-group--dark .denhaag-link:focus-visible {
-  outline-color: var(--denhaag-link-group-dark-denhaag-link-focus-outline-color);
-}
-
-.denhaag-link-group--dark {
-  --denhaag-focus-border-color: var(--denhaag-link-group-dark-denhaag-link-focus-border-color);
+  outline-color: var(--denhaag-link-group-dark-link-focus-outline-color);
 }
 
 .denhaag-link-group .denhaag-link:hover {
-  text-decoration: var(--denhaag-link-group-denhaag-link-hover-text-decoration);
+  text-decoration: var(--denhaag-link-group-link-hover-text-decoration);
 }
 
 .denhaag-link-group .denhaag-link--with-icon-start {
-  display: var(--denhaag-link-group-denhaag-link-with-icon-start-display);
-  padding-block-start: var(--denhaag-link-group-denhaag-link-with-icon-start-padding-block-start);
-  padding-block-end: var(--denhaag-link-group-denhaag-link-with-icon-start-padding-block-end);
+  display: var(--denhaag-link-group-link-with-icon-start-display);
+  padding-block-start: var(--denhaag-link-group-link-with-icon-start-padding-block-start);
+  padding-block-end: var(--denhaag-link-group-link-with-icon-start-padding-block-end);
 }
 
 .denhaag-link-group .denhaag-link__icon {
-  font-size: var(--denhaag-link-group-denhaag-link-icon-font-size);
-  width: var(--denhaag-link-group-denhaag-link-icon-width);
+  font-size: var(--denhaag-link-group-link-icon-font-size);
+  width: var(--denhaag-link-group-link-icon-width);
 }
 
 .denhaag-link-group .denhaag-link__icon .denhaag-icon {
-  align-self: var(--denhaag-link-group-denhaag-link-icon-denhaag-icon-align-self);
-  padding-block-start: var(--denhaag-link-group-denhaag-link-icon-denhaag-icon-padding-block-start);
-  height: var(--denhaag-link-group-denhaag-link-icon-denhaag-icon-height);
+  align-self: var(--denhaag-link-group-link-icon-denhaag-icon-align-self);
+  padding-block-start: var(--denhaag-link-group-link-icon-denhaag-icon-padding-block-start);
+  height: var(--denhaag-link-group-link-icon-denhaag-icon-height);
 }
 
 .denhaag-link-group--dark .denhaag-link-group__caption {

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -32,6 +32,10 @@
   color: var(--denhaag-link-group-dark-denhaag-link-color);
 }
 
+.denhaag-link-group--dark .denhaag-link:focus {
+  outline-color: var(--denhaag-link-group-dark-denhaag-link-focus-outline-color);
+}
+
 .denhaag-link-group--dark {
   --denhaag-focus-border-color: var(--denhaag-link-group-dark-denhaag-link-focus-border-color);
 }

--- a/components/LinkGroup/src/stories/bem.stories.mdx
+++ b/components/LinkGroup/src/stories/bem.stories.mdx
@@ -30,8 +30,8 @@ import readme from "../../README.md";
   <Story name="Default">
     <div class="denhaag-link-group">
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
-        <li class="denhaag-link-group__navigation-list-item">
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__list">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -57,7 +57,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -83,7 +83,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -109,7 +109,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -135,7 +135,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -175,8 +175,8 @@ import readme from "../../README.md";
     <div class="denhaag-link-group">
       <img class="denhaag-link-group__image" src="https://via.placeholder.com/140x140" alt="placeholder" />
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
-        <li class="denhaag-link-group__navigation-list-item">
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__list">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -205,7 +205,7 @@ import readme from "../../README.md";
             </span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -231,7 +231,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -257,7 +257,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -283,7 +283,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -322,8 +322,8 @@ import readme from "../../README.md";
   <Story name="Dark background">
     <div class="denhaag-link-group denhaag-link-group--dark" style={{ backgroundColor: "#2D2D2D", padding: "1rem" }}>
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
-        <li class="denhaag-link-group__navigation-list-item">
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__list">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -349,7 +349,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -375,7 +375,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -401,7 +401,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
@@ -427,7 +427,7 @@ import readme from "../../README.md";
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
-        <li class="denhaag-link-group__navigation-list-item">
+        <li class="denhaag-link-group__list-item">
           <a
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"

--- a/components/LinkGroup/src/stories/bem.stories.mdx
+++ b/components/LinkGroup/src/stories/bem.stories.mdx
@@ -30,143 +30,138 @@ import readme from "../../README.md";
   <Story name="Default">
     <div class="denhaag-link-group">
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <nav class="denhaag-link-group__navigation" aria-labelledby="denhaag-link-group-navigation-1">
-        <ul
-          id="denhaag-link-group-navigation-1"
-          class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list"
-        >
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Rijbewijs</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Akten</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Verklaringen</span>
-            </a>
-          </li>
-        </ul>
-      </nav>
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Rijbewijs</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Akten</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Verklaringen</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -180,146 +175,141 @@ import readme from "../../README.md";
     <div class="denhaag-link-group">
       <img class="denhaag-link-group__image" src="https://via.placeholder.com/140x140" alt="placeholder" />
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <nav class="denhaag-link-group__navigation" aria-labelledby="denhaag-link-group-navigation-2">
-        <ul
-          id="denhaag-link-group-navigation-2"
-          class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list"
-        >
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">
-                Paspoort en identiteitskaart. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non
-                dignissimos. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non dignissimos.
-              </span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Rijbewijs</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Akten</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Verklaringen</span>
-            </a>
-          </li>
-        </ul>
-      </nav>
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">
+              Paspoort en identiteitskaart. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non
+              dignissimos. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non dignissimos.
+            </span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Rijbewijs</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Akten</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Verklaringen</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -332,143 +322,138 @@ import readme from "../../README.md";
   <Story name="Dark background">
     <div class="denhaag-link-group denhaag-link-group--dark" style={{ backgroundColor: "#2D2D2D", padding: "1rem" }}>
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
-      <nav class="denhaag-link-group__navigation" aria-labelledby="denhaag-link-group-navigation-3">
-        <ul
-          id="denhaag-link-group-navigation-3"
-          class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list"
-        >
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Rijbewijs</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Akten</span>
-            </a>
-          </li>
-          <li class="denhaag-link-group__navigation-list-item">
-            <a
-              href="https://nl-design-system.github.io/denhaag/"
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-            >
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-              <span class="denhaag-link__label">Verklaringen</span>
-            </a>
-          </li>
-        </ul>
-      </nav>
+      <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__navigation-list">
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Rijbewijs</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Akten</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__navigation-list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <span class="denhaag-link__icon">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+            <span class="denhaag-link__label">Verklaringen</span>
+          </a>
+        </li>
+      </ul>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}

--- a/proprietary/Components/src/denhaag/highlighted-links.tokens.json
+++ b/proprietary/Components/src/denhaag/highlighted-links.tokens.json
@@ -5,7 +5,7 @@
       "padding-block-start": { "value": "{denhaag.space.block.3xl}" },
       "padding-block-end": { "value": "{denhaag.space.block.3xl}" },
       "width": { "value": "100%" },
-      "navigation-list": {
+      "list": {
         "display": { "value": "grid" },
         "gap": { "value": "0 {denhaag.space.block.3xl}" },
         "grid-template-columns": { "value": "repeat(2, 1fr)" },

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -19,23 +19,23 @@
         "padding-block": { "value": "{denhaag.space.block.xs}" }
       },
       "dark": {
-        "denhaag-link-color": { "value": "{denhaag.color.white}" },
+        "link-color": { "value": "{denhaag.color.white}" },
         "caption-color": { "value": "{denhaag.color.ocher.3}" },
-        "denhaag-link-focus-outline-color": { "value": "{denhaag.color.ocher.2}" }
+        "link-focus-outline-color": { "value": "{denhaag.color.ocher.2}" }
       },
-      "denhaag-link-hover": {
+      "link-hover": {
         "text-decoration": { "value": "underline" }
       },
-      "denhaag-link-with-icon-start": {
+      "link-with-icon-start": {
         "display": { "value": "inline-flex" },
         "padding-block-start": { "value": "0" },
         "padding-block-end": { "value": "0" }
       },
-      "denhaag-link-icon": {
+      "link-icon": {
         "font-size": { "value": "0.75rem" },
         "width": { "value": "0.625rem" }
       },
-      "denhaag-link-icon-denhaag-icon": {
+      "link-icon-denhaag-icon": {
         "align-self": { "value": "start" },
         "padding-block-start": { "value": "{denhaag.space.block.3xs}" },
         "height": { "value": "0.85rem" }

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -21,7 +21,7 @@
       "dark": {
         "denhaag-link-color": { "value": "{denhaag.color.white}" },
         "caption-color": { "value": "{denhaag.color.ocher.3}" },
-        "denhaag-link-focus-border-color": { "value": "{denhaag.color.ocher.2}" }
+        "denhaag-link-focus-outline-color": { "value": "{denhaag.color.ocher.2}" }
       },
       "denhaag-link-hover": {
         "text-decoration": { "value": "underline" }

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -9,13 +9,13 @@
       "caption": {
         "margin-block": { "value": "0" }
       },
-      "navigation-list": {
+      "list": {
         "margin-block-start": { "value": "{denhaag.space.block.xs}" },
         "margin-block-end": { "value": "{denhaag.space.block.md}" },
         "list-style": { "value": "none" },
         "padding-inline-start": { "value": "0" }
       },
-      "navigation-list-item": {
+      "list-item": {
         "padding-block": { "value": "{denhaag.space.block.xs}" }
       },
       "dark": {


### PR DESCRIPTION
### Solve: GDH-505 https://acato-nl.atlassian.net/browse/GDH-505

- overkill usage of nav tags when highlighted links + link group components are used as content on page
- link focus color contrast on dark variation of link group component to low

### Purpose:

- remove unnecesary nav tags, for accessibility purpose
- remove unnecesary id's in ul tags, previously used as reference for aria-labelledby in the nav tag
- add dark link focus styling to dark variation of link group component, for higher contrast (accessibility)

closes #1030