### PR TITLE
fix(button): style correction btn icon-only

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -166,6 +166,14 @@ a.denhaag-button {
   border: 0;
 }
 
-.denhaag-button--icon-only .denhaag-button__icon {
+.denhaag-button--icon-only {
+  --denhaag-button-medium-size-padding-inline: 0.75rem;
+
   height: var(--denhaag-button-icon-only-height);
+  padding-inline-start: var(--denhaag-button-medium-size-padding-inline);
+  padding-inline-end: var(--denhaag-button-medium-size-padding-inline);
+}
+
+.denhaag-button--icon-only .denhaag-button__icon {
+  height: var(--denhaag-button-icon-only-icon-height);
 }

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -51,7 +51,10 @@
         "padding-inline": { "value": "{denhaag.button.padding-inline}" }
       },
       "icon-only": {
-        "height": { "value": "{denhaag.space.block.lg}" }
+        "height": { "value": "2.6875rem" },
+        "icon": {
+          "height": { "value": "{denhaag.space.block.lg}" }
+        }
       }
     }
   }


### PR DESCRIPTION
### Solve:

- incorrect button icon-only height and width

### Purpose:

- height and width correction of button icon-only variant

Figma: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1%3A656

### Screenshot before:
![Screenshot 2022-08-31 at 11 35 31](https://user-images.githubusercontent.com/95216123/187648682-59f47882-b919-473f-aa72-594eaafa95dc.png)

### Screenshot after:
![Screenshot 2022-08-31 at 11 35 37](https://user-images.githubusercontent.com/95216123/187648735-93bd855b-e0b0-4a46-8692-34c808bca0a2.png)


closes #1080