### PR TITLE
docs: login page storybook template

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: [
-    './stories/*.stories.mdx',
+    './stories/**/*.stories.mdx',
     '../components/*/src/**/*.stories.@(js|jsx|ts|tsx)',
     '../components/*/src/**/*.stories.mdx',
   ],

--- a/.storybook/stories/templates/Login-page.stories.mdx
+++ b/.storybook/stories/templates/Login-page.stories.mdx
@@ -1,0 +1,116 @@
+import { Meta, Canvas } from "@storybook/addon-docs";
+import { AuthenticationBlock, defaultArgs } from "/components/AuthenticationBlock/src/css/story-template";
+import { Heading1, Paragraph } from "/components/Typography/src";
+import clsx from "clsx";
+
+export const FormToggle = ({ checked, disabled, focus, hover }) => {
+  // TODO: use Utrecht story-template and use checkbox with label
+  return (
+    <div
+      className={clsx(
+        "utrecht-form-toggle",
+        checked && "utrecht-form-toggle--checked",
+        !checked && "utrecht-form-toggle--not-checked",
+        disabled && "utrecht-form-toggle--disabled",
+        focus && "utrecht-form-toggle--focus",
+        hover && "utrecht-form-toggle--hover"
+      )}
+      role="switch"
+      tabindex="0"
+      aria-checked={checked}
+      aria-disabled={disabled}
+    >
+      <div
+        className={clsx(
+          "utrecht-form-toggle__track",
+          checked && "utrecht-form-toggle__track--checked",
+          !checked && "utrecht-form-toggle__track--not-checked",
+          disabled && "utrecht-form-toggle__track--disabled"
+        )}
+      >
+        <div
+          className={clsx(
+            "utrecht-form-toggle__thumb",
+            checked && "utrecht-form-toggle__thumb--checked",
+            !checked && "utrecht-form-toggle__thumb--not-checked",
+            disabled && "utrecht-form-toggle__thumb--disabled"
+          )}
+        ></div>
+      </div>
+    </div>
+  );
+};
+
+<Meta title="Templates/Login page" />
+
+# Login page
+
+In deze template worden de schermen vanuit de Login pagina nagebouwd met componenten die beschikbaar zijn in Storybook.
+
+<Canvas>
+  <Story name="personal">
+    <Heading1>Inloggen</Heading1>
+    <Paragraph>
+      Voor het behandelen van dit formulier heeft de gemeente uw elektronische handtekening nodig. Dat regelt u door in
+      te loggen met DigiD. Op basis hiervan wordt een deel van uw persoonlijke gegevens vooraf ingevuld. Dit werkt
+      alleen als u in Den Haag woont.
+    </Paragraph>
+    <FormToggle />
+    <AuthenticationBlock
+      {...defaultArgs}
+      header={{
+        title: "Inloggen met DigiD",
+        subtitle: "Voordeel: wij kunnen uw gegevens alvast voor u invullen.",
+        image: { src: "https://secure.denhaag.nl/vp/images/digid.svg", alt: "digid logo" },
+      }}
+      content={{ links: [{ type: "internal", href: "#digid", textContent: "Inloggen" }] }}
+    />
+    <AuthenticationBlock
+      {...defaultArgs}
+      header={{
+        title: "Inloggen met e-herkenning",
+        subtitle: "Voordeel: wij kunnen uw gegevens alvast voor u invullen.",
+        image: { src: "https://secure.denhaag.nl/vp/images/eherkenning.png", alt: "eherkenning logo" },
+      }}
+      content={{ links: [{ type: "internal", href: "#eherkenning", textContent: "Inloggen" }] }}
+    />
+    <AuthenticationBlock
+      {...defaultArgs}
+      header={{
+        title: "Als gast doorgaan",
+        subtitle: "U hoeft niet in te loggen.",
+      }}
+      content={{ links: [{ type: "internal", href: "#eherkenning", textContent: "Start formulier" }] }}
+    />
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="authorised representative">
+    <Heading1>Inloggen als gemachtigde</Heading1>
+    <Paragraph>
+      Voor het behandelen van dit formulier heeft de gemeente uw elektronische handtekening nodig. Dat regelt u door in
+      te loggen met DigiD. Op basis hiervan wordt een deel van uw persoonlijke gegevens vooraf ingevuld. Dit werkt
+      alleen als u in Den Haag woont.
+    </Paragraph>
+    <FormToggle checked />
+    <AuthenticationBlock
+      {...defaultArgs}
+      header={{
+        title: "Inloggen met DigiD",
+        subtitle: "Voordeel: wij kunnen uw gegevens alvast voor u invullen.",
+        image: { src: "https://secure.denhaag.nl/vp/images/digid.svg", alt: "digid logo" },
+      }}
+      content={{ links: [{ type: "internal", href: "#digid", textContent: "Inloggen" }] }}
+    />
+    <AuthenticationBlock
+      {...defaultArgs}
+      header={{
+        title: "Inloggen met e-herkenning",
+        subtitle: "Voordeel: wij kunnen uw gegevens alvast voor u invullen.",
+        image: { src: "https://secure.denhaag.nl/vp/images/eherkenning.png", alt: "eherkenning logo" },
+      }}
+      content={{ links: [{ type: "internal", href: "#eherkenning", textContent: "Inloggen" }] }}
+    />
+  </Story>
+</Canvas>

