### PR TITLE
fix: add removed authentication block and mark it deprecated

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -40,6 +40,12 @@ const addonStatus = {
         description:
           'Do not use in production. Does not follow semantic versioning and any published packages are for internal use only.',
       },
+      DEPRECATED: {
+        background: '#9e1616',
+        color: '#ffffff',
+        description:
+          'This component is no longer supported. If used in production, please replace with the recommended alternative.',
+      },
     },
   },
 };

--- a/components/AuthenticationBlock/package.json
+++ b/components/AuthenticationBlock/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@gemeente-denhaag/authentication-block",
+  "version": "0.1.1-alpha.139",
+  "description": "The Authentication block component",
+  "bugs": "https://github.com/nl-design-system/denhaag/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nl-design-system/denhaag.git",
+    "directory": "components/AuthenticationBlock"
+  },
+  "license": "EUPL-1.2",
+  "author": "Municipality of The Hague",
+  "exports": {
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "import": "./dist/mjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./index.css": "./dist/index.css"
+  },
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c ../../rollup.config.js",
+    "clean": "yarn rimraf dist tsconfig.tsbuildinfo"
+  }
+}

--- a/components/AuthenticationBlock/src/index.scss
+++ b/components/AuthenticationBlock/src/index.scss
@@ -1,0 +1,190 @@
+.denhaag-authentication {
+  // Calculation between Block CSS variables.
+  --denhaag-authentication-logo-with-gap: calc(
+    var(--denhaag-authentication-gap-small) + var(--denhaag-authentication-logo-size)
+  );
+
+  // Overrule CSS variables of used innerblocks.
+  --denhaag-button-group-padding: 0;
+  --denhaag-image-image-aspect-ratio: #{1} / #{1};
+  --denhaag-image-image-height: auto;
+  --denhaag-image-image-width: var(--denhaag-authentication-logo-size);
+  --denhaag-image-margin-inline: 0;
+
+  display: grid;
+  gap: var(--denhaag-authentication-gap);
+
+  @media (min-width: 375px) {
+    --denhaag-authentication-gap: var(--denhaag-authentication-gap-sm, 32px);
+  }
+
+  & + & {
+    margin-block-start: var(--denhaag-authentication-gap);
+  }
+
+  &__card {
+    align-self: stretch;
+    border: 1px solid var(--denhaag-authentication-border-color);
+    display: flex;
+    flex-direction: column;
+    gap: var(--denhaag-authentication-gap-small);
+    padding-inline-start: var(--denhaag-authentication-gap);
+    padding-inline-end: var(--denhaag-authentication-gap);
+    padding-block-start: var(--denhaag-authentication-gap);
+    padding-block-end: var(--denhaag-authentication-gap);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--denhaag-authentication-gap);
+  }
+
+  .denhaag-image {
+    margin-block-start: 0;
+    margin-block-end: var(--denhaag-authentication-image-spacing-end, 0);
+    max-width: var(--denhaag-authentication-logo-size);
+  }
+
+  // Remove unnecessary of existing blocks.
+  .utrecht-heading-3,
+  p {
+    margin-block-end: 0;
+    margin-block-start: 0;
+  }
+
+  // Modifiers & child-elements based on the modifier.
+  &--landscape {
+    --denhaag-authentication-image-spacing-end: var(--denhaag-authentication-gap);
+    @media (min-width: 375px) {
+      --denhaag-authentication-image-spacing-end: 0;
+    }
+  }
+
+  &--landscape &__header {
+    display: flex;
+    flex-direction: column;
+
+    .denhaag-image {
+      align-self: flex-end;
+    }
+
+    @media (min-width: 375px) {
+      .denhaag-image + * {
+        margin-block-start: calc(-1 * var(--denhaag-authentication-logo-size));
+      }
+    }
+  }
+
+  &--landscape .utrecht-heading-3,
+  &--landscape .utrecht-paragraph {
+    @media (min-width: 375px) {
+      max-width: calc(100% - var(--denhaag-authentication-logo-with-gap));
+    }
+  }
+
+  &--portrait {
+    --denhaag-button-group-flex-direction: unset;
+
+    @media (min-width: 375px) {
+      --denhaag-authentication-logo-size: var(--denhaag-authentication-portrait-logo-size-sm, 80px);
+
+      align-items: center;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+  }
+
+  &--portrait &__header {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    @media (max-width: 375px) {
+      .denhaag-image {
+        align-self: flex-end;
+
+        & + * {
+          margin-block-start: calc(-1 * var(--denhaag-authentication-logo-size));
+        }
+      }
+    }
+
+    @media (min-width: 375px) {
+      align-items: center;
+      gap: 24px;
+    }
+  }
+
+  &--portrait &__content {
+    display: flex;
+    width: 100%;
+
+    @media (min-width: 375px) {
+      flex-direction: column;
+    }
+  }
+
+  &--portrait .denhaag-button,
+  &--portrait .denhaag-button-group--single {
+    align-self: center;
+  }
+
+  &--portrait .denhaag-button-group {
+    --denhaag-button-group-flex-direction: column;
+  }
+
+  &--portrait .utrecht-heading-3,
+  &--portrait .utrecht-paragraph {
+    max-width: calc(100% - var(--denhaag-authentication-logo-with-gap));
+
+    @media (min-width: 375px) {
+      max-width: 100%;
+    }
+  }
+
+  &__footer-divider {
+    position: relative;
+  }
+
+  &__footer-label {
+    background: var(--denhaag-authentication-divider-label-background);
+    left: 50%;
+    padding-block-end: var(--denhaag-authentication-divider-label-padding-block);
+    padding-block-start: var(--denhaag-authentication-divider-label-padding-block);
+    padding-inline-end: var(--denhaag-authentication-divider-label-padding-inline);
+    padding-inline-start: var(--denhaag-authentication-divider-label-padding-inline);
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &-item {
+    align-items: center;
+    color: var(--denhaag-authentication-item-color, var(--denhaag-link-color));
+    display: flex;
+    flex-direction: row;
+    gap: var(--denhaag-authentication-item-gap, var(--denhaag-authentication-gap-small));
+    text-decoration: none;
+    width: 100%;
+
+    &:hover {
+      color: var(--denhaag-authentication-item-hover-color, var(--denhaag-link-hover-color));
+    }
+
+    &:focus-visible {
+      outline: var(--denhaag-authentication-item-focus-outline, var(--denhaag-link-focus-outline));
+    }
+
+    // CSS support may there be more than one item is added.
+    & + & {
+      margin-block-start: var(--denhaag-authentication-item-gap, var(--denhaag-authentication-gap-small));
+    }
+  }
+
+  &-item svg,
+  &-item__image {
+    height: auto;
+    max-width: var(--denhaag-authentication-item-image-width);
+  }
+}

--- a/components/AuthenticationBlock/src/stories/bem.stories.mdx
+++ b/components/AuthenticationBlock/src/stories/bem.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta, Story } from "@storybook/addon-docs";
+
+<Meta
+  title="CSS/Actions/Authentication Block"
+  parameters={{
+    status: {
+      type: "DEPRECATED",
+    },
+  }}
+/>
+
+# Authentication Block
+
+This is a early implementation of the Authentication Card.
+In practice we discovered a better name and more responsive way to implement this component. Please use this new implementation: `denhaag-card-authentication` instead.
+
+## Deprecated
+
+In the future we will remove this old implementation, so if you are using this component please consider updating your code.
+Otherwise you will not be able to keep receiving CSS updates without breaking changes.
+
+## Authentication Card
+
+<Story id="css-cards-authentication-card--default-story" />
+
+---
+
+<a className="denhaag-link" href="?path=/story/css-cards-authentication-card--default-story">
+  Naar Authentication Card
+</a>

--- a/components/AuthenticationBlock/tsconfig.json
+++ b/components/AuthenticationBlock/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "src/**/*.stories.tsx"]
+}


### PR DESCRIPTION
We thought no one was using the AuthenticationBlock, but as @YourivHDenHaag found out today it is actually used https://denhaag.staging.acato.nl/nl/parkeren/plattegronden-en-parkeerkosten/

- [x] Add the old CSS back
- [x] Reintroduce a story where we mark de AuthenticationBlock as default
- [x] Introduce "DEPRECATED" badge for stories

<img width="1329" alt="Screenshot 2022-09-14 at 17 24 22" src="https://user-images.githubusercontent.com/877246/190196710-f28330b3-9e58-44ad-bf4d-3c6e52191451.png">