### PR TITLE
style(dynamic-content): add flex-wrap due grid-breaking issues

### DIFF
--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -94,6 +94,7 @@
   color: var(--denhaag-dynamic-content-card-content-color);
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   gap: var(--denhaag-dynamic-content-card-content-gap);
 }
 


### PR DESCRIPTION
Add flex-wrap due to grid issues:

**Before**
![Screenshot 2022-08-15 at 11 15 47](https://user-images.githubusercontent.com/94894596/184609523-eb68c351-8030-42d2-a25b-b53594b4e314.png)

**After**
![Screenshot 2022-08-15 at 11 17 31](https://user-images.githubusercontent.com/94894596/184609591-4b003719-035e-4630-83fe-42cc33fea729.png)


