### PR TITLE
style(button): prevent full width btn

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -16,6 +16,7 @@
   padding-inline-start: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
   position: relative;
   text-decoration: none;
+  width: max-content;
 }
 
 a.denhaag-button {


### PR DESCRIPTION
### Solve:

- button width not correct
- figma: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1%3A656

### Purpose:

- prevent button width from being 100% of parent

### Screenshot before:
![Screenshot 2022-09-06 at 12 11 03](https://user-images.githubusercontent.com/95216123/188609567-2e952de8-0bbc-456e-9a4e-8bd78600f09e.png)


### Screenshot after:
![Screenshot 2022-09-06 at 12 12 48](https://user-images.githubusercontent.com/95216123/188609604-fb2e87c8-c407-42af-9056-451eb641463c.png)


closes #1086