### PR TITLE
feat(button): add icon only buttons

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -165,3 +165,18 @@ a.denhaag-button {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+.denhaag-button--icon-only {
+  --denhaag-button-medium-size-padding-block: 0.6875rem;
+  --denhaag-button-medium-size-padding-inline: 0.75rem;
+
+  padding-block-start: var(--denhaag-button-medium-size-padding-block);
+  padding-block-end: var(--denhaag-button-medium-size-padding-block);
+  padding-inline-start: var(--denhaag-button-medium-size-padding-inline);
+  padding-inline-end: var(--denhaag-button-medium-size-padding-inline);
+}
+
+.denhaag-button--icon-only .denhaag-button__icon {
+  margin-inline-end: 0;
+  margin-inline-start: 0;
+}

--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -166,17 +166,6 @@ a.denhaag-button {
   border: 0;
 }
 
-.denhaag-button--icon-only {
-  --denhaag-button-medium-size-padding-block: 0.6875rem;
-  --denhaag-button-medium-size-padding-inline: 0.75rem;
-
-  padding-block-start: var(--denhaag-button-medium-size-padding-block);
-  padding-block-end: var(--denhaag-button-medium-size-padding-block);
-  padding-inline-start: var(--denhaag-button-medium-size-padding-inline);
-  padding-inline-end: var(--denhaag-button-medium-size-padding-inline);
-}
-
 .denhaag-button--icon-only .denhaag-button__icon {
-  margin-inline-end: 0;
-  margin-inline-start: 0;
+  height: var(--denhaag-button-icon-only-height);
 }

--- a/components/Button/src/stories/bem.stories.mdx
+++ b/components/Button/src/stories/bem.stories.mdx
@@ -740,7 +740,8 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only">
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+      <button class="denhaag-button denhaag-button--icon-only">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -755,7 +756,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only">
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -772,7 +774,8 @@ import readme from "../../README.md";
       </button>
     </div>
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+      <button class="denhaag-button denhaag-button--icon-only">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -790,7 +793,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+      <button class="denhaag-button denhaag-button--icon-only">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -819,7 +823,8 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - hover">
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -834,7 +839,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -851,7 +857,8 @@ import readme from "../../README.md";
       </button>
     </div>
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -869,7 +876,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -898,10 +906,8 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - disabled">
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button
-        disabled
-        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
-      >
+      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -918,8 +924,9 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
+        class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--disabled"
       >
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -936,10 +943,8 @@ import readme from "../../README.md";
       </button>
     </div>
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button
-        disabled
-        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
-      >
+      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -957,10 +962,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button
-        disabled
-        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
-      >
+      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -989,7 +992,8 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - focus">
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -1004,7 +1008,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -1021,7 +1026,8 @@ import readme from "../../README.md";
       </button>
     </div>
     <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"
@@ -1039,7 +1045,8 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__sr-only">describing text</span>
         <span class="denhaag-button__icon">
           <svg
             width="1em"

--- a/components/Button/src/stories/bem.stories.mdx
+++ b/components/Button/src/stories/bem.stories.mdx
@@ -650,3 +650,414 @@ import readme from "../../README.md";
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
+
+### Large - focus
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Large - focus">
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--large denhaag-button--focus">Button</button>
+      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--focus">
+        Button
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M11.707 18.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 111.414 1.414L7.414 11H19a1 1 0 110 2H7.414l4.293 4.293a1 1 0 010 1.414z"></path>
+          </svg>
+        </span>
+        Button
+      </button>
+      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M11.707 18.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 111.414 1.414L7.414 11H19a1 1 0 110 2H7.414l4.293 4.293a1 1 0 010 1.414z"></path>
+          </svg>
+        </span>
+        Button
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--focus">
+        Button
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--focus">
+        Button
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Icon only
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Icon only">
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M12.2559 4.41009C12.5814 4.73553 12.5814 5.26317 12.2559 5.5886L7.84518 9.99935L12.2559 14.4101C12.5814 14.7355 12.5814 15.2632 12.2559 15.5886C11.9305 15.914 11.4028 15.914 11.0774 15.5886L6.07741 10.5886C5.75197 10.2632 5.75197 9.73553 6.07741 9.41009L11.0774 4.41009C11.4028 4.08466 11.9305 4.08466 12.2559 4.41009Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M7.74408 15.5899C7.41864 15.2645 7.41864 14.7368 7.74408 14.4114L12.1548 10.0007L7.74408 5.58991C7.41864 5.26447 7.41864 4.73683 7.74408 4.4114C8.06951 4.08596 8.59715 4.08596 8.92259 4.4114L13.9226 9.4114C14.248 9.73683 14.248 10.2645 13.9226 10.5899L8.92259 15.5899C8.59715 15.9153 8.06951 15.9153 7.74408 15.5899Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Icon only - hover
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Icon only - hover">
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M12.2559 4.41009C12.5814 4.73553 12.5814 5.26317 12.2559 5.5886L7.84518 9.99935L12.2559 14.4101C12.5814 14.7355 12.5814 15.2632 12.2559 15.5886C11.9305 15.914 11.4028 15.914 11.0774 15.5886L6.07741 10.5886C5.75197 10.2632 5.75197 9.73553 6.07741 9.41009L11.0774 4.41009C11.4028 4.08466 11.9305 4.08466 12.2559 4.41009Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--hover">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M7.74408 15.5899C7.41864 15.2645 7.41864 14.7368 7.74408 14.4114L12.1548 10.0007L7.74408 5.58991C7.41864 5.26447 7.41864 4.73683 7.74408 4.4114C8.06951 4.08596 8.59715 4.08596 8.92259 4.4114L13.9226 9.4114C14.248 9.73683 14.248 10.2645 13.9226 10.5899L8.92259 15.5899C8.59715 15.9153 8.06951 15.9153 7.74408 15.5899Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Icon only - disabled
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Icon only - disabled">
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button
+        disabled
+        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
+      >
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+      <button
+        disabled
+        class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
+      >
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button
+        disabled
+        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
+      >
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M12.2559 4.41009C12.5814 4.73553 12.5814 5.26317 12.2559 5.5886L7.84518 9.99935L12.2559 14.4101C12.5814 14.7355 12.5814 15.2632 12.2559 15.5886C11.9305 15.914 11.4028 15.914 11.0774 15.5886L6.07741 10.5886C5.75197 10.2632 5.75197 9.73553 6.07741 9.41009L11.0774 4.41009C11.4028 4.08466 11.9305 4.08466 12.2559 4.41009Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        disabled
+        class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--disabled"
+      >
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M7.74408 15.5899C7.41864 15.2645 7.41864 14.7368 7.74408 14.4114L12.1548 10.0007L7.74408 5.58991C7.41864 5.26447 7.41864 4.73683 7.74408 4.4114C8.06951 4.08596 8.59715 4.08596 8.92259 4.4114L13.9226 9.4114C14.248 9.73683 14.248 10.2645 13.9226 10.5899L8.92259 15.5899C8.59715 15.9153 8.06951 15.9153 7.74408 15.5899Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Icon only - focus
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Icon only - focus">
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"></path>
+          </svg>
+        </span>
+      </button>
+    </div>
+    <div class="denhaag-button-group denhaag-button-group--multiple">
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M12.2559 4.41009C12.5814 4.73553 12.5814 5.26317 12.2559 5.5886L7.84518 9.99935L12.2559 14.4101C12.5814 14.7355 12.5814 15.2632 12.2559 15.5886C11.9305 15.914 11.4028 15.914 11.0774 15.5886L6.07741 10.5886C5.75197 10.2632 5.75197 9.73553 6.07741 9.41009L11.0774 4.41009C11.4028 4.08466 11.9305 4.08466 12.2559 4.41009Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+      <button class="denhaag-button denhaag-button--end-icon denhaag-button--icon-only denhaag-button--focus">
+        <span class="denhaag-button__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+          >
+            <path
+              d="M7.74408 15.5899C7.41864 15.2645 7.41864 14.7368 7.74408 14.4114L12.1548 10.0007L7.74408 5.58991C7.41864 5.26447 7.41864 4.73683 7.74408 4.4114C8.06951 4.08596 8.59715 4.08596 8.92259 4.4114L13.9226 9.4114C14.248 9.73683 14.248 10.2645 13.9226 10.5899L8.92259 15.5899C8.59715 15.9153 8.06951 15.9153 7.74408 15.5899Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -49,6 +49,9 @@
       "medium-size": {
         "padding-block": { "value": "{denhaag.button.padding-block}" },
         "padding-inline": { "value": "{denhaag.button.padding-inline}" }
+      },
+      "icon-only": {
+        "height": { "value": "{denhaag.space.block.lg}" }
       }
     }
   }


### PR DESCRIPTION
### Solve:

- new button icon only missing

### Purpose:

- add icon only buttons, bem + css
![Screenshot 2022-08-30 at 15 50 02](https://user-images.githubusercontent.com/95216123/187454618-76e37d59-3a1d-4ac5-9e85-d517adfd4342.png)


### Figma:

- icon only, arrow right: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1%3A656
- icon only, horizontal scroll buttons (for mobile table): https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=5213%3A16235 

closes #1078