### PR TITLE
refactor: clean up heading CSS

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,13 +35,13 @@ jobs:
           yarn lint:prettier
 
       - name: build library
-        run: yarn build
+        run: yarn build:library
 
       - name: typecheck storybook
         run: yarn typecheck:storybook
 
       - name: build storybook
-        run: yarn build-storybook
+        run: yarn build:storybook
 
       - name: Upload storybook
         uses: actions/upload-artifact@v3

--- a/components/Alert/src/index.scss
+++ b/components/Alert/src/index.scss
@@ -15,7 +15,7 @@
 .denhaag-alert--error {
   background-color: var(--denhaag-alert-error-background-color);
 
-  --denhaag-paragraph-color: var(--denhaag-alert-error-paragraph-color);
+  --utrecht-paragraph-color: var(--denhaag-alert-error-paragraph-color);
   --utrecht-heading-4-color: var(--denhaag-alert-error-title-color);
   --denhaag-button-primary-action-background-color: var(--denhaag-alert-error-action-button-background-color);
   --denhaag-button-primary-action-color: var(--denhaag-alert-error-action-button-color);
@@ -52,7 +52,7 @@
 .denhaag-alert--info {
   background-color: var(--denhaag-alert-info-background-color);
 
-  --denhaag-paragraph-color: var(--denhaag-alert-info-paragraph-color);
+  --utrecht-paragraph-color: var(--denhaag-alert-info-paragraph-color);
   --utrecht-heading-4-color: var(--denhaag-alert-info-title-color);
   --denhaag-button-primary-action-background-color: var(--denhaag-alert-info-action-button-background-color);
   --denhaag-button-primary-action-color: var(--denhaag-alert-info-action-button-color);
@@ -71,7 +71,7 @@
 .denhaag-alert--success {
   background-color: var(--denhaag-alert-success-background-color);
 
-  --denhaag-paragraph-color: var(--denhaag-alert-success-paragraph-color);
+  --utrecht-paragraph-color: var(--denhaag-alert-success-paragraph-color);
   --utrecht-heading-4-color: var(--denhaag-alert-success-title-color);
   --denhaag-button-primary-action-background-color: var(--denhaag-alert-success-action-button-background-color);
   --denhaag-button-primary-action-color: var(--denhaag-alert-success-action-button-color);
@@ -90,7 +90,7 @@
 .denhaag-alert--warning {
   background-color: var(--denhaag-alert-warning-background-color);
 
-  --denhaag-paragraph-color: var(--denhaag-alert-warning-paragraph-color);
+  --utrecht-paragraph-color: var(--denhaag-alert-warning-paragraph-color);
   --utrecht-heading-4-color: var(--denhaag-alert-warning-title-color);
   --denhaag-button-primary-action-background-color: var(--denhaag-alert-warning-action-button-background-color);
   --denhaag-button-primary-action-color: var(--denhaag-alert-warning-action-button-color);

--- a/components/Alert/src/stories/bem.stories.mdx
+++ b/components/Alert/src/stories/bem.stories.mdx
@@ -48,7 +48,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -98,7 +98,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -166,7 +166,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -216,7 +216,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -253,7 +253,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -290,7 +290,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -336,7 +336,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
@@ -397,7 +397,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>Support Icons can be overwritten!</p>
           </div>
         </div>
@@ -467,7 +467,7 @@ import readme from "../../README.md";
             </svg>
           </div>
           <div class={"denhaag-alert__content"}>
-            <h4 class={"utrecht-heading-4 utrecht-heading-4--distanced"}>Title</h4>
+            <h4 class={"utrecht-heading-4"}>Title</h4>
             <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>

--- a/components/Alert/src/stories/bem.stories.mdx
+++ b/components/Alert/src/stories/bem.stories.mdx
@@ -49,7 +49,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
           </div>
@@ -99,7 +99,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
             <button class={"denhaag-button"} type="button">
@@ -167,7 +167,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
           </div>
@@ -217,7 +217,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
           </div>
@@ -254,7 +254,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
           </div>
@@ -291,7 +291,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
             <button class={"denhaag-button"} type="button">
@@ -337,7 +337,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
           </div>
@@ -398,7 +398,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>Support Icons can be overwritten!</p>
+            <p class={"utrecht-paragraph"}>Support Icons can be overwritten!</p>
           </div>
         </div>
         <div class={"denhaag-alert__close"}>
@@ -468,7 +468,7 @@ import readme from "../../README.md";
           </div>
           <div class={"denhaag-alert__content"}>
             <h4 class={"utrecht-heading-4"}>Title</h4>
-            <p class={"utrecht-paragraph utrecht-paragraph--distanced"}>
+            <p class={"utrecht-paragraph"}>
               Here comes text. This text provides additional details and actionable steps the user can take.
             </p>
             <button

--- a/components/AnchorCollapse/src/index.scss
+++ b/components/AnchorCollapse/src/index.scss
@@ -99,7 +99,7 @@
     --denhaag-anchor-collapse-content-padding-inline-start: 0;
 
     // Must always be the same as the H2 styles.
-    --denhaag-anchor-collapse-summary-color: var(--utrecht-heading-2-color, var(--denhaag-heading-color));
+    --denhaag-anchor-collapse-summary-color: var(--utrecht-heading-2-color, var(--utrecht-heading-color));
     --denhaag-anchor-collapse-summary-font-family: var(
       --utrecht-heading-2-font-family,
       var(--utrecht-heading-font-family, var(--utrecht-document-font-family))

--- a/components/CardNews/src/stories/bem.stories.mdx
+++ b/components/CardNews/src/stories/bem.stories.mdx
@@ -30,7 +30,11 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
     <div class="denhaag-card-news">
-      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <img
+        class="denhaag-card-news__image"
+        src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=307&h=173"
+        alt=""
+      />
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -68,7 +72,11 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hover">
     <div class="denhaag-card-news denhaag-card-news--hover">
-      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <img
+        class="denhaag-card-news__image"
+        src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=307&h=173"
+        alt=""
+      />
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -106,7 +114,11 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
     <div class="denhaag-card-news denhaag-card-news--focus">
-      <img class="denhaag-card-news__image" src="https://via.placeholder.com/307x173" alt="" />
+      <img
+        class="denhaag-card-news__image"
+        src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=307&h=173"
+        alt=""
+      />
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">

--- a/components/CtaImageContent/src/stories/bem.stories.mdx
+++ b/components/CtaImageContent/src/stories/bem.stories.mdx
@@ -31,7 +31,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
         alt=""
         loading="lazy"
       />
@@ -73,7 +73,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content denhaag-cta-image-content--filled">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce"
         alt=""
         loading="lazy"
       />
@@ -115,7 +115,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
         alt=""
         loading="lazy"
       />
@@ -138,7 +138,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content denhaag-cta-image-content--focus">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
         alt=""
         loading="lazy"
       />
@@ -180,7 +180,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content denhaag-cta-image-content--hover">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
         alt=""
         loading="lazy"
       />
@@ -222,7 +222,7 @@ import readme from "../../README.md";
     <div class="denhaag-cta-image-content">
       <img
         class="denhaag-cta-image-content__image"
-        src="https://via.placeholder.com/650x350/90D40166"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
         alt=""
         loading="lazy"
       />

--- a/components/DynamicContent/src/stories/bem.stories.mdx
+++ b/components/DynamicContent/src/stories/bem.stories.mdx
@@ -34,10 +34,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -67,10 +67,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card denhaag-dynamic-content__card--hover">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -100,10 +100,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card denhaag-dynamic-content__card--focus">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -133,10 +133,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -166,10 +166,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -199,10 +199,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -915,10 +915,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -948,10 +948,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -981,10 +981,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -1014,10 +1014,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -1047,10 +1047,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />
@@ -1080,10 +1080,10 @@ import readme from "../../README.md";
         <article class="denhaag-dynamic-content__card">
           <img
             class="denhaag-dynamic-content__card-image denhaag-image__image"
-            srcset="https://via.placeholder.com/340x190/90D40166 480w,
-                https://via.placeholder.com/510x285/90D40166 768w,
-                https://via.placeholder.com/680x380/90D40166 1290w"
-            src="https://via.placeholder.com/680x380/90D40166"
+            srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+            src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
             alt=""
             loading="lazy"
           />

--- a/components/FormGroup/src/index.scss
+++ b/components/FormGroup/src/index.scss
@@ -2,7 +2,7 @@
   /* Overwrite utrecht design tokens */
   --utrecht-heading-5-color: var(--denhaag-form-group-label-color);
   --utrecht-paragraph-font-size: var(--denhaag-form-group-helper-text-size);
-  --denhaag-paragraph-color: var(--denhaag-form-group-helper-text-color);
+  --utrecht-paragraph-color: var(--denhaag-form-group-helper-text-color);
 
   /* To ensure gap between helpertext and checkboxes */
   --utrecht-paragraph-margin-block-start: var(--denhaag-form-group-helper-text-margin-block-start);
@@ -20,5 +20,5 @@
 }
 
 .denhaag-form-group--error {
-  --denhaag-paragraph-color: var(--denhaag-form-group-helper-text-error-color);
+  --utrecht-paragraph-color: var(--denhaag-form-group-helper-text-error-color);
 }

--- a/components/FormProgress/src/stories/bem.stories.mdx
+++ b/components/FormProgress/src/stories/bem.stories.mdx
@@ -28,10 +28,9 @@ import pkg from "../../package.json";
     {() => (
       <div class="denhaag-form-progress">
         <div class="denhaag-form-progress__header">
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label for="denhaag-form-progress-bar">
-            <p class="utrecht-paragraph utrecht-paragraph--distanced">Stap 1 van 4</p>
-          </label>
+          <div for="denhaag-form-progress-bar">
+            <p class="utrecht-paragraph">Stap 1 van 4</p>
+          </div>
         </div>
         <progress id="denhaag-form-progress-bar" class="denhaag-form-progress__progress" max="4" value="1"></progress>
       </div>
@@ -49,11 +48,7 @@ import pkg from "../../package.json";
       <div class="denhaag-form-progress">
         <div class="denhaag-form-progress__header">
           <div class="denhaag-form-progress__previous">
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <a
-              class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
-              href="javascript:history.back()"
-            >
+            <a class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start" href="https://example.com/">
               <span class="denhaag-link__icon">
                 <svg
                   class="denhaag-icon"
@@ -75,10 +70,9 @@ import pkg from "../../package.json";
               <span>Vorige stap</span>
             </a>
           </div>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-          <label for="denhaag-form-progress-bar">
-            <p class="utrecht-paragraph utrecht-paragraph--distanced">Stap 2 van 4</p>
-          </label>
+          <div for="denhaag-form-progress-bar">
+            <p class="utrecht-paragraph">Stap 2 van 4</p>
+          </div>
         </div>
         <progress id="denhaag-form-progress-bar" class="denhaag-form-progress__progress" max="4" value="2"></progress>
       </div>

--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -1,4 +1,5 @@
 .denhaag-hero {
+  --utrecht-heading-color: var(--denhaag-hero-color);
   --denhaag-hero-image-display: none;
   --denhaag-hero-image-width: calc(
     (
@@ -134,8 +135,6 @@
 }
 
 .denhaag-hero__title {
-  --denhaag-heading-color: var(--denhaag-hero-color);
-
   margin-block-end: var(--denhaag-hero-title-margin-block-end);
   margin-block-start: var(--denhaag-hero-title-margin-block-start);
 

--- a/components/Image/src/stories/bem.stories.mdx
+++ b/components/Image/src/stories/bem.stories.mdx
@@ -31,10 +31,10 @@ import readme from "../../README.md";
     <figure class="denhaag-image">
       <img
         class="denhaag-image__image"
-        srcset="https://via.placeholder.com/480x270/90D40166 480w,
-                https://via.placeholder.com/768x432/90D40166 768w,
-                https://via.placeholder.com/1290x725/90D40166 1290w"
-        src="https://via.placeholder.com/1290x725/90D40166"
+        srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+        src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
         alt="Distinctio cupiditate"
         loading="lazy"
       />
@@ -45,7 +45,7 @@ import readme from "../../README.md";
         </span>
         <a
           class="denhaag-image__figcaption-download"
-          href="https://via.placeholder.com/1290x725/90D40166"
+          href="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
           download="distinctio-cupiditate"
           type="application/image"
           aria-label="Download image: [READABLE_FILENAME] ([FILE_EXTENSION], [FILE_SIZE])"
@@ -92,10 +92,10 @@ import readme from "../../README.md";
     <figure class="denhaag-image">
       <img
         class="denhaag-image__image"
-        srcset="https://via.placeholder.com/480x270/90D40166 480w,
-                https://via.placeholder.com/768x432/90D40166 768w,
-                https://via.placeholder.com/1290x725/90D40166 1290w"
-        src="https://via.placeholder.com/1290x725/90D40166"
+        srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+        src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
         alt="Istinctio cupiditate repellat"
         loading="lazy"
       />
@@ -118,17 +118,17 @@ import readme from "../../README.md";
     <figure class="denhaag-image">
       <img
         class="denhaag-image__image"
-        srcset="https://via.placeholder.com/480x270/90D40166 480w,
-                https://via.placeholder.com/768x432/90D40166 768w,
-                https://via.placeholder.com/1290x725/90D40166 1290w"
-        src="https://via.placeholder.com/1290x725/90D40166"
+        srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+        src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
         alt="Distinctio cupiditate"
         loading="lazy"
       />
       <figcaption class="denhaag-image__figcaption">
         <a
           class="denhaag-image__figcaption-download"
-          href="https://via.placeholder.com/1290x725/90D40166"
+          href="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
           download="distinctio-cupiditate"
           type="application/image"
           aria-label="Download image: [READABLE_FILENAME] ([FILE_EXTENSION], [FILE_SIZE])"
@@ -175,10 +175,10 @@ import readme from "../../README.md";
     <figure class="denhaag-image denhaag-image--figcaption-only">
       <img
         class="denhaag-image__image"
-        srcset="https://via.placeholder.com/480x270/90D40166 480w,
-                https://via.placeholder.com/768x432/90D40166 768w,
-                https://via.placeholder.com/1290x725/90D40166 1290w"
-        src="https://via.placeholder.com/1290x725/90D40166"
+        srcset="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+        src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
         alt="Placeat itaque velit iure"
         loading="lazy"
       />
@@ -195,10 +195,10 @@ import readme from "../../README.md";
     <figure class="denhaag-image">
       <img
         class="denhaag-image__image"
-        srcset="https://via.placeholder.com/270x480/90D40166 480w,
-                https://via.placeholder.com/432x768/90D40166 768w,
-                https://via.placeholder.com/725x1290/90D40166 1290w"
-        src="https://via.placeholder.com/1290x725/90D40166"
+        srcset="https://images.unsplash.com/photo-1611402881804-8fde5b755174?h=480 480h,
+                https://images.unsplash.com/photo-1611402881804-8fde5b755174?h=768 768h,
+                https://images.unsplash.com/photo-1611402881804-8fde5b755174?h=1290 1290h"
+        src="https://images.unsplash.com/photo-1611402881804-8fde5b755174?h=1290"
         alt="Distinctio cupiditate"
         loading="lazy"
       />
@@ -209,7 +209,7 @@ import readme from "../../README.md";
         </span>
         <a
           class="denhaag-image__figcaption-download"
-          href="https://via.placeholder.com/725x1290/90D40166"
+          href="https://images.unsplash.com/photo-1611402881804-8fde5b755174"
           download="distinctio-cupiditate"
           type="application/image"
           aria-label="Download image: [READABLE_FILENAME] ([FILE_EXTENSION], [FILE_SIZE])"

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -272,7 +272,7 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link in Paragraph">
-    <p class="utrecht-paragraph utrecht-paragraph--distanced">
+    <p class="utrecht-paragraph">
       It is possible to put{" "}
       <a href="#example-link" class="denhaag-link" tabindex="0">
         <span class="denhaag-link__label">a link</span>

--- a/components/LinkGroup/src/stories/bem.stories.mdx
+++ b/components/LinkGroup/src/stories/bem.stories.mdx
@@ -173,7 +173,11 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="With Image">
     <div class="denhaag-link-group">
-      <img class="denhaag-link-group__image" src="https://via.placeholder.com/140x140" alt="placeholder" />
+      <img
+        class="denhaag-link-group__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=140&h=140"
+        alt="placeholder"
+      />
       <h4 class="utrecht-heading-4 denhaag-link-group__caption">Caption</h4>
       <ul class="utrecht-link-list utrecht-link-list--html-ul denhaag-link-group__list">
         <li class="denhaag-link-group__list-item">

--- a/components/StylesProvider/src/index.tsx
+++ b/components/StylesProvider/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StylesProvider as MaterialStylesProvider } from '@material-ui/core';
-import '@utrecht/component-library-css/dist/index.css';
+import '@utrecht/components/document/css/index.scss';
 
 export interface StylesProviderProps {
   children?: React.ReactNode;

--- a/components/Typography/src/Heading1.tsx
+++ b/components/Typography/src/Heading1.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type Heading1Props = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/Heading1.tsx
+++ b/components/Typography/src/Heading1.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading1Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading1: React.FC<Heading1Props> = (props: Heading1Props) => {
-  const rootClassNames = clsx('utrecht-heading-1', 'utrecht-heading-1--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-1', props.className);
   return <h1 className={rootClassNames}>{props.children}</h1>;
 };

--- a/components/Typography/src/Heading2.tsx
+++ b/components/Typography/src/Heading2.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading2Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading2: React.FC<Heading2Props> = (props: Heading2Props) => {
-  const rootClassNames = clsx('utrecht-heading-2', 'utrecht-heading-2--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-2', props.className);
   return <h2 className={rootClassNames}>{props.children}</h2>;
 };

--- a/components/Typography/src/Heading2.tsx
+++ b/components/Typography/src/Heading2.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type Heading2Props = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/Heading3.tsx
+++ b/components/Typography/src/Heading3.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type Heading3Props = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/Heading3.tsx
+++ b/components/Typography/src/Heading3.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading3Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading3: React.FC<Heading3Props> = (props: Heading3Props) => {
-  const rootClassNames = clsx('utrecht-heading-3', 'utrecht-heading-3--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-3', props.className);
   return <h3 className={rootClassNames}>{props.children}</h3>;
 };

--- a/components/Typography/src/Heading4.tsx
+++ b/components/Typography/src/Heading4.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type Heading4Props = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/Heading4.tsx
+++ b/components/Typography/src/Heading4.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading4Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading4: React.FC<Heading4Props> = (props: Heading4Props) => {
-  const rootClassNames = clsx('utrecht-heading-4', 'utrecht-heading-4--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-4', props.className);
   return <h4 className={rootClassNames}>{props.children}</h4>;
 };

--- a/components/Typography/src/Heading5.tsx
+++ b/components/Typography/src/Heading5.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type Heading5Props = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Heading5: React.FC<Heading5Props> = (props: Heading5Props) => {
-  const rootClassNames = clsx('utrecht-heading-5', 'utrecht-heading-5--distanced', props.className);
+  const rootClassNames = clsx('utrecht-heading-5', props.className);
   return <h5 className={rootClassNames}>{props.children}</h5>;
 };

--- a/components/Typography/src/Heading5.tsx
+++ b/components/Typography/src/Heading5.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './heading.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type Heading5Props = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/LeadParagraph.tsx
+++ b/components/Typography/src/LeadParagraph.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type LeadParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const LeadParagraph: React.FC<LeadParagraphProps> = (props: LeadParagraphProps) => {
-  const rootClassNames = clsx(
-    'utrecht-paragraph',
-    'utrecht-paragraph--lead',
-    'utrecht-paragraph--distanced',
-    props.className,
-  );
+  const rootClassNames = clsx('utrecht-paragraph', 'utrecht-paragraph--lead', props.className);
   return <p className={rootClassNames}>{props.children}</p>;
 };

--- a/components/Typography/src/Paragraph.tsx
+++ b/components/Typography/src/Paragraph.tsx
@@ -6,6 +6,6 @@ import clsx from 'clsx';
 export type ParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;
 
 export const Paragraph: React.FC<ParagraphProps> = (props: ParagraphProps) => {
-  const rootClassNames = clsx('utrecht-paragraph', 'utrecht-paragraph--distanced', props.className);
+  const rootClassNames = clsx('utrecht-paragraph', props.className);
   return <p className={rootClassNames}> {props.children}</p>;
 };

--- a/components/Typography/src/Paragraph.tsx
+++ b/components/Typography/src/Paragraph.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import BaseDataDisplayProps from '@gemeente-denhaag/basedatadisplayprops';
 import './paragraph.scss';
+import './space.scss';
 import clsx from 'clsx';
 
 export type ParagraphProps = Omit<BaseDataDisplayProps, 'classes'>;

--- a/components/Typography/src/_space-mixin.scss
+++ b/components/Typography/src/_space-mixin.scss
@@ -1,0 +1,90 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ */
+
+@mixin rich-text-space {
+  &:not(:root) {
+    /* TODO: Use `space-around` when this mixin is no longer applied on `:root`
+     * but only on specific parts of the page.
+     */
+    --utrecht-space-around: 1;
+  }
+
+  * + .utrecht-heading-1,
+  * + .utrecht-heading-2,
+  * + .utrecht-heading-3,
+  * + .utrecht-heading-4,
+  * + .utrecht-heading-5,
+  * + .utrecht-heading-6 {
+    --utrecht-heading-1-margin-block-start: 1.125em;
+  }
+
+  .utrecht-heading-1:first-child {
+    --utrecht-heading-1-margin-block-start: 0;
+  }
+
+  .utrecht-heading-2:first-child {
+    --utrecht-heading-2-margin-block-start: 0;
+  }
+
+  .utrecht-heading-3:first-child {
+    --utrecht-heading-3-margin-block-start: 0;
+  }
+
+  .utrecht-heading-4:first-child {
+    --utrecht-heading-4-margin-block-start: 0;
+  }
+
+  .utrecht-heading-5:first-child {
+    --utrecht-heading-5-margin-block-start: 0;
+  }
+
+  .utrecht-heading-6:first-child {
+    --utrecht-heading-6-margin-block-start: 0;
+  }
+
+  .utrecht-heading-1 + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-1-font-size) / 4);
+  }
+
+  .utrecht-heading-2 + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-2-font-size) / 4);
+  }
+
+  .utrecht-heading-3 + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-3-font-size) / 4);
+  }
+
+  .utrecht-heading-4 + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-4-font-size) / 4);
+  }
+
+  .utrecht-heading-5 + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-5-font-size) / 4);
+  }
+
+  .utrecht-paragraph + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-paragraph-margin-block-start);
+  }
+
+  .utrecht-paragraph--lead + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-lead-paragraph-margin-block-start);
+  }
+
+  .denhaag-ordered-list + .utrecht-paragraph,
+  .denhaag-unordered-list + .utrecht-paragraph,
+  .denhaag-list + .utrecht-paragraph,
+  .denhaag-list__wrapper + .utrecht-paragraph {
+    --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-list-margin-block-start);
+  }
+
+  .denhaag-ordered-list + .utrecht-paragraph--lead,
+  .denhaag-unordered-list + .utrecht-paragraph--lead,
+  .denhaag-list + .utrecht-paragraph--lead,
+  .denhaag-list__wrapper + .utrecht-paragraph--lead {
+    --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-lead-list-margin-block-start);
+  }
+}

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -11,42 +11,12 @@
 @import "~@utrecht/components/heading-4/css";
 @import "~@utrecht/components/heading-5/css";
 
