### PR TITLE
style(accordion): styling corrections panel titles

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -25,6 +25,10 @@
 }
 
 .denhaag-accordion__panel {
+  position: inherit;
+  width: inherit;
+  font-family: inherit;
+  font-weight: inherit;
   outline: var(--denhaag-accordion-panel-outline);
   align-items: var(--denhaag-accordion-panel-align-items);
   border-radius: var(--denhaag-accordion-panel-border-radius);
@@ -34,15 +38,14 @@
   padding-block-start: var(--denhaag-accordion-panel-padding-block);
   padding-block-end: var(--denhaag-accordion-panel-padding-block);
   padding-inline-end: var(--denhaag-accordion-panel-padding-inline);
-  position: relative;
   min-height: var(--denhaag-accordion-panel-min-height);
   margin-block-start: var(--denhaag-accordion-panel-margin-block);
   margin-block-end: var(--denhaag-accordion-panel-margin-block);
-  width: var(--denhaag-accordion-panel-width);
+  font-size: var(--denhaag-accordion-panel-font-size);
 }
 
-.denhaag-accordion__panel > .denhaag-icon {
-  color: var(--denhaag-accordion-icon-color);
+.denhaag-accordion__panel .denhaag-icon {
+  color: inherit;
   position: var(--denhaag-accordion-icon-position);
   top: var(--denhaag-accordion-icon-top);
   right: var(--denhaag-accordion-icon-right);
@@ -50,29 +53,36 @@
 }
 
 .denhaag-accordion__title {
-  --utrecht-heading-5-margin-block-start: 0;
-  --utrecht-heading-5-margin-block-end: 0;
-  --utrecht-heading-5-font-family: var(--denhaag-accordion-font-family);
-  --utrecht-heading-5-font-weight: 400;
-
-  background: var(--denhaag-accordion-title-background);
-  border: var(--denhaag-accordion-title-border);
-  flex-grow: var(--denhaag-accordion-title-flex-grow);
+  font-family: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  background: inherit;
+  border: inherit;
+  text-align: inherit;
   hyphens: auto;
+  margin-block-start: 0;
+  margin-block-end: 0;
+  flex-grow: var(--denhaag-accordion-title-flex-grow);
   padding-block-start: var(--denhaag-accordion-title-padding-block);
   padding-block-end: var(--denhaag-accordion-title-padding-block);
   padding-inline-start: var(--denhaag-accordion-title-padding-inline);
   padding-inline-end: calc(
     (var(--denhaag-accordion-title-padding-inline) * 2) + var(--denhaag-accordion-icon-width, 0)
   );
-  text-align: var(--denhaag-accordion-title-text-align);
 }
 
-.denhaag-accordion__panel--focus .denhaag-accordion__title,
-.denhaag-accordion__panel--focus .denhaag-icon,
-.denhaag-accordion__title--hover,
-.denhaag-accordion__title--hover + .denhaag-icon {
+.denhaag-accordion__title--focus,
+.denhaag-accordion__title--focus + .denhaag-icon,
+.denhaag-accordion__panel--hover .denhaag-accordion__title,
+.denhaag-accordion__panel--hover .denhaag-icon,
+.denhaag-accordion__title:focus-visible {
   color: var(--denhaag-accordion-panel-color);
+  outline: var(--denhaag-accordion-panel-outline);
+}
+
+.denhaag-accordion__container--open .denhaag-accordion__title,
+.denhaag-accordion__container--open .denhaag-icon {
+  color: inherit;
 }
 
 .denhaag-accordion__title--disabled,
@@ -80,6 +90,28 @@
 .denhaag-accordion__title--disabled + .denhaag-icon,
 .denhaag-accordion__title[disabled] + .denhaag-icon {
   z-index: 1;
+}
+
+.denhaag-accordion__title:focus-visible,
+.denhaag-accordion__title:focus-visible + .denhaag-icon {
+  color: var(--denhaag-accordion-panel-color);
+  outline: var(--denhaag-accordion-panel-outline);
+}
+
+.denhaag-accordion__container--open .denhaag-accordion__panel--hover .denhaag-accordion__title,
+.denhaag-accordion__container--open .denhaag-accordion__panel--hover .denhaag-icon {
+  color: var(--denhaag-accordion-container-open-color);
+}
+
+.denhaag-accordion__container--open .denhaag-accordion__panel:hover .denhaag-accordion__title,
+.denhaag-accordion__container--open .denhaag-accordion__panel:hover .denhaag-icon {
+  color: var(--denhaag-accordion-container-open-color);
+}
+
+.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
+.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]) + .denhaag-icon {
+  color: var(--denhaag-accordion-panel-color);
+  outline: var(--denhaag-accordion-panel-outline);
 }
 
 .denhaag-accordion__title--disabled::before,
