### PR TITLE
style(typography): change font-family, mobile font-sizes

### DIFF
--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -19,13 +19,7 @@
 .utrecht-heading-6 {
   /* TODO: Move to container element, make spacing optional */
   --utrecht-space-around: 1;
-}
 
-.utrecht-heading-1,
-.utrecht-heading-2,
-.utrecht-heading-3,
-.utrecht-heading-4,
-.utrecht-heading-5 {
   font-family: var(--denhaag-typography-sans-serif-alternate);
 }
 

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -20,17 +20,13 @@
   /* TODO: Move to container element, make spacing optional */
   --utrecht-space-around: 1;
 
-  font-family: var(--denhaag-typography-sans-serif-alternate);
+  font-family: var(--utrecht-heading-font-family);
 }
 
 @media (max-width: 768px) {
-  .utrecht-heading-1 {
-    --utrecht-heading-1-font-size: 2.25rem;
-  }
-  .utrecht-heading-2 {
-    --utrecht-heading-2-font-size: 1.75rem;
-  }
-  .utrecht-heading-3 {
-    --utrecht-heading-3-font-size: 1.4375rem;
+  .denhaag-theme {
+    --utrecht-heading-1-font-size: var(--denhaag-typography-mobile-scale-3xl-font-size);
+    --utrecht-heading-2-font-size: var(--denhaag-typography-mobile-scale-2xl-font-size);
+    --utrecht-heading-3-font-size: var(--denhaag-typography-mobile-scale-xl-font-size);
   }
 }

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -15,8 +15,7 @@
 .utrecht-heading-2,
 .utrecht-heading-3,
 .utrecht-heading-4,
-.utrecht-heading-5,
-.utrecht-heading-6 {
+.utrecht-heading-5 {
   /* TODO: Move to container element, make spacing optional */
   --utrecht-space-around: 1;
 

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -20,3 +20,23 @@
   /* TODO: Move to container element, make spacing optional */
   --utrecht-space-around: 1;
 }
+
+.utrecht-heading-1,
+.utrecht-heading-2,
+.utrecht-heading-3,
+.utrecht-heading-4,
+.utrecht-heading-5 {
+  font-family: var(--denhaag-typography-sans-serif-alternate);
+}
+
+@media (max-width: 768px) {
+  .utrecht-heading-1 {
+    --utrecht-heading-1-font-size: 2.25rem;
+  }
+  .utrecht-heading-2 {
+    --utrecht-heading-2-font-size: 1.75rem;
+  }
+  .utrecht-heading-3 {
+    --utrecht-heading-3-font-size: 1.4375rem;
+  }
+}

--- a/proprietary/Proprietary/src/typography.tokens.json
+++ b/proprietary/Proprietary/src/typography.tokens.json
@@ -57,6 +57,19 @@
           },
           "line-height": { "value": "1.3" }
         }
+      },
+      "mobile": {
+        "scale": {
+          "xl": {
+            "font-size": { "value": "1.4375rem" }
+          },
+          "2xl": {
+            "font-size": { "value": "1.75rem" }
+          },
+          "3xl": {
+            "font-size": { "value": "2.25rem" }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Solve:

- headings on mobile are to big
- font-family for headings is not the correct one

### Purpose:

- add mobile headings font-sizes
- change headings font-family to theMix

### Figma:

- https://www.figma.com/file/fCCe3DA2gCfsqYOm0vuPsi/Final-UI---Transitie-Online?node-id=7416%3A91424

closes #1092