-[class^="denhaag-"] + .utrecht-heading-1 {
-  --utrecht-heading-1-margin-block-start: calc(var(--utrecht-heading-1-font-size) * 1.125);
-}
-
-[class^="denhaag-"] + .utrecht-heading-2 {
-  --utrecht-heading-2-margin-block-start: calc(var(--utrecht-heading-2-font-size) * 1.125);
-}
-
-[class^="denhaag-"] + .utrecht-heading-3 {
-  --utrecht-heading-3-margin-block-start: calc(var(--utrecht-heading-3-font-size) * 1.125);
-}
-
-[class^="denhaag-"] + .utrecht-heading-4 {
-  --utrecht-heading-4-margin-block-start: calc(var(--utrecht-heading-4-font-size) * 1.125);
-}
-
-[class^="denhaag-"] + .utrecht-heading-5 {
-  --utrecht-heading-5-margin-block-start: calc(var(--utrecht-heading-5-font-size) * 1.125);
-}
-
-.utrecht-heading-1 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-1-font-size) / 4);
-}
-
-.utrecht-heading-2 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-2-font-size) / 4);
-}
-
-.utrecht-heading-3 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-3-font-size) / 4);
-}
-
-.utrecht-heading-4 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-4-font-size) / 4);
-}
-
-.utrecht-heading-5 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-5-font-size) / 4);
+.utrecht-heading-1,
+.utrecht-heading-2,
+.utrecht-heading-3,
+.utrecht-heading-4,
+.utrecht-heading-5,
+.utrecht-heading-6 {
+  /* TODO: Move to container element, make spacing optional */
+  --utrecht-space-around: 1;
 }

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -5,128 +5,48 @@
  * Copyright (c) 2021 The Knights Who Say NIH! B.V.
  */
 
