### PR TITLE
fix(dynamic-content): fix for text breaking layout

### DIFF
--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -96,6 +96,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   gap: var(--denhaag-dynamic-content-card-content-gap);
+  padding-block-start: var(--denhaag-dynamic-content-card-content-padding);
 }
 
 .denhaag-dynamic-content__card-caption {
@@ -111,6 +112,7 @@
   color: var(--denhaag-dynamic-content-card-title-color);
   font-size: var(--denhaag-dynamic-content-card-title-font-size);
   font-weight: var(--denhaag-dynamic-content-card-title-font-weight);
+  hyphens: var(--denhaag-dynamic-content-card-title-hyphens);
   line-height: var(--denhaag-dynamic-content-card-title-line-height);
   margin-block-start: 0;
   margin-block-end: 0;

--- a/proprietary/Components/src/denhaag/dynamic-content.tokens.json
+++ b/proprietary/Components/src/denhaag/dynamic-content.tokens.json
@@ -8,6 +8,9 @@
           },
           "gap": {
             "value": "{denhaag.space.inline.lg}"
+          },
+          "padding": {
+            "value": "{denhaag.space.block.md}"
           }
         },
         "gap": {
@@ -37,6 +40,9 @@
             "weight": {
               "value": "{denhaag.typography.weight.bold}"
             }
+          },
+          "hyphens": {
+            "value": "auto"
           },
           "line-height": {
             "value": "{denhaag.typography.scale.s.line-height}"


### PR DESCRIPTION
Words that should be broken but aren't broken causing issues with the flex-layout.

**Before:**

![Schermafbeelding 2022-08-29 om 14 47 20](https://user-images.githubusercontent.com/94894596/187204478-4d7c37de-5fa8-42ca-af96-207b6fdf8d55.png)

**After:**
![Schermafbeelding 2022-08-29 om 14 46 56](https://user-images.githubusercontent.com/94894596/187204496-85ca2394-72a5-4780-b42f-1fcc562ee2b8.png)

Another issue (i already mentioned this to design) is that it's designed for 1/2 lines of text and now whole paragraphs are provided.
