### PR TITLE
Fix/hero horizontal scroll

### DIFF
--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -119,7 +119,7 @@
     100% 100%,
     100% 100%,
     0% 100%,
-    calc(0% + var(--denhaag-hero-image-path, 0px)) 0%,
+    calc(0% + var(--denhaag-hero-image-path, 0)) 0%,
     0% 0%
   );
   height: 100%;

--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -119,7 +119,7 @@
     100% 100%,
     100% 100%,
     0% 100%,
-    calc(0% + var(--denhaag-hero-image-path, 0)) 0%,
+    calc(0% + var(--denhaag-hero-image-path, 0px)) 0%,
     0% 0%
   );
   height: 100%;
@@ -264,7 +264,7 @@
       );
       content: "";
       height: 100%;
-      width: 100%;
+      width: calc(100% - var(--denhaag-hero-routing-shape-left, 0));
       top: 0;
       left: var(--denhaag-hero-routing-shape-left, 0);
       position: absolute;


### PR DESCRIPTION
Fixed issue caused by the routing hero where the pseudo pushes outside of the hero. Causing an horizontal overflow to appear ( https://wp:wp@denhaag.staging.acato.nl/nl/geld-en-schulden/ ) 