-[class^="utrecht-heading"],
-[class*=" utrecht-heading"] {
-  color: var(--denhaag-heading-color);
-  line-height: var(--denhaag-heading-line-height);
-}
-
-.utrecht-heading-1 {
-  font-family: var(
-    --utrecht-heading-1-font-family,
-    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
-  );
-  font-size: var(--utrecht-heading-1-font-size);
-  font-weight: var(--utrecht-heading-1-font-weight, var(--utrecht-heading-font-weight, bold));
-  margin-block-start: var(--utrecht-heading-1-margin-block-start);
-  margin-block-end: var(--utrecht-heading-1-margin-block-end);
-}
-
-.utrecht-heading-1--distanced {
-  --utrecht-heading-1-margin-block-start: var(--utrecht-heading-1-distanced-margin-block-start);
-  --utrecht-heading-1-margin-block-end: var(--utrecht-heading-1-distanced-margin-block-end);
-}
-
-.utrecht-heading-1 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-1-font-size) / 4);
-}
+@import "~@utrecht/components/heading-1/css";
+@import "~@utrecht/components/heading-2/css";
+@import "~@utrecht/components/heading-3/css";
+@import "~@utrecht/components/heading-4/css";
+@import "~@utrecht/components/heading-5/css";
 
 [class^="denhaag-"] + .utrecht-heading-1 {
   --utrecht-heading-1-margin-block-start: calc(var(--utrecht-heading-1-font-size) * 1.125);
-}
-
-.utrecht-heading-2 {
-  font-family: var(
-    --utrecht-heading-2-font-family,
-    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
-  );
-  font-size: var(--utrecht-heading-2-font-size);
-  font-weight: var(--utrecht-heading-2-font-weight, var(--utrecht-heading-font-weight, bold));
-  margin-block-start: var(--utrecht-heading-2-margin-block-start);
-  margin-block-end: var(--utrecht-heading-2-margin-block-end);
-}
-
-.utrecht-heading-2--distanced {
-  --utrecht-heading-2-margin-block-start: var(--utrecht-heading-2-distanced-margin-block-start);
-  --utrecht-heading-2-margin-block-end: var(--utrecht-heading-2-distanced-margin-block-end);
-}
-
-.utrecht-heading-2 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-2-font-size) / 4);
 }
 
 [class^="denhaag-"] + .utrecht-heading-2 {
   --utrecht-heading-2-margin-block-start: calc(var(--utrecht-heading-2-font-size) * 1.125);
 }
 
