### PR TITLE
build: add cicd for website branch

### DIFF
--- a/.github/workflows/cicd-website.yml
+++ b/.github/workflows/cicd-website.yml
@@ -1,0 +1,92 @@
+name: CI/CD Den Haag website branch
+
+on:
+  push:
+    branches:
+      - www.denhaag.nl
+  pull_request:
+    branches:
+      - www.denhaag.nl
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3.2.0
+        with:
+          node-version: "16.13.x"
+
+      - name: yarn install
+        run: |
+          npm install -g yarn
+          yarn install --frozen-lockfile
+
+      - name: run linters
+        run: |
+          yarn lint:css
+          yarn lint:package
+          yarn lint:js
+          yarn lint:prettier
+
+      - name: build library
+        run: yarn build:library
+
+      - name: typecheck storybook
+        run: yarn typecheck:storybook
+
+      - name: build storybook
+        run: yarn build:storybook
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/www.denhaag.nl'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3.2.0
+        with:
+          node-version: "16.13.x"
+
+      - name: yarn install
+        run: |
+          npm install -g yarn
+          yarn install --frozen-lockfile
+
+      - name: build library
+        run: yarn build
+
+      - name: lerna version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          GIT_AUTHOR_NAME: "Den Haag website"
+          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+          GIT_COMMITTER_NAME: "Den Haag website"
+        run: |
+          git push --set-upstream origin HEAD
+          yarn release -- --yes --no-git-tag-version --preid www-denhaag-nl
+
+      - name: lerna publish
+        with:
+          node-version: "16.13.x"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@gemeente-denhaag"
+        env:
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        run: |
+          npm config set "//npm.pkg.github.com/:_authToken" "${GH_ADMIN_TOKEN}"
+          npm config set access public
+          npm run publish -- --no-verify-access --yes
+          npm config delete "//npm.pkg.github.com/:_authToken"


### PR DESCRIPTION
For v1 of the website we have decided to split the code and responsibilities for the website components and CSS in a separate branch.

To ensure Acato can use this code in a package as they did before with the package from the npm registry we add a build step to publish the website code to the github registry instead.

I've already added a website branch just now with some editor rights, changed the access for acato-team and the design-system team and added some minor settings for the website branch to make it protected still and prevent merge commits.

Once this code is merged we will change the merge/admin rights on the main branch.