### PR TITLE
refactor(cta-image-content): change figure + figcaption

### DIFF
--- a/components/CtaImageContent/src/stories/bem.stories.mdx
+++ b/components/CtaImageContent/src/stories/bem.stories.mdx
@@ -28,14 +28,14 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
-    <figure class="denhaag-cta-image-content">
+    <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
@@ -59,8 +59,8 @@ import readme from "../../README.md";
             </svg>
           </span>
         </a>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -70,14 +70,14 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Filled">
-    <figure class="denhaag-cta-image-content denhaag-cta-image-content--filled">
+    <div class="denhaag-cta-image-content denhaag-cta-image-content--filled">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
@@ -101,8 +101,8 @@ import readme from "../../README.md";
             </svg>
           </span>
         </a>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -112,20 +112,20 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Without action">
-    <figure class="denhaag-cta-image-content">
+    <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
         </p>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -135,14 +135,14 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
-    <figure class="denhaag-cta-image-content denhaag-cta-image-content--focus">
+    <div class="denhaag-cta-image-content denhaag-cta-image-content--focus">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
@@ -166,8 +166,8 @@ import readme from "../../README.md";
             </svg>
           </span>
         </a>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -177,14 +177,14 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hover">
-    <figure class="denhaag-cta-image-content denhaag-cta-image-content--hover">
+    <div class="denhaag-cta-image-content denhaag-cta-image-content--hover">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
@@ -208,8 +208,8 @@ import readme from "../../README.md";
             </svg>
           </span>
         </a>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -219,14 +219,14 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Small">
-    <figure class="denhaag-cta-image-content">
+    <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
         src="https://via.placeholder.com/650x350/90D40166"
-        alt="placeholder"
+        alt=""
         loading="lazy"
       />
-      <figcaption class="denhaag-cta-image-content__content">
+      <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title denhaag-cta-image-content__title--small">
           Title
         </h3>
@@ -252,8 +252,8 @@ import readme from "../../README.md";
             </svg>
           </span>
         </a>
-      </figcaption>
-    </figure>
+      </div>
+    </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>


### PR DESCRIPTION
### Solve: 
--Quote Fernand van Olphen (accessibility The Hague):
Figure and figcaption are elements that are not necessary for accessibility.
We have decided not to give the image in this component alternative text.
A figcaption is an element that is used to complement the figure element.
It says something extra about what is in the figure element.
But since the image has no alternative text, the figcaption complements... nothing.

### Purpose:

- accessibility

closes #1031