-.utrecht-heading-3 {
-  font-family: var(
-    --utrecht-heading-3-font-family,
-    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
-  );
-  font-size: var(--utrecht-heading-3-font-size);
-  font-weight: var(--utrecht-heading-3-font-weight, var(--utrecht-heading-font-weight, bold));
-  margin-block-start: var(--utrecht-heading-3-margin-block-start);
-  margin-block-end: var(--utrecht-heading-3-margin-block-end);
-}
-
-.utrecht-heading-3--distanced {
-  --utrecht-heading-3-margin-block-start: var(--utrecht-heading-3-distanced-margin-block-start);
-  --utrecht-heading-3-margin-block-end: var(--utrecht-heading-3-distanced-margin-block-end);
-}
-
-.utrecht-heading-3 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-3-font-size) / 4);
-}
-
 [class^="denhaag-"] + .utrecht-heading-3 {
   --utrecht-heading-3-margin-block-start: calc(var(--utrecht-heading-3-font-size) * 1.125);
-}
-
-.utrecht-heading-4 {
-  font-family: var(
-    --utrecht-heading-4-font-family,
-    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
-  );
-  font-size: var(--utrecht-heading-4-font-size);
-  font-weight: var(--utrecht-heading-4-font-weight, var(--utrecht-heading-font-weight, bold));
-  margin-block-start: var(--utrecht-heading-4-margin-block-start);
-  margin-block-end: var(--utrecht-heading-4-margin-block-end);
-}
-
-.utrecht-heading-4--distanced {
-  --utrecht-heading-4-margin-block-start: var(--utrecht-heading-4-distanced-margin-block-start);
-  --utrecht-heading-4-margin-block-end: var(--utrecht-heading-4-distanced-margin-block-end);
-}
-
-.utrecht-heading-4 + .utrecht-paragraph {
-  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-4-font-size) / 4);
 }
 
 [class^="denhaag-"] + .utrecht-heading-4 {
   --utrecht-heading-4-margin-block-start: calc(var(--utrecht-heading-4-font-size) * 1.125);
 }
 