@@ -94,14 +126,8 @@
   z-index: -1;
 }
 
-.denhaag-accordion__title:focus-visible,
-.denhaag-accordion__title--focus {
-  color: var(--denhaag-accordion-panel-color);
-  outline: none;
-}
-
-.denhaag-accordion__title:focus-visible::after,
-.denhaag-accordion__title--focus::after {
+.denhaag-accordion__title--focus::after,
+.denhaag-accordion__title:focus-visible::after {
   border-radius: var(--denhaag-accordion-title-focus-border-radius);
   content: "";
   height: 100%;
@@ -117,31 +143,11 @@
   --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-title-color);
   --denhaag-accordion-icon-color: var(--denhaag-accordion-container-open-icon-color);
   --denhaag-accordion-icon-transform: var(--denhaag-accordion-container-open-icon-transform);
-  --utrecht-heading-font-weight: var(--denhaag-accordion-container-open-title-font-weight);
 }
 
-.denhaag-accordion__container--open .denhaag-accordion__panel > .denhaag-icon:hover {
-  --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-color);
-}
-
-.denhaag-accordion__container--open .denhaag-accordion__title:not([disabled]) {
-  --utrecht-heading-5-color: var(--denhaag-accordion-panel-color);
-  --utrecht-heading-5-font-weight: 700;
-}
-
-.denhaag-accordion__panel:focus .denhaag-accordion__title:not([disabled]),
-.denhaag-accordion__panel:focus .denhaag-accordion__title:not([disabled]) + .denhaag-icon,
-.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
-.denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]) + .denhaag-icon {
-  color: var(--denhaag-accordion-panel-color);
-}
-
-.denhaag-accordion__container--open .denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
-.denhaag-accordion__container--open
-  .denhaag-accordion__panel:hover
-  .denhaag-accordion__title:not([disabled])
-  + .denhaag-icon {
-  color: var(--denhaag-accordion-container-open-color);
+.denhaag-accordion__container--open .denhaag-accordion__panel {
+  color: var(--denhaag-accordion-container-open-panel-color);
+  font-weight: var(--denhaag-accordion-container-open-panel-font-weight);
 }
 
 .denhaag-accordion__details {

--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -52,6 +52,8 @@
 .denhaag-accordion__title {
   --utrecht-heading-5-margin-block-start: 0;
   --utrecht-heading-5-margin-block-end: 0;
+  --utrecht-heading-5-font-family: var(--denhaag-accordion-font-family);
+  --utrecht-heading-5-font-weight: 400;
 
   background: var(--denhaag-accordion-title-background);
   border: var(--denhaag-accordion-title-border);
@@ -94,6 +96,7 @@
 
 .denhaag-accordion__title:focus-visible,
 .denhaag-accordion__title--focus {
+  color: var(--denhaag-accordion-panel-color);
   outline: none;
 }
 
@@ -117,9 +120,13 @@
   --utrecht-heading-font-weight: var(--denhaag-accordion-container-open-title-font-weight);
 }
 
-.denhaag-accordion__container--open .denhaag-accordion__panel:hover,
 .denhaag-accordion__container--open .denhaag-accordion__panel > .denhaag-icon:hover {
   --denhaag-accordion-title-color: var(--denhaag-accordion-container-open-color);
+}
+
+.denhaag-accordion__container--open .denhaag-accordion__title:not([disabled]) {
+  --utrecht-heading-5-color: var(--denhaag-accordion-panel-color);
+  --utrecht-heading-5-font-weight: 700;
 }
 
 .denhaag-accordion__panel:focus .denhaag-accordion__title:not([disabled]),
@@ -127,6 +134,14 @@
 .denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
 .denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]) + .denhaag-icon {
   color: var(--denhaag-accordion-panel-color);
+}
+
+.denhaag-accordion__container--open .denhaag-accordion__panel:hover .denhaag-accordion__title:not([disabled]),
+.denhaag-accordion__container--open
+  .denhaag-accordion__panel:hover
+  .denhaag-accordion__title:not([disabled])
+  + .denhaag-icon {
+  color: var(--denhaag-accordion-container-open-color);
 }
 
 .denhaag-accordion__details {

--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -44,7 +44,7 @@
   font-size: var(--denhaag-accordion-panel-font-size);
 }
 
