### PR TITLE
fix(link-group): fix image, apply margin instead of padding

### DIFF
--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -1,5 +1,5 @@
 .denhaag-link-group__image {
-  padding-block-end: var(--denhaag-link-group-image-padding-block-end);
+  margin-block-end: var(--denhaag-link-group-image-margin-block-end);
   width: var(--denhaag-link-group-image-size);
   height: var(--denhaag-link-group-image-size);
   object-fit: var(--denhaag-link-group-image-object-fit);

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -6,7 +6,7 @@
 }
 
 .denhaag-link-group__caption {
-  margin-block-start: var(--denhaag-link-group-caption-margin-block);
+  margin-block-start: var(--denhaag-link-group-caption-margin-block) !important;
   margin-block-end: var(--denhaag-link-group-caption-margin-block);
 }
 

--- a/proprietary/Components/src/denhaag/link-group.tokens.json
+++ b/proprietary/Components/src/denhaag/link-group.tokens.json
@@ -2,7 +2,7 @@
   "denhaag": {
     "link-group": {
       "image": {
-        "padding-block-end": { "value": "{denhaag.space.block.md}" },
+        "margin-block-end": { "value": "{denhaag.space.block.md}" },
         "size": { "value": "8.75rem" },
         "object-fit": { "value": "cover" }
       },


### PR DESCRIPTION
Fixing issue where padding was used, causing the image to shrink instead of applying whitespace below the image.

Sadly the important is needed, otherwise the H3 margin-block-start overrules the caption style.