### PR TITLE
style(font-weight): accordion, breadcrumb, button

### DIFF
--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -28,7 +28,7 @@
   position: inherit;
   width: inherit;
   font-family: inherit;
-  font-weight: inherit;
+  font-weight: var(--denhaag-accordion-panel-font-weight, 400);
   outline: var(--denhaag-accordion-panel-outline);
   align-items: var(--denhaag-accordion-panel-align-items);
   border-radius: var(--denhaag-accordion-panel-border-radius);
@@ -147,8 +147,9 @@
 }
 
 .denhaag-accordion__container--open .denhaag-accordion__panel {
+  --denhaag-accordion-panel-font-weight: var(--denhaag-accordion-container-open-panel-font-weight);
+
   color: var(--denhaag-accordion-container-open-panel-color);
-  font-weight: var(--denhaag-accordion-container-open-panel-font-weight);
 }
 
 .denhaag-accordion__details {

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -6,6 +6,7 @@
   --denhaag-breadcrumb-item-display: none;
 
   color: var(--denhaag-breadcrumb-color, inherit);
+  font-weight: var(--denhaag-breadcrumb-font-weight, 400);
   padding-block-end: var(--denhaag-breadcrumb-padding-block);
   padding-block-start: var(--denhaag-breadcrumb-padding-block);
   padding-inline-end: var(--denhaag-breadcrumb-padding-inline);

--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -7,6 +7,7 @@
   cursor: var(--denhaag-button-cursor, default);
   display: inline-flex;
   font-family: var(--denhaag-button-font-family);
+  font-weight: var(--denhaag-button-font-weight, 400);
   font-size: var(--denhaag-typography-scale-base-font-size);
   justify-content: center;
   line-height: 1.5;

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -77,6 +77,9 @@
         },
         "font-size": {
           "value": "{denhaag.typography.scale.base.font-size}"
+        },
+        "font-weight": {
+          "value": "{denhaag.typography.weight.regular}"
         }
       },
       "title": {

--- a/proprietary/Components/src/denhaag/breadcrumb.tokens.json
+++ b/proprietary/Components/src/denhaag/breadcrumb.tokens.json
@@ -7,6 +7,9 @@
       "color": {
         "value": "{denhaag.color.grey.4}"
       },
+      "font-weight": {
+        "value": "{denhaag.typography.weight.regular}"
+      },
       "padding-block": {
         "value": "1rem"
       },

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -4,6 +4,7 @@
       "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
       "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+      "font-weight": { "value": "{denhaag.typography.weight.regular}" },
       "padding-block": { "value": "{denhaag.space.block.xs}" },
       "padding-inline": { "value": "{denhaag.space.inline.md}" },
       "focus": {


### PR DESCRIPTION
### Solve:

Wrong font-weight 100 in Firefox:
- Accordion panel
- Breadcrumb
- Buttons

### Purpose:

Font-weight correction/explicit font-weight 400, caused by Firefox font-weight inheritance:
- Accordion panel
- Breadcrumb
- Buttons

### Figma:

- Accordion: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1585%3A0
- Breadcrumb: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1569%3A5671
- Button: https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1%3A656

closes #1110