-.denhaag-accordion__panel .denhaag-icon {
+.denhaag-accordion__panel > .denhaag-icon {
   color: inherit;
   position: var(--denhaag-accordion-icon-position);
   top: var(--denhaag-accordion-icon-top);

--- a/components/Accordion/src/stories/bem.stories.mdx
+++ b/components/Accordion/src/stories/bem.stories.mdx
@@ -844,7 +844,7 @@ import readme from "../../README.md";
         </div>
       </div>
       <div class="denhaag-accordion__container denhaag-accordion__container--open" open>
-        <h3 class="denhaag-accordion__panel denhaag-accordion__panel">
+        <h3 class="denhaag-accordion__panel">
           <button
             aria-expanded="true"
             aria-controls="open-accordion-details-two"

--- a/components/Accordion/src/stories/bem.stories.mdx
+++ b/components/Accordion/src/stories/bem.stories.mdx
@@ -40,7 +40,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="default-accordion-details-one"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="default-accordion1id"
           >
             Accordion
@@ -79,7 +79,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="default-accordion-details-two"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="default-accordion2id"
           >
             Accordion
@@ -118,7 +118,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="default-accordion-details-three"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="default-accordion3id"
           >
             Integer blandit libero quis risus maximus auctor. Proin ullamcorper, metus.
@@ -157,134 +157,6 @@ import readme from "../../README.md";
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
 
-### Open
-
-<Canvas>
-  {/* eslint-disable react/no-unknown-property */}
-  <Story name="Open">
-    <div class="denhaag-accordion">
-      <div class="denhaag-accordion__container">
-        <h3 class="denhaag-accordion__panel">
-          <button
-            aria-expanded="false"
-            aria-controls="open-accordion-details-one"
-            class="utrecht-heading-5 denhaag-accordion__title"
-            id="open-accordion1id"
-          >
-            Accordion
-          </button>
-          <svg
-            class="denhaag-icon"
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </h3>
-        <div
-          id="open-accordion-details-one"
-          role="region"
-          aria-labelledby="open-accordion1id"
-          class="denhaag-accordion__details"
-        >
-          <p class="utrecht-paragraph">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-            leo lobortis eget.
-          </p>
-        </div>
-      </div>
-      <div class="denhaag-accordion__container denhaag-accordion__container--open" open>
-        <h3 class="denhaag-accordion__panel">
-          <button
-            aria-expanded="true"
-            aria-controls="open-accordion-details-two"
-            class="utrecht-heading-5 denhaag-accordion__title"
-            id="open-accordion2id"
-          >
-            Accordion
-          </button>
-          <svg
-            class="denhaag-icon"
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </h3>
-        <div
-          id="open-accordion-details-two"
-          role="region"
-          aria-labelledby="open-accordion2id"
-          class="denhaag-accordion__details"
-        >
-          <p class="utrecht-paragraph">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-            leo lobortis eget.
-          </p>
-        </div>
-      </div>
-      <div class="denhaag-accordion__container">
-        <h3 class="denhaag-accordion__panel">
-          <button
-            aria-expanded="false"
-            aria-controls="open-accordion-details-three"
-            class="utrecht-heading-5 denhaag-accordion__title"
-            id="open-accordion3id"
-          >
-            Accordion
-          </button>
-          <svg
-            class="denhaag-icon"
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </h3>
-        <div
-          id="open-accordion-details-three"
-          role="region"
-          aria-labelledby="open-accordion3id"
-          class="denhaag-accordion__details"
-        >
-          <p class="utrecht-paragraph">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
-            leo lobortis eget.
-          </p>
-        </div>
-      </div>
-    </div>
-  </Story>
-  {/* eslint-enable react/no-unknown-property */}
-</Canvas>
-
 ### Disabled
 
 <Canvas>
@@ -296,7 +168,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="disabled-accordion-details-one"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="disabled-accordion1id"
           >
             Accordion
@@ -335,7 +207,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="disabled-accordion-details-two"
-            class="utrecht-heading-5 denhaag-accordion__title denhaag-accordion__title--disabled"
+            class="denhaag-accordion__title denhaag-accordion__title--disabled"
             id="disabled-accordion2id"
             disabled
           >
@@ -375,7 +247,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="disabled-accordion-details-three"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="disabled-accordion3id"
           >
             Accordion
@@ -425,7 +297,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="focus-accordion-details-one"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="focus-accordion1id"
           >
             Accordion
@@ -464,7 +336,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="focus-accordion-details-two"
-            class="utrecht-heading-5 denhaag-accordion__title denhaag-accordion__title--focus"
+            class="denhaag-accordion__title denhaag-accordion__title--focus"
             id="focus-accordion2id"
           >
             Accordion
@@ -503,7 +375,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="focus-accordion-details-three"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="focus-accordion3id"
           >
             Accordion
@@ -553,7 +425,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="hover-accordion-details-one"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="hover-accordion1id"
           >
             Accordion
@@ -588,11 +460,11 @@ import readme from "../../README.md";
         </div>
       </div>
       <div class="denhaag-accordion__container">
-        <h3 class="denhaag-accordion__panel">
+        <h3 class="denhaag-accordion__panel denhaag-accordion__panel--hover">
           <button
             aria-expanded="false"
             aria-controls="hover-accordion-details-two"
-            class="utrecht-heading-5 denhaag-accordion__title denhaag-accordion__title--hover"
+            class="denhaag-accordion__title"
             id="hover-accordion2id"
           >
             Accordion
@@ -631,7 +503,7 @@ import readme from "../../README.md";
           <button
             aria-expanded="false"
             aria-controls="hover-accordion-details-three"
-            class="utrecht-heading-5 denhaag-accordion__title"
+            class="denhaag-accordion__title"
             id="hover-accordion3id"
           >
             Accordion
@@ -657,6 +529,390 @@ import readme from "../../README.md";
           id="hover-accordion-details-three"
           role="region"
           aria-labelledby="hover-accordion3id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Open
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Open">
+    <div class="denhaag-accordion">
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-one"
+            class="denhaag-accordion__title"
+            id="open-accordion1id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-one"
+          role="region"
+          aria-labelledby="open-accordion1id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container denhaag-accordion__container--open" open>
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="true"
+            aria-controls="open-accordion-details-two"
+            class="denhaag-accordion__title"
+            id="open-accordion2id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-two"
+          role="region"
+          aria-labelledby="open-accordion2id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-three"
+            class="denhaag-accordion__title"
+            id="open-accordion3id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-three"
+          role="region"
+          aria-labelledby="open-accordion3id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Open - hover
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Open - hover">
+    <div class="denhaag-accordion">
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-one"
+            class="denhaag-accordion__title"
+            id="open-accordion1id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-one"
+          role="region"
+          aria-labelledby="open-accordion1id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container denhaag-accordion__container--open" open>
+        <h3 class="denhaag-accordion__panel denhaag-accordion__panel--hover">
+          <button
+            aria-expanded="true"
+            aria-controls="open-accordion-details-two"
+            class="denhaag-accordion__title"
+            id="open-accordion2id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-two"
+          role="region"
+          aria-labelledby="open-accordion2id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-three"
+            class="denhaag-accordion__title"
+            id="open-accordion3id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-three"
+          role="region"
+          aria-labelledby="open-accordion3id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Open - focus
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Open - focus">
+    <div class="denhaag-accordion">
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-one"
+            class="denhaag-accordion__title"
+            id="open-accordion1id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-one"
+          role="region"
+          aria-labelledby="open-accordion1id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container denhaag-accordion__container--open" open>
+        <h3 class="denhaag-accordion__panel denhaag-accordion__panel">
+          <button
+            aria-expanded="true"
+            aria-controls="open-accordion-details-two"
+            class="denhaag-accordion__title denhaag-accordion__title--focus"
+            id="open-accordion2id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-two"
+          role="region"
+          aria-labelledby="open-accordion2id"
+          class="denhaag-accordion__details"
+        >
+          <p class="utrecht-paragraph">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit
+            leo lobortis eget.
+          </p>
+        </div>
+      </div>
+      <div class="denhaag-accordion__container">
+        <h3 class="denhaag-accordion__panel">
+          <button
+            aria-expanded="false"
+            aria-controls="open-accordion-details-three"
+            class="denhaag-accordion__title"
+            id="open-accordion3id"
+          >
+            Accordion
+          </button>
+          <svg
+            class="denhaag-icon"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M5.293 8.293a1 1 0 011.414 0L12 13.586l5.293-5.293a1 1 0 111.414 1.414l-6 6a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </h3>
+        <div
+          id="open-accordion-details-three"
+          role="region"
+          aria-labelledby="open-accordion3id"
           class="denhaag-accordion__details"
         >
           <p class="utrecht-paragraph">

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -24,9 +24,6 @@
           "title": {
             "color": {
               "value": "{denhaag.color.green.3}"
-            },
-            "font-weight": {
-              "value": "{denhaag.typography.weight.bold}"
             }
           },
           "icon": {
@@ -35,6 +32,14 @@
             },
             "transform": {
               "value": "rotate(180deg)"
+            }
+          },
+          "panel": {
+            "color": {
+              "value": "{denhaag.color.green.3}"
+            },
+            "font-weight": {
+              "value": "{denhaag.typography.weight.bold}"
             }
           }
         }
