### PR TITLE
style(breadcrumb): change media query

### DIFF
--- a/components/Breadcrumb/README.md
+++ b/components/Breadcrumb/README.md
@@ -20,8 +20,10 @@ The breadcrumb consists of:
 
 1. Page link: directs users to the parent-level page
 2. Seperator: clearly distinguishes between each page
-3. Icon (optional): this icon shows the homepage
+3. House icon (optional): this icon shows the homepage
 4. Collapsed icon: hides the intermediate pages
+5. Container: the background with the breadcrumbs on it
+6. Arrow icon and page link (only on mobile)
 
 ## (Interactive) states
 
@@ -35,22 +37,44 @@ The breadcrumb contains the states inactive, active, hover and focus.
 
 ### Color
 
+#### Desktop
+
 - Inactive page link: text color Blue/3
 - Active page link: text color Grey/4
-- Separator: svg color Grey/4
-- Icon: svg color Blue/3
+- Seperator: svg color Grey/4
+- House icon: svg color Blue/3
 - Collapsed icon: background-color Grey/1, svg fill color Grey/3
+- Container: background-color Warm grey
+
+#### Mobile
+
+- Arrow and page link: icon color Blue/3, text color Blue/3
 
 ### Interactive states
 
-- Hover: page link text color Blue/4, icon svg color Blue/4, collapsed icon background-color Grey/2
-- Focus: page link text color Blue/4, icon svg color Blue/4, border color Ocher/5
+#### Desktop
+
+- Hover: page link text color Blue/4, house icon svg color Blue/4, collapsed icon background-color Grey/2
+- Focus: page link text color Blue/4, house icon svg color Blue/4, border color Ocher/5
+
+#### Mobile
+
+- Focus: page link text color Blue/4, border color Ocher/5
 
 ### Structure
 
-- Seperator: margin-left and margin-right 8px, height and width 16px
-- Icon: height and width 20px
+#### Desktop
+
+- Seperator: margin-left and margin-right 8px, size 16px
+- Icon: size 20px
 - Collapsed icon: height 16px, width 24px
+- - Background: padding-top and padding-bottom 12px
+
+#### Mobile
+
+Arrow icon: size 20px, margin-right 8px
+
+- Container: padding-top and padding-bottom 16px
 
 ## Accessibility
 
@@ -58,13 +82,11 @@ The breadcrumb contains the states inactive, active, hover and focus.
 
 ## Content guidelines
 
-### Page links
+### Page links should:
 
-Page links should:
-
-- Be short and clearly reflect the location or entity it links to;
-- Start with the highest level parent page and move deeper into the information architecture as the breadcrumb trail progresses;
-- Be consistent with the page titles;
+- Be short and clearly reflect the location or entity it links to
+- Start with the highest level parent page and move deeper into the information architecture as the breadcrumb trail progresses
+- Be consistent with the page titles
 
 ## Best practices
 
@@ -77,9 +99,11 @@ Breadcrumbs should:
 - Include the current page as the last item in the breadcrumb trail
 - Include only site pages, not logical categories in your information architecture
 - Include the full navigational path
-- Use a collapsed icon to truncate the breadcrumbs when space becomes limited
+- Use an collapsed icon per page to truncate the breadcrumbs when space becomes limited (see ‘Logic’)
+- Show on the pages that are truncated with the collapsed icon, on hover a tooltip that displays the full page name.
 - Not exceed half of the page
 - Preferably not have more than 6 pages. If there are more than 6 pages, look how you can improve the menu structure.
+- Only include the last level on a viewport smaller than 1024px.
 
 ### Don’ts
 
@@ -93,11 +117,14 @@ Breadcrumbs should:
 - Always show the first and current page
 - Only use the collapsed icon if there are more than 4 pages.
 - If the collapsed icon is used, always show on the right side the underlying page and next to this the current page.
-  - If there are for example 5 pages, then show the homepage (1), hide the 2nd and 3rd page and show the 4th and current page (5).
-  - If there are for example 6 pages, then show the homepage
+
+#### Logic - Examples
+
+- If there are for example 5 pages, then show the homepage (1), hide the 2nd and 3rd page and show the 4th and current page (5).
+- If there are for example 6 pages, then show the homepage (1), hide the 2nd, 3rd and 4th page and show the 5th and current page (6).
 
 ## References
 
