### PR TITLE
fix(accordion-item): fix click action on icon

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -47,6 +47,7 @@
 .denhaag-accordion__panel > .denhaag-icon {
   color: inherit;
   position: var(--denhaag-accordion-icon-position);
+  pointer-events: none;
   top: var(--denhaag-accordion-icon-top);
   right: var(--denhaag-accordion-icon-right);
   transform: var(--denhaag-accordion-icon-transform);


### PR DESCRIPTION
Fixing the click action on the icon. Since it had the default pointer-events, clicking on the icon wouldn't toggle the accordion-item.