### PR TITLE
feat(floating-contact): remove label change on click

### DIFF
--- a/components/FloatingContact/src/FloatingContact.js
+++ b/components/FloatingContact/src/FloatingContact.js
@@ -29,9 +29,6 @@ export default class FloatingContact {
   toggleEvents() {
     const state = this.toggle.getAttribute('aria-expanded') === 'false';
     this.toggle.setAttribute('aria-expanded', state ? 'true' : 'false');
-    this.labelWrapper.innerHTML = state
-      ? this.toggle?.dataset?.labelClose || 'Close'
-      : this.toggle?.dataset?.labelOpen || 'Open';
     this.links.forEach((link) => (link.tabIndex = state ? 0 : -1));
   }
 

--- a/components/FloatingContact/src/stories/bem.stories.mdx
+++ b/components/FloatingContact/src/stories/bem.stories.mdx
@@ -54,8 +54,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -211,8 +209,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--hover"
           aria-expanded="false"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -368,8 +364,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch denhaag-floating-contact-switch--focus"
           aria-expanded="false"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -525,8 +519,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="false"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -680,8 +672,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -837,8 +827,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact
@@ -994,8 +982,6 @@ import { useEffect, useMemo } from "@storybook/client-api";
           class="denhaag-floating-contact-switch"
           aria-expanded="true"
           aria-label="Contact"
-          data-label-open="Contact"
-          data-label-close="Sluiten"
         >
           <div id="denhaag-floating-contact__label" class="denhaag-floating-contact-switch__label">
             Contact


### PR DESCRIPTION
Applying feedback of Fernand (accessibility expert): Removing the label-update due to an accessibility issue which will occur for screenreader

Example screenreader old way:
- Open contact;
- Close Close;

Example screenreader new way:
- Open contact;
- Close contact;