-.utrecht-heading-5 {
-  font-family: var(
-    --utrecht-heading-5-font-family,
-    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
-  );
-  font-size: var(--utrecht-heading-5-font-size);
-  font-weight: var(--utrecht-heading-5-font-weight, var(--utrecht-heading-font-weight, bold));
-  margin-block-start: var(--utrecht-heading-5-margin-block-start);
-  margin-block-end: var(--utrecht-heading-5-margin-block-end);
+[class^="denhaag-"] + .utrecht-heading-5 {
+  --utrecht-heading-5-margin-block-start: calc(var(--utrecht-heading-5-font-size) * 1.125);
 }
 
-.utrecht-heading-5--distanced {
-  --utrecht-heading-5-margin-block-start: var(--utrecht-heading-5-distanced-margin-block-start);
-  --utrecht-heading-5-margin-block-end: var(--utrecht-heading-5-distanced-margin-block-end);
+.utrecht-heading-1 + .utrecht-paragraph {
+  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-1-font-size) / 4);
+}
+
+.utrecht-heading-2 + .utrecht-paragraph {
+  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-2-font-size) / 4);
+}
+
+.utrecht-heading-3 + .utrecht-paragraph {
+  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-3-font-size) / 4);
+}
+
+.utrecht-heading-4 + .utrecht-paragraph {
+  --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-4-font-size) / 4);
 }
 
 .utrecht-heading-5 + .utrecht-paragraph {
   --utrecht-paragraph-margin-block-start: calc(var(--utrecht-heading-5-font-size) / 4);
-}
-
-[class^="denhaag-"] + .utrecht-heading-5 {
-  --utrecht-heading-5-margin-block-start: calc(var(--utrecht-heading-5-font-size) * 1.125);
 }