-[https://www.nngroup.com/articles/breadcrumbs/](https://www.nngroup.com/articles/breadcrumbs/)
-[https://blog.hubspot.com/marketing/navigation-breadcrumbs](https://blog.hubspot.com/marketing/navigation-breadcrumbs)
-[https://blog.prototypr.io/design-guide-breadcrumbs-a980eb28bfaa?gi=a989e02ab9ff](https://blog.prototypr.io/design-guide-breadcrumbs-a980eb28bfaa?gi=a989e02ab9ff)
+- https://www.nngroup.com/articles/breadcrumbs/
+- https://blog.hubspot.com/marketing/navigation-breadcrumbs
+- https://blog.prototypr.io/design-guide-breadcrumbs-a980eb28bfaa?gi=a989e02ab9ff

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -34,6 +34,17 @@ ol.denhaag-breadcrumb__list {
   --denhaag-breadcrumb-item-display: flex;
 }
 
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link::before {
+  color: var(--denhaag-breadcrumb-dots-color, inherit);
+  content: "...";
+  left: calc(50% - 7px);
+  line-height: 0;
+  position: absolute;
+  text-indent: 0;
+  top: calc(50% - 5px);
+  vertical-align: baseline;
+}
+
 .denhaag-breadcrumb__item:nth-last-child(2) > .denhaag-breadcrumb__link::before {
   background: var(--denhaag-breadcrumb-link-color);
   clip-path: path(
@@ -71,6 +82,13 @@ ol.denhaag-breadcrumb__list {
   outline: var(--denhaag-breadcrumb-link-focus-outline, var(--denhaag-link-focus-outline));
 }
 
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link {
+  aspect-ratio: 24/16;
+  border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
+  max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
+  text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
+}
+
 .denhaag-breadcrumb__link--current .denhaag-breadcrumb__link,
 .denhaag-breadcrumb__item:last-child .denhaag-breadcrumb__link {
   pointer-events: var(--denhaag-breadcrumb-link-pointer-events);
@@ -106,6 +124,10 @@ ol.denhaag-breadcrumb__list {
   margin-inline-end: calc(-1 * var(--denhaag-breadcrumb-spacing, 8px));
 }
 
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text + .denhaag-icon {
+  margin-inline-start: 2rem;
+}
+
 [dir="rtl"] .denhaag-breadcrumb__link > .denhaag-breadcrumb__text + .denhaag-icon,
 [dir="rtl"] .denhaag-breadcrumb__item:nth-last-child(2) > .denhaag-breadcrumb__link::before {
   transform: scaleX(-1);
@@ -120,22 +142,62 @@ ol.denhaag-breadcrumb__list {
   white-space: var(--denhaag-breadcrumb-text-white-space, nowrap);
 }
 
+// .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {
+//   aspect-ratio: 24/16;
+//   border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
+//   max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
+//   text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
+// }
+
+// .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text::before {
+//   color: var(--denhaag-breadcrumb-dots-color, inherit);
+//   content: "...";
+//   left: calc(50% - 7px);
+//   line-height: 0;
+//   position: absolute;
+//   text-indent: 0;
+//   top: calc(50% - 5px);
+//   vertical-align: baseline;
+// }
+
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {
-  aspect-ratio: 24/16;
-  border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
-  max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-  text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
+  display: none;
 }
 
-.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text::before {
-  color: var(--denhaag-breadcrumb-dots-color, inherit);
-  content: "...";
-  left: calc(50% - 7px);
-  line-height: 0;
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link:hover .denhaag-breadcrumb__text {
+  overflow: unset;
+  max-width: unset;
+  text-overflow: unset;
+  white-space: unset;
+  text-indent: unset;
+  display: inline-block;
   position: absolute;
-  text-indent: 0;
-  top: calc(50% - 5px);
-  vertical-align: baseline;
+  bottom: -100%;
+  left: -100%;
+  width: max-content;
+  height: fit-content;
+  background-color: #4b4b4b;
+  color: white;
+  font-family: "TheSans", sans-serif;
+  font-size: 14px;
+  line-height: 1.3;
+  font-weight: 400;
+  padding-block-start: 8px;
+  padding-block-end: 8px;
+  padding-inline-start: 12px;
+  text-align: center;
+  padding-inline-end: 12px;
+}
+
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link:hover .denhaag-breadcrumb__text::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  background-color: #4b4b4b;
+  transform: rotate(45deg);
+  position: absolute;
+  top: -3px;
+  left: calc(50% - 3px);
 }
 
 @media (min-width: 1024px) {

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -53,7 +53,6 @@ ol.denhaag-breadcrumb__list {
   padding-block-end: var(--denhaag-breadcrumb-spacing, 8px);
   padding-inline-start: var(--denhaag-breadcrumb-spacing, 8px);
   padding-inline-end: var(--denhaag-breadcrumb-spacing, 8px);
-  pointer-events: var(--denhaag-breadcrumb-link-pointer-events);
   position: relative;
   text-decoration: var(--denhaag-breadcrumb-link-text-decoration, none);
 }
@@ -70,6 +69,11 @@ ol.denhaag-breadcrumb__list {
   --denhaag-breadcrumb-link-text-decoration: var(--denhaag-breadcrumb-link-focus-text-decoration, underline);
 
   outline: var(--denhaag-breadcrumb-link-focus-outline, var(--denhaag-link-focus-outline));
+}
+
+.denhaag-breadcrumb__link--current .denhaag-breadcrumb__link,
+.denhaag-breadcrumb__item:last-child .denhaag-breadcrumb__link {
+  pointer-events: var(--denhaag-breadcrumb-link-pointer-events);
 }
 
 .denhaag-breadcrumb__item:nth-child(1) {
@@ -109,9 +113,11 @@ ol.denhaag-breadcrumb__list {
 
 .denhaag-breadcrumb__text {
   background-color: var(--denhaag-breadcrumb-link-background-color);
-  overflow: hidden;
-  position: relative;
-  text-overflow: ellipsis;
+  overflow: var(--denhaag-breadcrumb-text-overflow, hidden);
+  position: var(--denhaag-breadcrumb-text-position, relative);
+  max-width: var(--denhaag-breadcrumb-text-max-width, 16.5rem);
+  text-overflow: var(--denhaag-breadcrumb-text-text-overflow, ellipsis);
+  white-space: var(--denhaag-breadcrumb-text-white-space, nowrap);
 }
 
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -37,12 +37,33 @@ ol.denhaag-breadcrumb__list {
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link::before {
   color: var(--denhaag-breadcrumb-dots-color, inherit);
   content: "...";
-  left: calc(50% - 7px);
-  line-height: 0;
-  position: absolute;
-  text-indent: 0;
-  top: calc(50% - 5px);
-  vertical-align: baseline;
+  left: var(--denhaag-breadcrumb-item-hidden-link-before-left, auto);
+  line-height: var(--denhaag-breadcrumb-item-hidden-link-before-line-height, 0);
+  position: var(--denhaag-breadcrumb-item-hidden-link-before-position, absolute);
+  text-indent: var(--denhaag-breadcrumb-item-hidden-link-before-text-indent, 0);
+  top: var(--denhaag-breadcrumb-item-hidden-link-before-top, auto);
+  vertical-align: var(--denhaag-breadcrumb-item-hidden-link-before-vertical-align, baseline);
+  aspect-ratio: var(--denhaag-breadcrumb-item-hidden-link-before-aspect-ratio, 24 / 16);
+  border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
+  background-color: var(--denhaag-breadcrumb-link-background-color);
+  max-width: calc(var(--denhaag-breadcrumb-spacing, 0.5rem) * 3);
+  padding-block-start: var(--denhaag-breadcrumb-item-hidden-link-before-padding-block, 0.1875rem);
+  padding-block-end: var(--denhaag-breadcrumb-item-hidden-link-before-padding-block, 0.1875rem);
+  padding-inline-start: var(--denhaag-breadcrumb-item-hidden-link-before-padding-inline, 0.2813rem);
+  padding-inline-end: var(--denhaag-breadcrumb-item-hidden-link-before-padding-inline, 0.2813rem);
+}
+
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link:hover::after,
+.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link--hover::after {
+  content: "";
+  width: var(--denhaag-breadcrumb-item-hidden-link-after-width, 0.375rem);
+  height: var(--denhaag-breadcrumb-item-hidden-link-after-height, 0.375rem);
+  background-color: var(--denhaag-breadcrumb-item-hidden-link-after-background-color, var(--denhaag-color-grey-4));
+  transform: var(--denhaag-breadcrumb-item-hidden-link-after-transform, rotate(45deg));
+  position: var(--denhaag-breadcrumb-item-hidden-link-after-position, absolute);
+  bottom: calc(-1 * var(--denhaag-breadcrumb-item-hidden-link-after-height));
+  left: calc(50% - (var(--denhaag-breadcrumb-item-hidden-link-after-height) * 2));
+  display: var(--denhaag-breadcrumb-item-hidden-link-after-display, inline-block);
 }
 
 .denhaag-breadcrumb__item:nth-last-child(2) > .denhaag-breadcrumb__link::before {
@@ -60,10 +81,10 @@ ol.denhaag-breadcrumb__list {
   align-items: center;
   color: var(--denhaag-breadcrumb-link-color, inherit);
   display: flex;
-  padding-block-start: var(--denhaag-breadcrumb-spacing, 8px);
-  padding-block-end: var(--denhaag-breadcrumb-spacing, 8px);
-  padding-inline-start: var(--denhaag-breadcrumb-spacing, 8px);
-  padding-inline-end: var(--denhaag-breadcrumb-spacing, 8px);
+  padding-block-start: var(--denhaag-breadcrumb-spacing, 0.5rem);
+  padding-block-end: var(--denhaag-breadcrumb-spacing, 0.5rem);
+  padding-inline-start: var(--denhaag-breadcrumb-spacing, 0.5rem);
+  padding-inline-end: var(--denhaag-breadcrumb-spacing, 0.5rem);
   position: relative;
   text-decoration: var(--denhaag-breadcrumb-link-text-decoration, none);
 }
@@ -80,13 +101,6 @@ ol.denhaag-breadcrumb__list {
   --denhaag-breadcrumb-link-text-decoration: var(--denhaag-breadcrumb-link-focus-text-decoration, underline);
 
   outline: var(--denhaag-breadcrumb-link-focus-outline, var(--denhaag-link-focus-outline));
-}
-
-.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link {
-  aspect-ratio: 24/16;
-  border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
-  max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-  text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
 }
 
 .denhaag-breadcrumb__link--current .denhaag-breadcrumb__link,
@@ -120,12 +134,12 @@ ol.denhaag-breadcrumb__list {
   color: initial;
   font-size: inherit;
   display: var(--denhaag-breadcrumb-chevron-display);
-  margin-inline-start: var(--denhaag-breadcrumb-spacing, 8px);
-  margin-inline-end: calc(-1 * var(--denhaag-breadcrumb-spacing, 8px));
+  margin-inline-start: var(--denhaag-breadcrumb-spacing, 0.5rem);
+  margin-inline-end: calc(-1 * var(--denhaag-breadcrumb-spacing, 0.5rem));
 }
 
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text + .denhaag-icon {
-  margin-inline-start: 2rem;
+  margin-inline-start: var(--denhaag-breadcrumb-item-hidden-icon-margin-inline-start, var(--denhaag-space-inline-2xl));
 }
 
 [dir="rtl"] .denhaag-breadcrumb__link > .denhaag-breadcrumb__text + .denhaag-icon,
@@ -142,62 +156,38 @@ ol.denhaag-breadcrumb__list {
   white-space: var(--denhaag-breadcrumb-text-white-space, nowrap);
 }
 
-// .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {
-//   aspect-ratio: 24/16;
-//   border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
-//   max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-//   text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-// }
-
-// .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text::before {
-//   color: var(--denhaag-breadcrumb-dots-color, inherit);
-//   content: "...";
-//   left: calc(50% - 7px);
-//   line-height: 0;
-//   position: absolute;
-//   text-indent: 0;
-//   top: calc(50% - 5px);
-//   vertical-align: baseline;
-// }
-
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {
-  display: none;
+  --denhaag-breadcrumb-text-overflow: var(--denhaag-breadcrumb-item-hidden-text-overflow, visible);
+  --denhaag-breadcrumb-text-max-width: var(--denhaag-breadcrumb-item-hidden-text-max-width, unset);
+  --denhaag-breadcrumb-text-text-overflow: var(--denhaag-breadcrumb-item-hidden-text-text-overflow, unset);
+  --denhaag-breadcrumb-text-white-space: var(--denhaag-breadcrumb-item-hidden-text-white-space, unset);
+  --denhaag-breadcrumb-text-position: var(--denhaag-breadcrumb-item-hidden-text-position, absolute);
+  --denhaag-breadcrumb-link-background-color: var(
+    --denhaag-breadcrumb-item-hidden-text-background-color,
+    var(--denhaag-color-grey-4)
+  );
+
+  text-indent: var(--denhaag-breadcrumb-item-hidden-text-text-indent, 0);
+  visibility: var(--denhaag-breadcrumb-item-hidden-text-visibility, hidden);
+  opacity: var(--denhaag-breadcrumb-item-hidden-text-opacity, 0%);
+  bottom: var(--denhaag-breadcrumb-item-hidden-text-bottom, -100%);
+  left: var(--denhaag-breadcrumb-item-hidden-text-left, -50%);
+  width: var(--denhaag-breadcrumb-item-hidden-text-width, max-content);
+  height: var(--denhaag-breadcrumb-item-hidden-text-height, fit-content);
+  color: var(--denhaag-breadcrumb-item-hidden-text-color, var(--denhaag-color-white));
+  font-family: var(--denhaag-breadcrumb-item-hidden-text-font-family, var(--denhaag-typography-sans-serif-font-family));
+  font-size: var(--denhaag-breadcrumb-item-hidden-text-font-size, var(--denhaag-typography-scale-s-font-size));
+  line-height: var(--denhaag-breadcrumb-item-hidden-text-height, var(--denhaag-typography-scale-s-line-height));
+  font-weight: var(--denhaag-breadcrumb-item-hidden-text-font-weight, var(--denhaag-typography-weight-regular));
+  padding-block-start: var(--denhaag-breadcrumb-item-hidden-text-padding-block, var(--denhaag-space-block-xs));
+  padding-block-end: var(--denhaag-breadcrumb-item-hidden-text-padding-block, var(--denhaag-space-block-xs));
+  padding-inline-start: var(--denhaag-breadcrumb-item-hidden-text-padding-inline, 0.75rem);
+  padding-inline-end: var(--denhaag-breadcrumb-item-hidden-text-padding-inline, 0.75rem);
 }
 
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link:hover .denhaag-breadcrumb__text {
-  overflow: unset;
-  max-width: unset;
-  text-overflow: unset;
-  white-space: unset;
-  text-indent: unset;
-  display: inline-block;
-  position: absolute;
-  bottom: -100%;
-  left: -100%;
-  width: max-content;
-  height: fit-content;
-  background-color: #4b4b4b;
-  color: white;
-  font-family: "TheSans", sans-serif;
-  font-size: 14px;
-  line-height: 1.3;
-  font-weight: 400;
-  padding-block-start: 8px;
-  padding-block-end: 8px;
-  padding-inline-start: 12px;
-  text-align: center;
-  padding-inline-end: 12px;
-}
-
-.denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__link:hover .denhaag-breadcrumb__text::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  background-color: #4b4b4b;
-  transform: rotate(45deg);
-  position: absolute;
-  top: -3px;
-  left: calc(50% - 3px);
+  visibility: visible;
+  opacity: 100%;
 }
 
 @media (min-width: 1024px) {
@@ -223,43 +213,3 @@ ol.denhaag-breadcrumb__list {
     --denhaag-breadcrumb-padding-inline: 0;
   }
 }
-
-// Deprecated, but added to prevent breaking changes.
-/* stylelint-disable selector-class-pattern */
-/* stylelint-disable no-descending-specificity */
-.breadcrumbs-container {
-  .denhaag-breadcrumb {
-    .denhaag-breadcrumb__list {
-      margin-inline-end: auto;
-      margin-inline-start: auto;
-      max-width: var(--denhaag-breadcrumb-list-max-width, 100%);
-
-      .denhaag-breadcrumb__item {
-        .denhaag-breadcrumb__link {
-          padding-inline-start: var(--denhaag-breadcrumb-spacing, 8px);
-        }
-      }
-
-      .denhaag-breadcrumb__item:not(:first-child):not(:nth-last-child(2)):not(:last-child) .denhaag-breadcrumb__text {
-        aspect-ratio: 24/16;
-        border-radius: var(--denhaag-breadcrumb-dots-border-radius, var(--denhaag-border-radius));
-        max-width: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-        text-indent: calc(var(--denhaag-breadcrumb-spacing, 8px) * 3);
-      }
-
-      .denhaag-breadcrumb__item:not(:first-child):not(:nth-last-child(2)):not(:last-child)
-        .denhaag-breadcrumb__text::before {
-        color: var(--denhaag-breadcrumb-dots-color, inherit);
-        content: "...";
-        left: calc(50% - 7px);
-        line-height: 0;
-        position: absolute;
-        text-indent: 0;
-        top: calc(50% - 5px);
-        vertical-align: baseline;
-      }
-    }
-  }
-}
-/* stylelint-enable no-descending-specificity */
-/* stylelint-enable selector-class-pattern */

--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -132,7 +132,7 @@ ol.denhaag-breadcrumb__list {
   vertical-align: baseline;
 }
 
-@media (min-width: 481px) {
+@media (min-width: 1024px) {
   .denhaag-breadcrumb {
     --denhaag-breadcrumb-chevron-display: inline-block;
     --denhaag-breadcrumb-link-icon-content: unset;

--- a/components/Breadcrumb/src/stories/bem.stories.mdx
+++ b/components/Breadcrumb/src/stories/bem.stories.mdx
@@ -447,9 +447,6 @@ import readme from "../../README.md";
             <a class="denhaag-breadcrumb__link" href="https://example.com/a/" itemprop="item">
               <span class="denhaag-breadcrumb__text" itemprop="name">
                 In de stad
-                <span className="denhaag-breadcrumb__tooltip" aria-label="pop up showing title of hidden link text">
-                  In de stad
-                </span>
               </span>
               <svg
                 width="1em"
@@ -500,16 +497,12 @@ import readme from "../../README.md";
             </a>
           </li>
           <li
-            class="denhaag-breadcrumb__item"
+            class="denhaag-breadcrumb__item denhaag-breadcrumb__item--hidden"
             itemscope
             itemtype="https://schema.org/ListItem"
             itemprop="itemListElement"
           >
-            <a
-              class="denhaag-breadcrumb__link denhaag-breadcrumb__item--hidden"
-              href="https://example.com/a/"
-              itemprop="item"
-            >
+            <a class="denhaag-breadcrumb__link" href="https://example.com/a/" itemprop="item">
               <span class="denhaag-breadcrumb__text" itemprop="name">
                 Loosduinen
               </span>

--- a/components/Breadcrumb/src/stories/bem.stories.mdx
+++ b/components/Breadcrumb/src/stories/bem.stories.mdx
@@ -446,7 +446,10 @@ import readme from "../../README.md";
           >
             <a class="denhaag-breadcrumb__link" href="https://example.com/a/" itemprop="item">
               <span class="denhaag-breadcrumb__text" itemprop="name">
-                Wonen en leven
+                In de stad
+                <span className="denhaag-breadcrumb__tooltip" aria-label="pop up showing title of hidden link text">
+                  In de stad
+                </span>
               </span>
               <svg
                 width="1em"
@@ -475,7 +478,7 @@ import readme from "../../README.md";
           >
             <a class="denhaag-breadcrumb__link" href="https://example.com/a/" itemprop="item">
               <span class="denhaag-breadcrumb__text" itemprop="name">
-                Wonen en leven
+                Stadsdelen
               </span>
               <svg
                 width="1em"
@@ -502,9 +505,13 @@ import readme from "../../README.md";
             itemtype="https://schema.org/ListItem"
             itemprop="itemListElement"
           >
-            <a class="denhaag-breadcrumb__link" href="https://example.com/a/" itemprop="item">
+            <a
+              class="denhaag-breadcrumb__link denhaag-breadcrumb__item--hidden"
+              href="https://example.com/a/"
+              itemprop="item"
+            >
               <span class="denhaag-breadcrumb__text" itemprop="name">
-                Wonen en leven
+                Loosduinen
               </span>
               <svg
                 width="1em"
@@ -533,7 +540,7 @@ import readme from "../../README.md";
           >
             <a class="denhaag-breadcrumb__link" href="https://example.com/a/b/" itemprop="item">
               <span class="denhaag-breadcrumb__text" itemprop="name">
-                Afval
+                Nieuws stadsdeel Loosduinen
               </span>
               <svg
                 width="1em"
@@ -567,7 +574,7 @@ import readme from "../../README.md";
               aria-current="page"
             >
               <span class="denhaag-breadcrumb__text" itemprop="name">
-                Kliko&apos;s
+                Ut aspernatur qui quidem ipsum alias asperiores
               </span>
               <meta itemprop="position" content="4" />
             </a>

--- a/proprietary/Components/src/denhaag/breadcrumb.tokens.json
+++ b/proprietary/Components/src/denhaag/breadcrumb.tokens.json
@@ -69,6 +69,13 @@
           "text-decoration": { "value": "underline" }
         }
       },
+      "text": {
+        "overflow": { "value": "hidden" },
+        "position": { "value": "relative" },
+        "max-width": { "value": "16.5rem" },
+        "text-overflow": { "value": "ellipsis" },
+        "white-space": { "value": "nowrap" }
+      },
       "list": {
         "max-width": {
           "value": "67.5rem"

--- a/proprietary/Components/src/denhaag/breadcrumb.tokens.json
+++ b/proprietary/Components/src/denhaag/breadcrumb.tokens.json
@@ -76,9 +76,50 @@
         "text-overflow": { "value": "ellipsis" },
         "white-space": { "value": "nowrap" }
       },
-      "list": {
-        "max-width": {
-          "value": "67.5rem"
+      "item-hidden": {
+        "link-before": {
+          "left": { "value": "auto" },
+          "line-height": { "value": "0" },
+          "position": { "value": "absolute" },
+          "text-indent": { "value": "0" },
+          "top": { "value": "auto" },
+          "vertical-align": { "value": "baseline" },
+          "aspect-ratio": { "value": "24 / 16" },
+          "padding-block": { "value": "0.1875rem" },
+          "padding-inline": { "value": "0.2813rem" }
+        },
+        "link-after": {
+          "width": { "value": "0.375rem" },
+          "height": { "value": "0.375rem" },
+          "background-color": { "value": "{denhaag.color.grey.4}" },
+          "transform": { "value": "rotate(45deg)" },
+          "position": { "value": "absolute" },
+          "display": { "value": "inline-block" }
+        },
+        "icon": {
+          "margin-inline-start": { "value": "{denhaag.space.inline.2xl}" }
+        },
+        "text": {
+          "overflow": { "value": "visible" },
+          "max-width": { "value": "unset" },
+          "text-overflow": { "value": "unset" },
+          "white-space": { "value": "unset" },
+          "position": { "value": "absolute" },
+          "background-color": { "value": "{denhaag.color.grey.4}" },
+          "text-indent": { "value": "0" },
+          "visibility": { "value": "hidden" },
+          "opacity": { "value": "0%" },
+          "bottom": { "value": "-100%" },
+          "left": { "value": "-50%" },
+          "width": { "value": "max-content" },
+          "height": { "value": "fit-content" },
+          "color": { "value": "{denhaag.color.white}" },
+          "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
+          "font-size": { "value": "{denhaag.typography.scale.s.font-size}" },
+          "line-height": { "value": "{denhaag.typography.scale.s.line-height}" },
+          "font-weight": { "value": "{denhaag.typography.weight.regular}" },
+          "padding-block": { "value": "{denhaag.space.block.xs}" },
+          "padding-inline": { "value": "0.75rem" }
         }
       }
     }


### PR DESCRIPTION
### Purpose:

- For viewports under 1024px, just like on mobile, we show the breadcrumb with back arrow.
- For 5 items or more we use truncation (or the collapsed icon).
- Always show the 1st page in the path and the current one.
- We display the collapsed icon for each hidden page. It is also clickable and takes you to the page.
- For each hidden page, we also display a tooltip. This shows the name of the page. It did not exist and was therefore designed.
- We break off the current page, or the last item, with an ellipsis. 

### Figma:

- https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Design-System---Gemeente-Den-Haag?node-id=1569%3A5671

### Screen Captures:

- https://user-images.githubusercontent.com/95216123/194615050-0a2a54d7-4c79-4d17-99a3-3c3d6ab8d10d.mov
- https://user-images.githubusercontent.com/95216123/194615091-5dc80f17-65ce-4ab3-8a5c-1f1585231fec.mov

### Remark

- Only applied new styles to the `.denhaag-breadcrumb__item--hidden class` in the  Long Breadcrumb + previous path and current path (ellipsis)
- added some refactor
- seperate tokens for the `.denhaag-breadcrumb__item--hidden` applied styles
- removed depricated css

closes  #1120