### PR TITLE
fix: remove new spacing rules, which broke many components/templates

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -178,12 +178,3 @@ a.denhaag-button {
 .denhaag-button--icon-only .denhaag-button__icon {
   height: var(--denhaag-button-icon-only-icon-height);
 }
-
-[class^="utrecht-heading"] + .denhaag-button,
-[class*=" utrecht-heading"] + .denhaag-button {
-  margin-block-start: var(--denhaag-space-block-xs);
-}
-
-.utrecht-paragraph + .denhaag-button {
-  margin-block-start: var(--denhaag-space-block-md);
-}

--- a/components/Typography/src/heading.scss
+++ b/components/Typography/src/heading.scss
@@ -22,67 +22,10 @@
   font-family: var(--utrecht-heading-font-family);
 }
 
-.utrecht-heading-1:first-child {
-  /* overwriting root :root .utrecht-heading-1:first-child */
-  --utrecht-heading-1-margin-block-start: var(--denhaag-space-block-xs, 0.5rem) !important;
-}
-
-*:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-  + .utrecht-heading-2 {
-  --utrecht-heading-2-margin-block-start: var(--denhaag-space-block-4xl);
-}
-
-*:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-  + .utrecht-heading-3 {
-  --utrecht-heading-3-margin-block-start: var(--denhaag-space-block-3xl);
-}
-
-*:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-  + .utrecht-heading-4 {
-  --utrecht-heading-4-margin-block-start: var(--denhaag-space-block-2xl);
-}
-
-*:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-  + .utrecht-heading-5 {
-  --utrecht-heading-5-margin-block-start: var(--denhaag-space-block-xl);
-}
-
-[class^="utrecht-heading"] + *:not(.denhaag-button),
-[class*=" utrecht-heading"] + *:not(.denhaag-button) {
-  margin-block-start: var(--denhaag-space-block-xl);
-}
-
 @media (max-width: 768px) {
   .denhaag-theme {
     --utrecht-heading-1-font-size: var(--denhaag-typography-mobile-scale-3xl-font-size);
     --utrecht-heading-2-font-size: var(--denhaag-typography-mobile-scale-2xl-font-size);
     --utrecht-heading-3-font-size: var(--denhaag-typography-mobile-scale-xl-font-size);
-  }
-}
-
-@media (min-width: 768px) {
-  .utrecht-heading-1:first-child {
-    /* overwriting root :root .utrecht-heading-1:first-child */
-    --utrecht-heading-1-margin-block-start: 0 !important;
-  }
-
-  *:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-    + .utrecht-heading-2 {
-    --utrecht-heading-2-margin-block-start: var(--denhaag-space-block-5xl);
-  }
-
-  *:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-    + .utrecht-heading-3 {
-    --utrecht-heading-3-margin-block-start: var(--denhaag-space-block-4xl);
-  }
-
-  *:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-    + .utrecht-heading-4 {
-    --utrecht-heading-4-margin-block-start: var(--denhaag-space-block-3xl);
-  }
-
-  *:not(.denhaag-columns):not(.denhaag-button-group):not(.denhaag-featured-posts):not(.denhaag-page-buttons):not(.denhaag-image)
-    + .utrecht-heading-5 {
-    --utrecht-heading-5-margin-block-start: var(--denhaag-space-block-2xl);
   }
 }

--- a/components/Typography/src/paragraph.scss
+++ b/components/Typography/src/paragraph.scss
@@ -40,21 +40,3 @@
 .denhaag-list__wrapper + .utrecht-paragraph--lead {
   --utrecht-paragraph-margin-block-start: var(--utrecht-paragraph-lead-list-margin-block-start, inherit);
 }
-
-@media (min-width: 768px) {
-  *:not(.utrecht-paragraph):not([class^="utrecht-heading"]):not([class*=" utrecht-heading"]) + .utrecht-paragraph {
-    margin-block-start: var(--denhaag-space-block-2xl);
-  }
-
-  .utrecht-paragraph + *:not(.utrecht-paragraph):not([class^="utrecht-heading"]):not([class*=" utrecht-heading"]) {
-    margin-block-start: var(--denhaag-space-block-2xl);
-  }
-}
-
-*:not(.utrecht-paragraph):not([class^="utrecht-heading"]):not([class*=" utrecht-heading"]) + .utrecht-paragraph {
-  margin-block-start: var(--denhaag-space-block-xl);
-}
-
-.utrecht-paragraph + *:not(.utrecht-paragraph):not([class^="utrecht-heading"]):not([class*=" utrecht-heading"]) {
-  margin-block-start: var(--denhaag-space-block-xl);
-}


### PR DESCRIPTION
This PR reverts some changes made earlier, which broke many components. The PR can be merged after the new Den Haag website branch is ready.

We are going to write out spacing rules, and translate those rules to styling to fix the issue with spacing between all kinds of components.