### PR TITLE
Style/article meta change in margins

### DIFF
--- a/components/ArticleMeta/README.md
+++ b/components/ArticleMeta/README.md
@@ -29,7 +29,7 @@ If there are edits on the same day as de publication date, show both on the same
 
 **Structure**
 
-Publication and edited date: small divider padding-left and padding-right 12px
+Publication and edited date: small divider padding-left and padding-right 12px, margin-top 32px, margin-bottom 64px
 
 ## Accessibility
 

--- a/components/ArticleMeta/src/index.scss
+++ b/components/ArticleMeta/src/index.scss
@@ -6,6 +6,8 @@
 }
 
 .denhaag-article-meta {
+  border-block-start: var(--denhaag-article-meta-border-width) var(--denhaag-article-meta-border-style)
+    var(--denhaag-article-meta-border-color);
   color: var(--denhaag-article-meta-color);
   display: flex;
   flex-direction: column;
@@ -16,8 +18,7 @@
   font-size: var(--denhaag-article-meta-font-size);
   padding-block-start: var(--denhaag-article-meta-padding-block-start);
   padding-block-end: var(--denhaag-article-meta-padding-block-end);
-  border-block-start: var(--denhaag-article-meta-border-width) var(--denhaag-article-meta-border-style)
-    var(--denhaag-article-meta-border-color);
+  margin-block-start: var(--denhaag-article-meta-margin-block-start);
 }
 
 .denhaag-article-meta--horizontal {

--- a/proprietary/Components/src/denhaag/article-meta.tokens.json
+++ b/proprietary/Components/src/denhaag/article-meta.tokens.json
@@ -32,6 +32,9 @@
         "value": "{denhaag.space.block.md}"
       },
       "padding-block-end": {
+        "value": "{denhaag.space.block.5xl}"
+      },
+      "margin-block-start": {
         "value": "{denhaag.space.block.2xl}"
       },
       "horizontal": {


### PR DESCRIPTION
Apply new styles for the article-meta block, due to test-feedback which caused a minor design-change.

**Old:**
![Screenshot 2022-08-02 at 08 49 17](https://user-images.githubusercontent.com/94894596/182318997-ed006cad-776d-47c7-8a60-4e9daed0cdce.png)

**New:**
![Screenshot 2022-08-02 at 09 32 37](https://user-images.githubusercontent.com/94894596/182318989-5efc6e12-a024-49ee-a426-40d5ab8bb5b2.png)



**Closing issues**

Closing refactor branches:
closes #1040 #1038 
