### PR TITLE
style(image): remove letter-spacing

### DIFF
--- a/components/Image/src/index.scss
+++ b/components/Image/src/index.scss
@@ -31,7 +31,6 @@
   grid-area: image-figcaption;
   color: var(--denhaag-image-figcaption-text-color);
   font-size: var(--denhaag-image-figcaption-text-font-size);
-  letter-spacing: var(--denhaag-image-figcaption-text-letter-spacing);
   line-height: var(--denhaag-image-figcaption-text-line-height);
 }
 

--- a/proprietary/Components/src/denhaag/image.tokens.json
+++ b/proprietary/Components/src/denhaag/image.tokens.json
@@ -84,9 +84,6 @@
           "font-size": {
             "value": "{denhaag.typography.scale.s.font-size}"
           },
-          "letter-spacing": {
-            "value": "1px"
-          },
           "line-height": {
             "value": "1.5"
           }


### PR DESCRIPTION
### Solve:
- outdated image caption style (letter-spacing)
- figma: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=8553%3A29678

### Purpose:

- update image caption style (remove letter-spacing)

closes #1085