--- a/components/Typography/src/paragraph.scss
+++ b/components/Typography/src/paragraph.scss
@@ -3,32 +3,19 @@
  * Copyright (c) 2021 The Knights Who Say NIH! B.V.
  */
 
+@import "~@utrecht/components/paragraph/css";
+
 .utrecht-paragraph {
-  color: var(--utrecht-paragraph-color, var(--utrecht-document-color, inherit));
-  font-family: var(--utrecht-paragraph-font-family, var(--utrecht-document-font-family, inherit));
-  font-size: var(--utrecht-paragraph-font-size, var(--utrecht-document-font-size, inherit));
-  font-weight: var(--utrecht-paragraph-font-weight, inherit);
-  line-height: var(--utrecht-paragraph-line-height, var(--utrecht-document-line-height, normal));
-  margin-block-start: var(--utrecht-paragraph-margin-block-start);
-  margin-block-end: var(--utrecht-paragraph-margin-block-end);
-}
-
-.utrecht-paragraph--lead {
-  font-size: var(--utrecht-paragraph-lead-font-size, inherit);
-  font-weight: var(--utrecht-paragraph-lead-font-weight, inherit);
-  line-height: var(--utrecht-paragraph-lead-line-height, inherit);
-}
-
-.utrecht-paragraph--distanced {
-  --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-distanced-margin-block-start);
-  --utrecht-paragraph-margin-block-end: var(--utrecht-paragraph-distanced-margin-block-end);
+  /* TODO: Move `space-around` to container element */
+  --utrecht-space-around: 1;
 }
 
 .denhaag-paragraph--detail {
-  font-family: var(--denhaag-posttypelabel-font-family, inherit);
-  font-size: var(--denhaag-posttypelabel-font-size, 0.75rem);
+  --utrecht-paragraph-font-family: var(--denhaag-posttypelabel-font-family, inherit);
+  --utrecht-paragraph-font-size: var(--denhaag-posttypelabel-font-size, 0.75rem);
+  --utrecht-paragraph-line-height: var(--denhaag-posttypelabel-line-height, 1.5);
+
   letter-spacing: var(--denhaag-posttypelabel-letter-spacing, 1px);
-  line-height: var(--denhaag-posttypelabel-line-height, 1.5);
   text-transform: var(--denhaag-posttypelabel-text-transform, uppercase);
 }
 

