### PR TITLE
style(image): remove uppercase img caption

### DIFF
--- a/components/Image/src/index.scss
+++ b/components/Image/src/index.scss
@@ -33,7 +33,6 @@
   font-size: var(--denhaag-image-figcaption-text-font-size);
   letter-spacing: var(--denhaag-image-figcaption-text-letter-spacing);
   line-height: var(--denhaag-image-figcaption-text-line-height);
-  text-transform: var(--denhaag-image-figcaption-text-text-transform);
 }
 
 .denhaag-image__figcaption-download {

--- a/proprietary/Components/src/denhaag/image.tokens.json
+++ b/proprietary/Components/src/denhaag/image.tokens.json
@@ -89,9 +89,6 @@
           },
           "line-height": {
             "value": "1.5"
-          },
-          "text-transform": {
-            "value": "uppercase"
           }
         }
       },


### PR DESCRIPTION
Solve:

- old uppercase image caption

Purpose:

- change to new non text-transform, a.k.a. the default text without transform

Figma: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=8553%3A29678

closes #1076