### PR TITLE
style(anchor-collapse): remove margin

### DIFF
--- a/components/AnchorCollapse/src/index.scss
+++ b/components/AnchorCollapse/src/index.scss
@@ -66,7 +66,6 @@
   border-top: var(--denhaag-anchor-collapse-border-width) var(--denhaag-anchor-collapse-border-style)
     var(--denhaag-anchor-collapse-border-color);
   display: var(--denhaag-anchor-collapse-content-display);
-  margin-block-start: var(--denhaag-anchor-collapse-content-margin-block-start, 0.5rem);
   padding-block-end: var(
     --denhaag-anchor-collapse-content-padding-block-end,
     var(--denhaag-anchor-collapse-summary-padding-block)

--- a/components/AnchorCollapse/src/index.scss
+++ b/components/AnchorCollapse/src/index.scss
@@ -110,4 +110,8 @@
     );
     --denhaag-anchor-collapse-summary-margin-block-start: var(--utrecht-heading-2-margin-block-start);
   }
+
+  .denhaag-anchor-collapse__content {
+    margin-block-start: var(--denhaag-anchor-collapse-content-margin-block-start, 0.5rem);
+  }
 }

--- a/proprietary/Components/src/denhaag/anchor-collapse.tokens.json
+++ b/proprietary/Components/src/denhaag/anchor-collapse.tokens.json
@@ -16,11 +16,6 @@
         "value": "-180deg"
       },
       "content": {
-        "margin": {
-          "block": {
-            "start": { "value": "{denhaag.space.block.xs}" }
-          }
-        },
         "padding": {
           "block": {
             "start": {

--- a/proprietary/Components/src/denhaag/anchor-collapse.tokens.json
+++ b/proprietary/Components/src/denhaag/anchor-collapse.tokens.json
@@ -16,6 +16,11 @@
         "value": "-180deg"
       },
       "content": {
+        "margin": {
+          "block": {
+            "start": { "value": "{denhaag.space.block.xs}" }
+          }
+        },
         "padding": {
           "block": {
             "start": {


### PR DESCRIPTION
### Solve:

- to much margin above anchor content when collapsed

### Purpose:

- move margin anchor content to desktop (not-collapsed)

### Figma:

- https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1628%3A287

closes #1117