--- a/components/Typography/src/paragraph.scss
+++ b/components/Typography/src/paragraph.scss
@@ -10,7 +10,7 @@
   --utrecht-space-around: 1;
 }
 
-.denhaag-paragraph--detail {
+.utrecht-paragraph--denhaag-detail {
   --utrecht-paragraph-font-family: var(--denhaag-posttypelabel-font-family, inherit);
   --utrecht-paragraph-font-size: var(--denhaag-posttypelabel-font-size, 0.75rem);
   --utrecht-paragraph-line-height: var(--denhaag-posttypelabel-line-height, 1.5);

--- a/components/Typography/src/space.scss
+++ b/components/Typography/src/space.scss
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ */
+
+@import "space-mixin";
+
+:root {
+  @include rich-text-space;
+}

--- a/components/Typography/src/stories/paragraph.bem.stories.mdx
+++ b/components/Typography/src/stories/paragraph.bem.stories.mdx
@@ -51,7 +51,7 @@ import "../paragraph.scss";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Detail Small">
-    <p class="denhaag-paragraph--detail">
+    <p class="utrecht-paragraph utrecht-paragraph--denhaag-detail">
       Atque qui praesentium provident. A aliquid quae earum neque accusamus voluptatem. Assumenda ut iure in et
       repellendus quam omnis excepturi. Vero quod eos eveniet molestias eum in quis. Delectus qui ullam necessitatibus
       illum. Beatae consequatur sint eveniet animi neque.

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "@material-ui/core": "4.12.4",
     "@material-ui/lab": "4.11.3-deprecations.1",
-    "@utrecht/component-library-css": "1.0.0-alpha.221",
-    "@utrecht/components": "1.0.0-alpha.182",
+    "@utrecht/component-library-css": "1.0.0-alpha.321",
+    "@utrecht/components": "1.0.0-alpha.282",
     "clsx": "1.1.1",
     "sass": "1.52.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   ],
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "lerna run build",
-    "build-storybook": "build-storybook",
+    "build": "yarn build:library && yarn build:storybook",
+    "build:library": "lerna run build",
+    "build:storybook": "build-storybook",
     "clean": "lerna run clean --parallel && rimraf .rollup-cache",
     "lint": "npm-run-all --continue-on-error lint:** && lerna run lint",
     "lint-fix": "npm-run-all --continue-on-error lint-fix:** prettier",

--- a/proprietary/Components/src/utrecht/heading-1.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-1.tokens.json
@@ -5,7 +5,7 @@
       "font-family": {},
       "font-size": { "value": "{denhaag.typography.scale.3xl.font-size}" },
       "font-weight": {},
-      "line-height": {},
+      "line-height": { "value": "{denhaag.typography.scale.3xl.line-height}" },
       "margin-block-end": {},
       "margin-block-start": {}
     }

--- a/proprietary/Components/src/utrecht/heading-1.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-1.tokens.json
@@ -7,12 +7,7 @@
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},
-      "margin-block-start": {},
-
-      "distanced": {
-        "margin-block-start": { "value": "0" },
-        "margin-block-end": { "value": "0" }
-      }
+      "margin-block-start": {}
     }
   }
 }

--- a/proprietary/Components/src/utrecht/heading-2.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-2.tokens.json
@@ -5,7 +5,7 @@
       "font-family": {},
       "font-size": { "value": "{denhaag.typography.scale.2xl.font-size}" },
       "font-weight": {},