@@ -70,22 +75,13 @@
         "text-decoration": {
           "value": "none"
         },
-        "width": {
-          "value": "100%"
+        "font-size": {
+          "value": "{denhaag.typography.scale.base.font-size}"
         }
       },
       "title": {
-        "background": {
-          "value": "none"
-        },
-        "border": {
-          "value": 0
-        },
         "flex-grow": {
           "value": 1
-        },
-        "text-align": {
-          "value": "left"
         },
         "padding-inline": {
           "value": "{denhaag.space.inline.md}"
@@ -121,7 +117,7 @@
           "value": "{denhaag.space.inline.md}"
         },
         "width": {
-          "value": "1.5rem"
+          "value": "{denhaag.space.inline.xl}"
         }
       },
       "details": {
@@ -129,10 +125,10 @@
           "value": 0
         },
         "padding-block-end": {
-          "value": "1rem"
+          "value": "{denhaag.space.block.md}"
         },
         "padding-inline": {
-          "value": "1rem"
+          "value": "{denhaag.space.inline.md}"
         },
         "margin-inline-end": {
           "value": "calc((2 * 1rem) + (2 * 0.75rem))"


### PR DESCRIPTION
### Solve: 
wrong/not up-to-date styling https://acato-nl.atlassian.net/browse/GDH-665

### Purpose: 
correct font-size, font-weight, font-family and color for accorion panel titles

- closed and opened: font-size 18px, font-family TheSans
- when closed: default (font-weight 400), hover (font-weight 400, color green 3) and focus (font-weight 400, color green 3)
- when opened: default (font-weight 700 ,color green 3), hover (font-weight 700, color green 4) and focus (font-weight 700, color green 3)

### EXTRA: 

- overhaul/refactor of bem, css and tokens.
- added 'open', 'open - hover' and 'open - focus' bem for more clearity in styling

### Figma: 
https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1585%3A0

closes #1041