### PR TITLE
style(heading): set color for heading and remove unset tokens

### DIFF
--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -134,7 +134,7 @@
 }
 
 .denhaag-hero__title {
-  --utrecht-heading-1-color: var(--denhaag-hero-color);
+  --denhaag-heading-color: var(--denhaag-hero-color);
 
   margin-block-end: var(--denhaag-hero-title-margin-block-end);
   margin-block-start: var(--denhaag-hero-title-margin-block-start);

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -5,10 +5,13 @@
  * Copyright (c) 2021 The Knights Who Say NIH! B.V.
  */
 
-.utrecht-heading-1 {
-  --utrecht-heading-1-color: var(--denhaag-heading-color);
-  --utrecht-heading-1-line-height: var(--denhaag-heading-line-height);
+[class^="utrecht-heading"],
+[class*=" utrecht-heading"] {
+  color: var(--denhaag-heading-color);
+  line-height: var(--denhaag-heading-line-height);
+}
 
+.utrecht-heading-1 {
   font-family: var(
     --utrecht-heading-1-font-family,
     var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
@@ -33,9 +36,6 @@
 }
 
 .utrecht-heading-2 {
-  --utrecht-heading-2-line-height: var(--denhaag-heading-line-height);
-  --utrecht-heading-2-color: var(--denhaag-heading-color);
-
   font-family: var(
     --utrecht-heading-2-font-family,
     var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
@@ -60,9 +60,6 @@
 }
 
 .utrecht-heading-3 {
-  --utrecht-heading-3-line-height: var(--denhaag-heading-line-height);
-  --utrecht-heading-3-color: var(--denhaag-heading-color);
-
   font-family: var(
     --utrecht-heading-3-font-family,
     var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
@@ -87,9 +84,6 @@
 }
 
 .utrecht-heading-4 {
-  --utrecht-heading-4-line-height: var(--denhaag-heading-line-height);
-  --utrecht-heading-4-color: var(--denhaag-heading-color);
-
   font-family: var(
     --utrecht-heading-4-font-family,
     var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
@@ -114,9 +108,6 @@
 }
 
 .utrecht-heading-5 {
-  --utrecht-heading-5-line-height: var(--denhaag-heading-line-height);
-  --utrecht-heading-5-color: var(--denhaag-heading-color);
-
   font-family: var(
     --utrecht-heading-5-font-family,
     var(--utrecht-heading-font-family, var(--utrecht-document-font-family))


### PR DESCRIPTION
Headings didn't get any color or line-height css line. Also all values were equal, therefor a change for all header-classes and an update for the hero which used the old heading token.