-      "line-height": {},
+      "line-height": { "value": "{denhaag.typography.scale.2xl.line-height}" },
       "margin-block-end": { "value": "0.5rem" },
       "margin-block-start": { "value": "1.775rem" },
       "distanced": {

--- a/proprietary/Components/src/utrecht/heading-3.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-3.tokens.json
@@ -5,7 +5,7 @@
       "font-family": {},
       "font-size": { "value": "{denhaag.typography.scale.xl.font-size}" },
       "font-weight": {},
-      "line-height": {},
+      "line-height": { "value": "{denhaag.typography.scale.xl.line-height}" },
       "margin-block-end": { "value": "0.375rem" },
       "margin-block-start": { "value": "1.33125rem" },
       "distanced": {

--- a/proprietary/Components/src/utrecht/heading-4.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-4.tokens.json
@@ -5,7 +5,7 @@
       "font-family": {},
       "font-size": { "value": "{denhaag.typography.scale.lg.font-size}" },
       "font-weight": {},
-      "line-height": {},
+      "line-height": { "value": "{denhaag.typography.scale.lg.line-height}" },
       "margin-block-end": { "value": "0.3125rem" },
       "margin-block-start": { "value": "1.1125rem" },
       "distanced": {

--- a/proprietary/Components/src/utrecht/heading-5.tokens.json
+++ b/proprietary/Components/src/utrecht/heading-5.tokens.json
@@ -5,7 +5,7 @@
       "font-family": {},
       "font-size": { "value": "{denhaag.typography.scale.base.font-size}" },
       "font-weight": {},
-      "line-height": {},
+      "line-height": { "value": "{denhaag.typography.scale.base.line-height}" },
       "margin-block-end": { "value": "0.28125rem" },
       "margin-block-start": { "value": "1rem" },
       "distanced": {

--- a/proprietary/Components/src/utrecht/heading.tokens.json
+++ b/proprietary/Components/src/utrecht/heading.tokens.json
@@ -1,13 +1,10 @@
 {
   "utrecht": {
     "heading": {
-      "color": { "value": "{denhaag.color.grey.4}" },
+      "color": { "value": "{denhaag.heading.color}" },
+      "line-height": { "value": "{denhaag.heading.line-height}" },
       "font-family": { "value": "{denhaag.typography.sans-serif-alternate.font-family}" },
-      "font-weight": { "value": "{denhaag.typography.weight.bold}" },
-      "distanced": {
-        "margin-block-start": { "value": "0" },
-        "margin-block-end": { "value": "0" }
-      }
+      "font-weight": { "value": "{denhaag.typography.weight.bold}" }
     }
   }
 }

--- a/proprietary/Components/src/utrecht/heading.tokens.json
+++ b/proprietary/Components/src/utrecht/heading.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "heading": {
       "color": { "value": "{denhaag.heading.color}" },
-      "line-height": { "value": "{denhaag.heading.line-height}" },
+      "line-height": {},
       "font-family": { "value": "{denhaag.typography.sans-serif-alternate.font-family}" },
       "font-weight": { "value": "{denhaag.typography.weight.bold}" }
     }

--- a/proprietary/Proprietary/src/typography.tokens.json
+++ b/proprietary/Proprietary/src/typography.tokens.json
@@ -25,33 +25,37 @@
           "font-size": {
             "value": "0.875rem"
           },
-          "line-height": { "value": 1.3 }
+          "line-height": { "value": "1.3" }
         },
         "base": {
           "font-size": {
             "value": "1.125rem"
           },
-          "line-height": { "value": 1.5 }
+          "line-height": { "value": "1.5" }
         },
         "lg": {
           "font-size": {
             "value": "1.25rem"
-          }
+          },
+          "line-height": { "value": "1.3" }
         },
         "xl": {
           "font-size": {
             "value": "1.5rem"
-          }
+          },
+          "line-height": { "value": "1.3" }
         },
         "2xl": {
           "font-size": {
             "value": "2rem"
-          }
+          },
+          "line-height": { "value": "1.3" }
         },
         "3xl": {
           "font-size": {
             "value": "3rem"
-          }
+          },
+          "line-height": { "value": "1.3" }
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,17 +4899,17 @@
     "@typescript-eslint/types" "5.25.0"
     eslint-visitor-keys "^3.3.0"
 
-"@utrecht/component-library-css@1.0.0-alpha.221":
-  version "1.0.0-alpha.221"
-  resolved "https://registry.yarnpkg.com/@utrecht/component-library-css/-/component-library-css-1.0.0-alpha.221.tgz#a36df87c656da9cfff66d8841b3b06b73573693e"
-  integrity sha512-BaGr+yRWfWk9NuOI8OBlqF4+pARLXx3WdKPuy3kMiwXkdUwDQEe5cY2G2DQJ3J594aEuClh9K6A24ETVp9s03Q==
+"@utrecht/component-library-css@1.0.0-alpha.321":
+  version "1.0.0-alpha.321"
+  resolved "https://registry.yarnpkg.com/@utrecht/component-library-css/-/component-library-css-1.0.0-alpha.321.tgz#bba620964b68f230da6b5d523c57c0bf1b4852e2"
+  integrity sha512-e6Uxcw17PKYiNlIuQc6JmN8giXz+VrE3ZFAEi/cfeEX3+PP87AMD8gHNisJ20K0iFtHWtacD9FRABytzXcuBJQ==
 
-"@utrecht/components@1.0.0-alpha.182":
-  version "1.0.0-alpha.182"
-  resolved "https://registry.yarnpkg.com/@utrecht/components/-/components-1.0.0-alpha.182.tgz#1fb7f2648990956b2645c39e14c3e5a21e6c8b8b"
-  integrity sha512-RUWw9auEyQFkYuxvaXX/aAJZIN/dVxB96R7cYG2TaniqFJd/ghhXYHw9kzHVYJifbWpWjaQCHq6fX9EQDu8EGQ==
+"@utrecht/components@1.0.0-alpha.282":
+  version "1.0.0-alpha.282"
+  resolved "https://registry.yarnpkg.com/@utrecht/components/-/components-1.0.0-alpha.282.tgz#1c85e772d9011d83e1e3cad0725381a222638f98"
+  integrity sha512-IYTSOs+JYjU6gdOmKPUbrAPGhduhVX7rLvpw+MDqJyrI9tHJYfBHxic96Wz4mxVMU11oOE35O8xdV/NmcqMLYQ==
   dependencies:
-    clsx "1.1.1"
+    clsx "1.2.1"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -7002,6 +7002,11 @@ clsx@1.1.1, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
+clsx@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 cmd-shim@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Heading CSS duplicated a lot of code from `utrecht-heading` instead of importing it. Also some custom properties were hardcoded instead of configured via the design tokens JSON.

What remains is some custom code for setting margins of paragraph and heading in certain adjacency situations, this code should probably be moved to a "rich text container" component to beautifully format prose.

Not tested yet, was hoping for a branch deployment to see it in action. 🤠