### PR TITLE
docs(release): update package versions

### DIFF
--- a/components/DynamicContent/package.json
+++ b/components/DynamicContent/package.json
@@ -3,7 +3,7 @@
   "description": "Dynamic content component, used to display content in multiple ways.",
   "author": "Municipality of The Hague",
   "license": "EUPL-1.2",
-  "version": "0.1.1-alpha.43",
+  "version": "0.1.1-alpha.44",
   "exports": {
     ".": {
       "types": "./dist/cjs/index.d.ts",
@@ -30,7 +30,7 @@
   "bugs": "https://github.com/nl-design-system/denhaag/issues",
   "devDependencies": {
     "@gemeente-denhaag/icons": "0.2.3-alpha.270",
-    "@gemeente-denhaag/image": "0.1.1-alpha.178",
+    "@gemeente-denhaag/image": "0.1.1-alpha.179",
     "@gemeente-denhaag/link": "0.2.3-alpha.270",
     "@gemeente-denhaag/pagination": "0.1.1-alpha.197"
   },

--- a/components/Image/package.json
+++ b/components/Image/package.json
@@ -3,7 +3,7 @@
   "description": "Image component",
   "author": "Municipality of The Hague",
   "license": "EUPL-1.2",
-  "version": "0.1.1-alpha.178",
+  "version": "0.1.1-alpha.179",
   "exports": {
     ".": {
       "types": "./dist/cjs/index.d.ts",

--- a/components/Table/package.json
+++ b/components/Table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemeente-denhaag/table",
-  "version": "0.1.1-alpha.171",
+  "version": "0.1.1-alpha.172",
   "description": "A Table component",
   "bugs": "https://github.com/nl-design-system/denhaag/issues",
   "repository": {


### PR DESCRIPTION
Solve:

- npm publish tags are not up-to-date, so when updating packages (@gemeente-denhaag/components-css, @gemeente-denhaag/design-tokens-common and @gemeente-denhaag/design-tokens-components) in another project, they still get the old tags/npm publish dates/versions

Purpose:

- update package versions, so the npm publish tags will be hopefully updated

closes #1089