### PR TITLE
fix(focus styles): apply focus styles only for accessibility a.k.a :f…

### DIFF
--- a/components/AuthenticationBlock/src/index.scss
+++ b/components/AuthenticationBlock/src/index.scss
@@ -172,7 +172,7 @@
       color: var(--denhaag-authentication-item-hover-color, var(--denhaag-link-hover-color));
     }
 
-    &:focus {
+    &:focus-visible {
       outline: var(--denhaag-authentication-item-focus-outline, var(--denhaag-link-focus-outline));
     }
 

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -72,7 +72,7 @@ ol.denhaag-breadcrumb__list {
   --denhaag-breadcrumb-link-color: var(--denhaag-breadcrumb-link-hover-color, inherit);
 }
 
-.denhaag-breadcrumb__link:focus,
+.denhaag-breadcrumb__link:focus-visible,
 .denhaag-breadcrumb__link--focus {
   --denhaag-breadcrumb-link-color: var(--denhaag-breadcrumb-link-focus-color, inherit);
 

--- a/components/CtaDownload/src/index.scss
+++ b/components/CtaDownload/src/index.scss
@@ -35,7 +35,7 @@
   background-color: var(--denhaag-cta-download-hover-dot-background-color, var(--denhaag-cta-download-color));
 }
 
-.denhaag-cta-download:focus,
+.denhaag-cta-download:focus-visible,
 .denhaag-cta-download--focus {
   --denhaag-cta-download-dot-background-color: var(
     --denhaag-cta-download-focus-dot-background-color,

--- a/components/CtaEvent/src/index.scss
+++ b/components/CtaEvent/src/index.scss
@@ -31,7 +31,7 @@
   );
 }
 
-.denhaag-cta-event:focus,
+.denhaag-cta-event:focus-visible,
 .denhaag-cta-event--focus {
   --denhaag-cta-event-dot-background-color: var(
     --denhaag-cta-event-focus-dot-background-color,

--- a/components/CtaLink/src/index.scss
+++ b/components/CtaLink/src/index.scss
@@ -23,7 +23,7 @@
   --denhaag-cta-link-highlight-color: var(--denhaag-cta-link-hover-highlight-color, var(--denhaag-cta-link-color));
 }
 
-.denhaag-cta-link:focus,
+.denhaag-cta-link:focus-visible,
 .denhaag-cta-link--focus {
   --denhaag-cta-link-highlight-color: var(
     --denhaag-cta-link-focus-highlight-color,

--- a/components/IconButton/src/index.scss
+++ b/components/IconButton/src/index.scss
@@ -18,7 +18,7 @@
   color: var(--denhaag-icon-button-hover-color);
 }
 
-.denhaag-icon-button:focus,
+.denhaag-icon-button:focus-visible,
 .denhaag-icon-button--focus {
   color: var(--denhaag-icon-button-focus-color);
   outline-color: var(--denhaag-icon-button-focus-outline-color);

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -33,7 +33,7 @@
 .denhaag-link--hover,
 .denhaag-link:hover,
 .denhaag-link--focus,
-.denhaag-link:focus {
+.denhaag-link:focus-visible {
   text-decoration: var(--denhaag-link-text-decoration);
 }
 
@@ -47,7 +47,7 @@
 }
 
 .denhaag-link--focus,
-.denhaag-link:focus {
+.denhaag-link:focus-visible {
   --denhaag-link-color: var(--denhaag-link-focus-color);
 
   outline: var(--denhaag-link-focus-outline);

--- a/components/Modal/src/index.scss
+++ b/components/Modal/src/index.scss
@@ -80,7 +80,7 @@
   --denhaag-modal-icon-color: var(--denhaag-modal-icon-hover-color);
 }
 
-.denhaag-modal__button:focus,
+.denhaag-modal__button:focus-visible,
 .denhaag-modal__button--focus {
   outline: var(--denhaag-focus-border);
 }

--- a/components/Pagination/src/index.scss
+++ b/components/Pagination/src/index.scss
@@ -52,7 +52,7 @@
   --denhaag-pagination-color: var(--denhaag-pagination-link-hover-color);
 }
 
-.denhaag-pagination__link:focus,
+.denhaag-pagination__link:focus-visible,
 .denhaag-pagination__link--focus {
   outline: var(--denhaag-link-focus-outline);
   border-radius: 0;

--- a/components/Sidenav/src/index.scss
+++ b/components/Sidenav/src/index.scss
@@ -45,7 +45,7 @@
   cursor: pointer;
 }
 
-.denhaag-sidenav__link:focus,
+.denhaag-sidenav__link:focus-visible,
 .denhaag-sidenav__link--focus {
   outline: var(--denhaag-focus-border);
 }

--- a/components/Timeline/src/styles/step.scss
+++ b/components/Timeline/src/styles/step.scss
@@ -4,7 +4,6 @@
 }
 
 .denhaag-timeline__step--focus,
-.denhaag-timeline__step:focus,
 .denhaag-timeline__step:focus-visible {
   outline: var(--denhaag-timeline-step-outline);
   outline-offset: var(--denhaag-timeline-step-outline-offset);


### PR DESCRIPTION
### Solve:

- focus styles that are meant for accessibility with keyboard tab, are currently visible for keyboard tabbing AND click events

### Purpose:

- apply focus styles ONLY for accessibility (keyboard tabbing) a.k.a `:focus-visible` instead of `:focus` pseudo css

closes #1069