### PR TITLE
fix(table): remove tabindex for accessibility

### DIFF
--- a/components/Table/src/TableRow.tsx
+++ b/components/Table/src/TableRow.tsx
@@ -7,10 +7,10 @@ export type TableRowProps = HTMLAttributes<HTMLTableRowElement>;
  * TableRow component based on the <tr> element.
  * Defines a row of cells in a table. The row's cells can then be established using a mix of <TableCell> (<td>) and <TableHeader> (<th>) elements.
  */
-export const TableRow: React.FC<TableRowProps> = ({ className, tabIndex = 0, ...props }: TableRowProps) => {
+export const TableRow: React.FC<TableRowProps> = ({ className, ...props }: TableRowProps) => {
   const rootClassNames = clsx('denhaag-table__row', className);
   return (
-    <tr className={rootClassNames} {...props} tabIndex={tabIndex}>
+    <tr className={rootClassNames} {...props}>
       {props.children}
     </tr>
   );

--- a/components/Table/src/stories/bem.stories.mdx
+++ b/components/Table/src/stories/bem.stories.mdx
@@ -27,7 +27,7 @@ import readme from "../../README.md";
     <table class="denhaag-table">
       <caption class="denhaag-table__caption">He-Man and Skeletor facts</caption>
       <thead class="denhaag-table__head">
-        <tr class="denhaag-table__row" tabindex="-1">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">&nbsp;</td>
           <th class="denhaag-table__heading" scope="col" aria-sort="none">
             He-Man
@@ -38,21 +38,21 @@ import readme from "../../README.md";
         </tr>
       </thead>
       <tbody class="denhaag-table__body">
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Role
           </th>
           <td class="denhaag-table__cell">Hero</td>
           <td class="denhaag-table__cell">Villain</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Weapon
           </th>
           <td class="denhaag-table__cell">Power Sword</td>
           <td class="denhaag-table__cell">Havoc Staff</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Dark secret
           </th>
@@ -73,7 +73,7 @@ import readme from "../../README.md";
     <table class="denhaag-table">
       <caption class="denhaag-table__caption">He-Man and Skeletor facts</caption>
       <thead class="denhaag-table__head">
-        <tr class="denhaag-table__row" tabindex="-1">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">&nbsp;</td>
           <th class="denhaag-table__heading" scope="col" aria-sort="none">
             He-Man
@@ -84,7 +84,7 @@ import readme from "../../README.md";
         </tr>
       </thead>
       <tbody class="denhaag-table__body">
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Role
           </th>
@@ -98,7 +98,7 @@ import readme from "../../README.md";
           <td class="denhaag-table__cell">Power Sword</td>
           <td class="denhaag-table__cell">Havoc Staff</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Dark secret
           </th>
@@ -119,7 +119,7 @@ import readme from "../../README.md";
     <table class="denhaag-table">
       <caption class="denhaag-table__caption">He-Man and Skeletor facts</caption>
       <thead class="denhaag-table__head">
-        <tr class="denhaag-table__row" tabindex="-1">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">&nbsp;</td>
           <th class="denhaag-table__heading" scope="col" aria-sort="none">
             He-Man
@@ -130,7 +130,7 @@ import readme from "../../README.md";
         </tr>
       </thead>
       <tbody class="denhaag-table__body">
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Role
           </th>
@@ -144,7 +144,7 @@ import readme from "../../README.md";
           <td class="denhaag-table__cell">Power Sword</td>
           <td class="denhaag-table__cell">Havoc Staff</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="row">
             Dark secret
           </th>
@@ -165,7 +165,7 @@ import readme from "../../README.md";
     <table class="denhaag-table">
       <caption class="denhaag-table__caption">Kosten overzicht</caption>
       <thead class="denhaag-table__head">
-        <tr class="denhaag-table__row" tabindex="-1">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="col" aria-sort="none">
             Soort kosten
           </th>
@@ -175,15 +175,15 @@ import readme from "../../README.md";
         </tr>
       </thead>
       <tbody class="denhaag-table__body">
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">Beheerkosten (administratiekosten) per jaar</td>
           <td class="denhaag-table__cell">&euro; 27,50</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">Afkoopsom beheerkosten</td>
           <td class="denhaag-table__cell">&euro; 232</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">Splitsingskosten per appartmentsrecht of per recht van erfpacht</td>
           <td class="denhaag-table__cell">&euro; 153</td>
         </tr>
@@ -203,7 +203,7 @@ import readme from "../../README.md";
         Voorbeeld met extreem lange titel die je eigenlijk wilt voorkomen.
       </caption>
       <thead class="denhaag-table__head">
-        <tr class="denhaag-table__row" tabindex="-1">
+        <tr class="denhaag-table__row">
           <th class="denhaag-table__heading" scope="col" aria-sort="none">
             Titel met een hele lange omschrijving die overloopt
           </th>
@@ -216,17 +216,17 @@ import readme from "../../README.md";
         </tr>
       </thead>
       <tbody class="denhaag-table__body">
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">maandag</td>
           <td class="denhaag-table__cell">11.00 tot 12,30</td>
           <td class="denhaag-table__cell">Alle leeftijden</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">dinsdag</td>
           <td class="denhaag-table__cell">8.30 tot 11,30</td>
           <td class="denhaag-table__cell">Alle leeftijden</td>
         </tr>
-        <tr class="denhaag-table__row" tabindex="0">
+        <tr class="denhaag-table__row">
           <td class="denhaag-table__cell">donderdag</td>
           <td class="denhaag-table__cell">11.00 tot 12,30</td>
           <td class="denhaag-table__cell">Alle leeftijden</td>


### PR DESCRIPTION
### Solve: https://acato-nl.atlassian.net/browse/GDH-420

- suggestion there is any action on the table row (when ther isn't any) tabbing with keyboard focus

### Purpose:

- cleanup the tabindex on the table rows, so suggestion of action is removed

closes #1044