### PR TITLE
fix: use display flex

### DIFF
--- a/components/CtaLink/src/index.scss
+++ b/components/CtaLink/src/index.scss
@@ -58,7 +58,7 @@
 
 @supports (-webkit-line-clamp: 2) {
   .denhaag-cta-link__excerpt {
-    display: box;
+    display: flex;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;


### PR DESCRIPTION
so autoprefixer in open-forms will not return a warning