--- a/components/AuthenticationBlock/src/css/story-template.tsx
+++ b/components/AuthenticationBlock/src/css/story-template.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface AuthenticationBlockImage {
+  alt: string;
+  src: string;
+  height?: number;
+  width?: number;
+}
+
+interface AuthenticationBlockLink {
+  href: string;
+  type: 'internal' | 'external';
+  textContent: string;
+}
+
+interface AuthenticationBlockProps {
+  type: 'landscape' | 'portrait';
+  header: { title: string; subtitle: string; image?: AuthenticationBlockImage };
+  content: { links: AuthenticationBlockLink[] };
+  footer?: {
+    label: string;
+    link: AuthenticationBlockLink;
+    image: AuthenticationBlockImage;
+  };
+}
+
+export const defaultArgs: AuthenticationBlockProps = {
+  type: 'landscape',
+  header: {
+    title: 'Title',
+    subtitle: 'Subtitle',
+  },
+  content: {
+    links: [{ href: '#example-link', type: 'internal', textContent: 'Internal link' }],
+  },
+};
+
+export const AuthenticationBlock = ({ type, header, content, footer }: AuthenticationBlockProps = defaultArgs) => (
+  <div className={clsx('denhaag-authentication', `denhaag-authentication--${type}`)}>
+    <div className="denhaag-authentication__card">
+      <header className="denhaag-authentication__header">
+        {header.image && (
+          <figure className="denhaag-image">
+            <img
+              alt={header.image.alt}
+              className="denhaag-image__image"
+              height={header.image.height || '80'}
+              loading="lazy"
+              src={header.image.src}
+              width={header.image.width || '80'}
+            />
+          </figure>
+        )}
+        <h3 className="utrecht-heading-3">{header.title}</h3>
+        <p className="utrecht-paragraph">{header.subtitle}</p>
+      </header>
+      <div className="denhaag-authentication__content">
+        <div
+          className={clsx(
+            'denhaag-button-group',
+            `denhaag-button-group--${content.links.length > 1 ? 'multiple' : 'single'}`,
+          )}
+        >
+          {content.links.map(({ type, href, textContent }) => (
+            <a
+              key={href}
+              className="denhaag-button denhaag-button--end-icon denhaag-button--large"
+              href={href}
+              target={type === 'internal' ? '_self' : '_blank'}
+              rel="noreferrer"
+            >
+              {textContent}
+              <span className="denhaag-button__icon">
+                {type === 'internal' ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                    <path
+                      d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                ) : (
+                  <svg fill="none" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                )}
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+      {footer && (
+        <footer className="denhaag-authentication__footer">
+          <div className="denhaag-authentication__footer-divider">
+            <hr className="denhaag-divider" role="presentation" />
+            <div className="denhaag-authentication__footer-label">{footer.label}</div>
+          </div>
+          <a
+            className="denhaag-authentication-item"
+            href={footer.link.href}
+            rel="noreferrer noopener nofollow"
+            target="_blank"
+            title={footer.link.textContent}
+          >
+            <img
+              alt={footer.image.alt}
+              className="denhaag-authentication-item__image"
+              height={footer.image.height || '40'}
+              loading="lazy"
+              src={footer.image.src}
+              width={footer.image.width || '40'}
+            />
+            {footer.link.textContent}
+            <svg
+              aria-hidden="true"
+              className="denhaag-icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
+        </footer>
+      )}
+    </div>
+  </div>
+);
+
+export const AuthenticationBlockMultipleCards = () => (
+  <div className="denhaag-authentication denhaag-authentication--portrait">
+    <div className="denhaag-authentication__card">
+      <header className="denhaag-authentication__header">
+        <figure className="denhaag-image">
+          <img
+            width="80"
+            height="80"
+            src="https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=80&h=80"
+            className="denhaag-image__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+        </figure>
+        <h3 className="utrecht-heading-3">Title</h3>
+        <p className="utrecht-paragraph">Subtitle</p>
+      </header>
+      <div className="denhaag-authentication__content">
+        <div className="denhaag-button-group denhaag-button-group--single">
+          <a
+            className="denhaag-button denhaag-button--end-icon denhaag-button--large"
+            href="#example-link"
+            target="_self"
+          >
+            Internal link
+            <span className="denhaag-button__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+      <footer className="denhaag-authentication__footer">
+        <div className="denhaag-authentication__footer-divider">
+          <hr className="denhaag-divider" role="presentation" />
+          <div className="denhaag-authentication__footer-label">or</div>
+        </div>
+        <a
+          className="denhaag-authentication-item"
+          href="#example-link"
+          target="_blank"
+          title="Gebruik een Europees erkend middel"
+          rel="noreferrer noopener nofollow"
+        >
+          <img
+            width="40"
+            height="40"
+            src="https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=40&h=40"
+            className="denhaag-authentication-item__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+          Gebruik een Europees erkend middel
+          <svg
+            aria-hidden="true"
+            className="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </a>
+      </footer>
+    </div>
+    <div className="denhaag-authentication__card">
+      <header className="denhaag-authentication__header">
+        <figure className="denhaag-image">
+          <img
+            width="80"
+            height="80"
+            src={'https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=80&h=80'}
+            className="denhaag-image__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+        </figure>
+        <h3 className="utrecht-heading-3">Title</h3>
+        <p className="utrecht-paragraph">Subtitle</p>
+      </header>
+      <div className="denhaag-authentication__content">
+        <div className="denhaag-button-group denhaag-button-group--single">
+          <a
+            className="denhaag-button denhaag-button--end-icon denhaag-button--large"
+            href="#example-link"
+            target="_self"
+          >
+            Internal link
+            <span className="denhaag-button__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+      <footer className="denhaag-authentication__footer">
+        <div className="denhaag-authentication__footer-divider">
+          <hr className="denhaag-divider" role="presentation" />
+          <div className="denhaag-authentication__footer-label">or</div>
+        </div>
+        <a
+          className="denhaag-authentication-item"
+          href="#example-link"
+          target="_blank"
+          title="Gebruik een Europees erkend middel"
+          rel="noreferrer noopener nofollow"
+        >
+          <img
+            width="40"
+            height="40"
+            src="https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=40&h=40"
+            className="denhaag-authentication-item__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+          Gebruik een Europees erkend middel
+          <svg
+            aria-hidden="true"
+            className="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </a>
+      </footer>
+    </div>
+    <div className="denhaag-authentication__card">
+      <header className="denhaag-authentication__header">
+        <figure className="denhaag-image">
+          <img
+            width="80"
+            height="80"
+            src="https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=80&h=80"
+            className="denhaag-image__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+        </figure>
+        <h3 className="utrecht-heading-3">Title</h3>
+        <p className="utrecht-paragraph">Subtitle</p>
+      </header>
+      <div className="denhaag-authentication__content">
+        <div className="denhaag-button-group denhaag-button-group--single">
+          <a
+            className="denhaag-button denhaag-button--end-icon denhaag-button--large"
+            href="#example-link"
+            target="_self"
+          >
+            Internal link
+            <span className="denhaag-button__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                <path
+                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  fill="currentColor"
+                ></path>
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+      <footer className="denhaag-authentication__footer">
+        <div className="denhaag-authentication__footer-divider">
+          <hr className="denhaag-divider" role="presentation" />
+          <div className="denhaag-authentication__footer-label">or</div>
+        </div>
+        <a
+          className="denhaag-authentication-item"
+          href="#example-link"
+          target="_blank"
+          title="Gebruik een Europees erkend middel"
+          rel="noreferrer noopener nofollow"
+        >
+          <img
+            width="40"
+            height="40"
+            src="https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=40&h=40"
+            className="denhaag-authentication-item__image"
+            alt="regenboog merk"
+            loading="lazy"
+          />
+          Gebruik een Europees erkend middel
+          <svg
+            aria-hidden="true"
+            className="denhaag-icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </a>
+      </footer>
+    </div>
+  </div>
+);
+
+export default AuthenticationBlock;

--- a/components/AuthenticationBlock/src/stories/bem.stories.mdx
+++ b/components/AuthenticationBlock/src/stories/bem.stories.mdx
@@ -3,6 +3,7 @@ import { DesignTokenDocBlock } from "storybook-design-token/dist/doc-blocks";
 import "../index.scss";
 import pkg from "../../package.json";
 import readme from "../../README.md";
+import { AuthenticationBlock, defaultArgs, AuthenticationBlockMultipleCards } from "../css/story-template";
 
 export const brandImage = (h, w) =>
   `https://images.unsplash.com/photo-1541723011216-c57eaed19919?fit=crop&w=${w}&h=${h}`;
@@ -30,34 +31,8 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Default">
-    <div class="denhaag-authentication denhaag-authentication--landscape">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--single">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+  <Story name="Default" args={defaultArgs}>
+    {AuthenticationBlock.bind({})}
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -66,49 +41,19 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Multiple buttons">
-    <div class="denhaag-authentication denhaag-authentication--landscape">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--multiple">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_blank"
-            >
-              External link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+  <Story
+    name="Multiple buttons"
+    args={{
+      ...defaultArgs,
+      content: {
+        links: [
+          { href: "#example-link", type: "internal", textContent: "Internal link" },
+          { href: "https://example.com", type: "external", textContent: "External link" },
+        ],
+      },
+    }}
+  >
+    {AuthenticationBlock.bind({})}
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -117,59 +62,20 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="With image">
-    <div class="denhaag-authentication denhaag-authentication--landscape">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--multiple">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_blank"
-            >
-              External link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
+  <Story
+    name="With image"
+    args={{
+      ...defaultArgs,
+      header: { ...defaultArgs.header, image: { src: brandImage(80, 80), alt: "regenboog merk" } },
+      content: {
+        links: [
+          { href: "#example-link", type: "internal", textContent: "Internal link" },
+          { href: "https://example.com", type: "external", textContent: "External link" },
+        ],
+      },
+    }}
+  >
+    {AuthenticationBlock.bind({})}
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -178,96 +84,25 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Extra link">
-    <div class="denhaag-authentication denhaag-authentication--landscape">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--multiple">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_blank"
-            >
-              External link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <footer class="denhaag-authentication__footer">
-          <div class="denhaag-authentication__footer-divider">
-            <hr class="denhaag-divider" role="presentation" />
-            <div class="denhaag-authentication__footer-label">or</div>
-          </div>
-          <a
-            class="denhaag-authentication-item"
-            href="#example-link"
-            target="_blank"
-            title="Gebruik een Europees erkend middel"
-            rel="noreferrer noopener nofollow"
-          >
-            <img
-              width="40"
-              height="40"
-              src={brandImage(40, 40)}
-              class="denhaag-authentication-item__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-            Gebruik een Europees erkend middel
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </a>
-        </footer>
-      </div>
-    </div>
+  <Story
+    name="Extra link"
+    args={{
+      ...defaultArgs,
+      header: { ...defaultArgs.header, image: { src: brandImage(80, 80), alt: "regenboog merk" } },
+      content: {
+        links: [
+          { href: "#example-link", type: "internal", textContent: "Internal link" },
+          { href: "https://example.com", type: "external", textContent: "External link" },
+        ],
+      },
+      footer: {
+        label: "or",
+        link: { href: "https://example.com", type: "external", textContent: "Gebruik een Europees erkend middel" },
+        image: { src: brandImage(80, 80), alt: "regenboog merk" },
+      },
+    }}
+  >
+    {AuthenticationBlock.bind({})}
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -276,81 +111,20 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Portrait">
-    <div class="denhaag-authentication denhaag-authentication--portrait">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--single">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <footer class="denhaag-authentication__footer">
-          <div class="denhaag-authentication__footer-divider">
-            <hr class="denhaag-divider" role="presentation" />
-            <div class="denhaag-authentication__footer-label">or</div>
-          </div>
-          <a
-            class="denhaag-authentication-item"
-            href="#example-link"
-            target="_blank"
-            title="Gebruik een Europees erkend middel"
-            rel="noreferrer noopener nofollow"
-          >
-            <img
-              width="40"
-              height="40"
-              src={brandImage(40, 40)}
-              class="denhaag-authentication-item__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-            Gebruik een Europees erkend middel
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </a>
-        </footer>
-      </div>
-    </div>
+  <Story
+    name="Portrait"
+    args={{
+      ...defaultArgs,
+      type: "portrait",
+      header: { ...defaultArgs.header, image: { src: brandImage(80, 80), alt: "regenboog merk" } },
+      footer: {
+        label: "or",
+        link: { href: "https://example.com", type: "external", textContent: "Gebruik een Europees erkend middel" },
+        image: { src: brandImage(80, 80), alt: "regenboog merk" },
+      },
+    }}
+  >
+    {AuthenticationBlock.bind({})}
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -359,225 +133,6 @@ export const brandImage = (h, w) =>
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Portrait multiple">
-    <div class="denhaag-authentication denhaag-authentication--portrait">
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--single">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <footer class="denhaag-authentication__footer">
-          <div class="denhaag-authentication__footer-divider">
-            <hr class="denhaag-divider" role="presentation" />
-            <div class="denhaag-authentication__footer-label">or</div>
-          </div>
-          <a
-            class="denhaag-authentication-item"
-            href="#example-link"
-            target="_blank"
-            title="Gebruik een Europees erkend middel"
-            rel="noreferrer noopener nofollow"
-          >
-            <img
-              width="40"
-              height="40"
-              src={brandImage(40, 40)}
-              class="denhaag-authentication-item__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-            Gebruik een Europees erkend middel
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </a>
-        </footer>
-      </div>
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--single">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <footer class="denhaag-authentication__footer">
-          <div class="denhaag-authentication__footer-divider">
-            <hr class="denhaag-divider" role="presentation" />
-            <div class="denhaag-authentication__footer-label">or</div>
-          </div>
-          <a
-            class="denhaag-authentication-item"
-            href="#example-link"
-            target="_blank"
-            title="Gebruik een Europees erkend middel"
-            rel="noreferrer noopener nofollow"
-          >
-            <img
-              width="40"
-              height="40"
-              src={brandImage(40, 40)}
-              class="denhaag-authentication-item__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-            Gebruik een Europees erkend middel
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </a>
-        </footer>
-      </div>
-      <div class="denhaag-authentication__card">
-        <header class="denhaag-authentication__header">
-          <figure class="denhaag-image">
-            <img
-              width="80"
-              height="80"
-              src={brandImage(80, 80)}
-              class="denhaag-image__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-          </figure>
-          <h3 class="utrecht-heading-3">Title</h3>
-          <p class="utrecht-paragraph">Subtitle</p>
-        </header>
-        <div class="denhaag-authentication__content">
-          <div class="denhaag-button-group denhaag-button-group--single">
-            <a
-              class="denhaag-button denhaag-button--end-icon denhaag-button--large"
-              href="#example-link"
-              target="_self"
-            >
-              Internal link
-              <span class="denhaag-button__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
-                  <path
-                    d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    fill="currentColor"
-                  ></path>
-                </svg>
-              </span>
-            </a>
-          </div>
-        </div>
-        <footer class="denhaag-authentication__footer">
-          <div class="denhaag-authentication__footer-divider">
-            <hr class="denhaag-divider" role="presentation" />
-            <div class="denhaag-authentication__footer-label">or</div>
-          </div>
-          <a
-            class="denhaag-authentication-item"
-            href="#example-link"
-            target="_blank"
-            title="Gebruik een Europees erkend middel"
-            rel="noreferrer noopener nofollow"
-          >
-            <img
-              width="40"
-              height="40"
-              src={brandImage(40, 40)}
-              class="denhaag-authentication-item__image"
-              alt="regenboog merk"
-              loading="lazy"
-            />
-            Gebruik een Europees erkend middel
-            <svg
-              aria-hidden="true"
-              class="denhaag-icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </a>
-        </footer>
-      </div>
-    </div>
-  </Story>
+  <Story name="Portrait multiple">{AuthenticationBlockMultipleCards.bind({})}</Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>

--- a/components/Switch/src/react.stories.tsx
+++ b/components/Switch/src/react.stories.tsx
@@ -23,7 +23,7 @@ export default {
 const Template: Story<SwitchProps> = (args: SwitchProps) => {
   return (
     <div>
-      <FormControlLabel label="Switch" control={<Switch {...args} />} />
+      <FormControlLabel label="Switch" input={<Switch {...args} />} />
     </div>
   );
 };

--- a/proprietary/Components/src/utrecht/form-toggle.tokens.json
+++ b/proprietary/Components/src/utrecht/form-toggle.tokens.json
@@ -1,0 +1,38 @@
+{
+  "utrecht": {
+    "form-toggle": {
+      "accent-color": { "value": "{denhaag.color.grey.3}" },
+      "background-color": {},
+      "border-color": { "value": "{denhaag.color.grey.3}" },
+      "border-radius": { "value": "12px" },
+      "border-width": { "value": "0" },
+      "color": { "value": "{denhaag.color.white}" },
+      "height": { "value": "24px" },
+      "width": { "value": "48px" },
+      "track": {
+        "border-radius": {},
+        "disabled": {
+          "background-color": {}
+        }
+      },
+      "thumb": {
+        "background-color": {},
+        "margin-inline-start": { "value": ".25em" },
+        "margin-inline-end": { "value": ".25em" },
+        "min-inline-size": { "value": "1em" },
+        "disabled": {
+          "box-shadow": {},
+          "background-color": {}
+        }
+      },
+      "checked": {
+        "accent-color": { "value": "{denhaag.color.green.3}" }
+      },
+      "focus": {
+        "border-color": {},
+        "border-style": {},
+        "border-width": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
As the new login page design will be used in several places, let's make a storybook template with all necessary components.

- [ ] Convert existing hardcoded stories of the needed components into stories with story-templates (these can also be used in the NL Design System themes repository later)
- [ ] Add templates folder and `login-page` stories 
  - [ ] Personal login
  - [ ] Authorised representative
- [ ] Use component templates to render the whole design
- [ ] Ensure the code-sample is not of the template components but of the actual rendered html instead
- [x] Utrecht Form Toggle Den Haag theme
- [ ] Replace Den Haag Switch (which is still Material) with Utrecht Form Toggle
  - [ ] Deprecate Switch
  - [ ] Add Form Toggle story based on Utrecht story-template
- [ ] Replace AuthenticationBlock with more generic CTICard
  - [ ] Align with UX (Rozerin)
  - [ ] Replace `--landscape` and `--portrait` logic with `--inline` variant and combine AuthenticationBlock and AuthenticationBlockCard

**Dependencies**

- [ ] Improved Utrecht Form Toggle CSS component with checkbox and no label
- [ ] Utrecht shared React story-template for Form Toggle 

**Issues**

https://github.com/nl-design-system/open-forms-sdk/issues/22
