### PR TITLE
Fix/responsive openforms pages

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -8,6 +8,7 @@
   display: inline-flex;
   font-family: var(--denhaag-button-font-family);
   font-size: var(--denhaag-typography-scale-base-font-size);
+  justify-content: center;
   line-height: 1.75;
   padding-block-end: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
   padding-block-start: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));

--- a/components/ButtonGroup/src/index.scss
+++ b/components/ButtonGroup/src/index.scss
@@ -3,7 +3,7 @@
   padding-block-start: var(--denhaag-button-group-padding, var(--denhaag-button-group-gap));
   padding-block-end: var(--denhaag-button-group-padding, var(--denhaag-button-group-gap));
 
-  @media (min-width: 481px) {
+  @media (min-width: 768px) {
     --denhaag-button-group-flex-direction: row;
   }
 

--- a/components/CtaLink/src/index.scss
+++ b/components/CtaLink/src/index.scss
@@ -62,6 +62,7 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    white-space: pre-wrap;
   }
 }
 

--- a/components/CtaLink/src/index.scss
+++ b/components/CtaLink/src/index.scss
@@ -58,7 +58,7 @@
 
 @supports (-webkit-line-clamp: 2) {
   .denhaag-cta-link__excerpt {
-    display: box;
+    display: flex;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;

--- a/components/FormProgress/src/index.scss
+++ b/components/FormProgress/src/index.scss
@@ -11,6 +11,13 @@
   margin-block-end: var(--denhaag-form-progress-header-margin-block-end);
 }
 
+/* Den Haag S */
+@media (max-width: 767px) {
+  .denhaag-form-progress__header {
+    justify-content: flex-end;
+  }
+}
+
 .denhaag-form-progress__previous {
   position: absolute;
   inset-inline-start: 0;


### PR DESCRIPTION
Fixes for issue https://github.com/nl-design-system/open-forms-sdk/issues/9

- Fix a building warning. 
- Use breakpoints as defined in the design.
- Center button content on mobile.
- Moved form progress label to the right on mobile.