### PR TITLE
fix: remove flexbox logic from .denhaag-cta-link__excerpt

### DIFF
--- a/components/CtaLink/src/index.scss
+++ b/components/CtaLink/src/index.scss
@@ -16,7 +16,6 @@
   padding-inline-start: var(--denhaag-cta-link-padding-inline, calc(var(--denhaag-cta-link-gap) / 1.5));
   padding-inline-end: var(--denhaag-cta-link-padding-inline, calc(var(--denhaag-cta-link-gap) / 1.5));
   text-decoration: none;
-  word-break: break-word;
 }
 
 .denhaag-cta-link:hover,
@@ -54,16 +53,6 @@
 
 .denhaag-cta-link__excerpt {
   font-size: var(--denhaag-typography-scale-lg-font-size);
-}
-
-@supports (-webkit-line-clamp: 2) {
-  .denhaag-cta-link__excerpt {
-    display: flex;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    white-space: pre-wrap;
-  }
 }
 
 .denhaag-cta-link__highlight,

--- a/components/CtaLink/src/stories/bem.stories.mdx
+++ b/components/CtaLink/src/stories/bem.stories.mdx
@@ -46,9 +46,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -76,9 +76,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -106,9 +106,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -136,9 +136,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
     <a class="denhaag-cta-link" href="#example-url" rel="nofollow noopener">
       <div class="denhaag-cta-link__dot">
@@ -157,9 +157,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
     <a class="denhaag-cta-link" href="#example-url" rel="nofollow noopener">
       <div class="denhaag-cta-link__dot">
@@ -178,9 +178,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook: <span class="denhaag-cta-link__highlight">Met een link</span>
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -208,12 +208,12 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         Zie ook:{" "}
         <span class="denhaag-cta-link__highlight">
           Donec bibendum, mauris et laoreet euismod, nunc felis fermentum nisi, ut ultrices nisi nisi et
         </span>
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -241,9 +241,9 @@ import readme from "../../README.md";
           />
         </svg>
       </div>
-      <div class="denhaag-cta-link__excerpt">
+      <p class="denhaag-cta-link__excerpt">
         <span class="denhaag-cta-link__highlight">Bekijk</span> een lange tekst over de video
-      </div>
+      </p>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}


### PR DESCRIPTION
to align it with the [Figma designs](https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=8105%3A21885)
and to prevent weird whitespace and wrap issues
