### PR TITLE
fix(dynamic-content-title): word-break and hyphens issue

### DIFF
--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -114,6 +114,7 @@
   line-height: var(--denhaag-dynamic-content-card-title-line-height);
   margin-block-start: 0;
   margin-block-end: 0;
+  word-break: break-all; // Fixes hypens issue for Chrome & safari on windows device.
 }
 
 .denhaag-dynamic-content__pagination {

--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -114,7 +114,7 @@
   line-height: var(--denhaag-dynamic-content-card-title-line-height);
   margin-block-start: 0;
   margin-block-end: 0;
-  word-break: break-all; // Fixes hypens issue for Chrome & safari on windows device.
+  word-break: break-word; // Fixes hypens issue for Chrome & safari on windows device.
 }
 
 .denhaag-dynamic-content__pagination {


### PR DESCRIPTION
Fix issue for Chrome for windows and Safari in default.

Causing the CSS grid not to work properly because it pushes out the first 2 columns, therefore the third shrinks.

Without word-break:
![Schermafbeelding 2022-09-15 om 08 23 58](https://user-images.githubusercontent.com/94894596/190329807-58c9e390-89d7-4087-b32f-fd300e82e98b.png)

With word-break:
![Schermafbeelding 2022-09-15 om 08 24 07](https://user-images.githubusercontent.com/94894596/190329801-05752031-45d1-457e-a717-8140f1276dc0.png)
