### PR TITLE
style(breadcrumb): change bg color mobile

### DIFF
--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -5,7 +5,6 @@
   --denhaag-breadcrumb-link-pointer-events: bounding-box;
   --denhaag-breadcrumb-item-display: none;
 
-  background-color: var(--denhaag-breadcrumb-background-color, transparent);
   color: var(--denhaag-breadcrumb-color, inherit);
   padding-block-end: var(--denhaag-breadcrumb-padding-block);
   padding-block-start: var(--denhaag-breadcrumb-padding-block);
@@ -133,6 +132,8 @@ ol.denhaag-breadcrumb__list {
     --denhaag-breadcrumb-chevron-display: inline-block;
     --denhaag-breadcrumb-link-icon-content: unset;
     --denhaag-breadcrumb-padding-block: var(--denhaag-breadcrumb-padding-block-md);
+
+    background-color: var(--denhaag-breadcrumb-background-color, transparent);
   }
 
   .denhaag-breadcrumb__item:not(:nth-last-child(2)) {


### PR DESCRIPTION
### Solve: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1569%3A5671

- background color on mobile

### Purpose:

- only apply background color to non mobile viewports

#closes 