### PR TITLE
Fix/gdh 738 denhaag link external

### DIFF
--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -44,6 +44,11 @@
 
 .denhaag-link--external {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align);
+
+  display: inline;
+  padding-inline-end: 1.5rem;
+  position: relative;
+  hyphens: auto;
 }
 
 .denhaag-link--focus,
@@ -82,6 +87,12 @@
 li .denhaag-link__icon {
   align-self: start;
   flex: 1 0 auto;
+}
+
+.denhaag-link--external .denhaag-link__icon {
+  position: absolute;
+  right: 0;
+  bottom: 0;
 }
 
 .denhaag-link__icon > :first-child {

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -68,10 +68,32 @@ li .denhaag-link__icon {
   display: var(--denhaag-link-external-display, initial);
 }
 
+/* undo change .denhaag-card-authentication */
+.denhaag-card-authentication .utrecht-paragraph .denhaag-link--external {
+  display: inline-flex;
+}
+
 .utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
 .denhaag-unordered-list .denhaag-link--external .denhaag-link__icon,
 .denhaag-ordered-list.denhaag-link--external .denhaag-link__icon {
   margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
+}
+
+/* undo change .denhaag-card-authentication */
+.denhaag-card-authentication .utrecht-paragraph .denhaag-link--external .denhaag-link__icon {
+  margin-inline-start: unset;
+}
+
+.utrecht-paragraph .denhaag-link--external.denhaag-link--with-small-icon .denhaag-link__icon {
+  vertical-align: var(--denhaag-link-external-icon-small-vertical-align, middle);
+}
+
+/* undo change .denhaag-card-authentication */
+.denhaag-card-authentication
+  .utrecht-paragraph
+  .denhaag-link--external.denhaag-link--with-small-icon
+  .denhaag-link__icon {
+  vertical-align: text-top;
 }
 
 .denhaag-unordered-list li > .denhaag-link--external .denhaag-icon,

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -60,15 +60,22 @@ li .denhaag-link__icon {
 
 .denhaag-link--external {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align);
+}
 
+.utrecht-paragraph .denhaag-link--external,
+.denhaag-unordered-list li > .denhaag-link--external,
+.denhaag-ordered-list li > .denhaag-link--external {
   display: var(--denhaag-link-external-display, initial);
 }
 
-.denhaag-link--external .denhaag-link__icon {
+.utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
+.denhaag-unordered-list .denhaag-link--external .denhaag-link__icon,
+.denhaag-ordered-list.denhaag-link--external .denhaag-link__icon {
   margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
 }
 
-li > .denhaag-link--external .denhaag-icon {
+.denhaag-unordered-list li > .denhaag-link--external .denhaag-icon,
+.denhaag-ordered-list li > .denhaag-link--external .denhaag-icon {
   --denhaag-listitem-link-external-icon-size: calc(var(--denhaag-link-icon-size) - 0.3125rem);
 
   width: var(--denhaag-listitem-link-external-icon-size, 0.9375rem);

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -86,7 +86,7 @@ li .denhaag-link__icon {
 
 /* undo change .denhaag-card-authentication */
 /* stylelint-disable-next-line no-descending-specificity */
-.denhaag-card-authentication .denhaag-link__icon {
+.denhaag-card-authentication .denhaag-link--external .denhaag-link__icon {
   --denhaag-link-with-icon-vertical-align: text-top;
 
   margin-inline-start: unset;

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -42,13 +42,37 @@
   --denhaag-link-padding-inline-end: 0;
 }
 
+.denhaag-link__icon {
+  align-items: var(--denhaag-link-icon-align);
+  display: inline-flex;
+  height: var(--denhaag-link-icon-size);
+  justify-content: center;
+  order: var(--denhaag-link-icon-order, 0);
+  position: relative;
+  vertical-align: text-top;
+  width: var(--denhaag-link-icon-size);
+}
+
+li .denhaag-link__icon {
+  align-self: start;
+  flex: 1 0 auto;
+}
+
 .denhaag-link--external {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align);
 
-  display: inline;
-  padding-inline-end: 1.5rem;
-  position: relative;
-  hyphens: auto;
+  display: var(--denhaag-link-external-display, initial);
+}
+
+.denhaag-link--external .denhaag-link__icon {
+  margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
+}
+
+li > .denhaag-link--external .denhaag-icon {
+  --denhaag-listitem-link-external-icon-size: calc(var(--denhaag-link-icon-size) - 0.3125rem);
+
+  width: var(--denhaag-listitem-link-external-icon-size, 0.9375rem);
+  height: var(--denhaag-listitem-link-external-icon-size, 0.9375rem);
 }
 
 .denhaag-link--focus,
@@ -71,28 +95,6 @@
   --denhaag-link-cursor: none;
 
   pointer-events: none;
-}
-
-.denhaag-link__icon {
-  align-items: var(--denhaag-link-icon-align);
-  display: inline-flex;
-  height: var(--denhaag-link-icon-size);
-  justify-content: center;
-  order: var(--denhaag-link-icon-order, 0);
-  position: relative;
-  vertical-align: text-top;
-  width: var(--denhaag-link-icon-size);
-}
-
-li .denhaag-link__icon {
-  align-self: start;
-  flex: 1 0 auto;
-}
-
-.denhaag-link--external .denhaag-link__icon {
-  position: absolute;
-  right: 0;
-  bottom: 0;
 }
 
 .denhaag-link__icon > :first-child {

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -62,22 +62,16 @@ li .denhaag-link__icon {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align);
 }
 
-/* undo change .denhaag-card-authentication */
-.denhaag-card-authentication .denhaag-link--external {
-  display: inline-flex;
-}
-
 .utrecht-paragraph .denhaag-link--external,
 .denhaag-unordered-list li > .denhaag-link--external,
 .denhaag-ordered-list li > .denhaag-link--external {
   display: var(--denhaag-link-external-display, initial);
 }
 
-/* undo change .denhaag-card-authentication */
-.denhaag-card-authentication .denhaag-link__icon {
-  --denhaag-link-with-icon-vertical-align: text-top;
-
-  margin-inline-start: unset;
+/* undo change .denhaag-card-authentication  */
+/* stylelint-disable-next-line no-descending-specificity */
+.denhaag-card-authentication .denhaag-link--external {
+  display: inline-flex;
 }
 
 .utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
@@ -86,8 +80,16 @@ li .denhaag-link__icon {
   margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
 }
 
-.denhaag-link--external.denhaag-link--with-small-icon {
-  --denhaag-link-with-icon-vertical-align: middle;
+.denhaag-link--external.denhaag-link--with-small-icon .denhaag-link__icon {
+  vertical-align: middle;
+}
+
+/* undo change .denhaag-card-authentication */
+/* stylelint-disable-next-line no-descending-specificity */
+.denhaag-card-authentication .denhaag-link__icon {
+  --denhaag-link-with-icon-vertical-align: text-top;
+
+  margin-inline-start: unset;
 }
 
 .denhaag-unordered-list li > .denhaag-link--external .denhaag-icon,

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -82,7 +82,7 @@ li .denhaag-link__icon {
 
 .utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
 .denhaag-unordered-list .denhaag-link--external .denhaag-link__icon,
-.denhaag-ordered-list.denhaag-link--external .denhaag-link__icon {
+.denhaag-ordered-list .denhaag-link--external .denhaag-link__icon {
   margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
 }
 

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -62,6 +62,11 @@ li .denhaag-link__icon {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align);
 }
 
+/* undo change .denhaag-card-authentication */
+.denhaag-card-authentication .denhaag-link--external {
+  display: inline-flex;
+}
+
 .utrecht-paragraph .denhaag-link--external,
 .denhaag-unordered-list li > .denhaag-link--external,
 .denhaag-ordered-list li > .denhaag-link--external {
@@ -69,8 +74,10 @@ li .denhaag-link__icon {
 }
 
 /* undo change .denhaag-card-authentication */
-.denhaag-card-authentication .utrecht-paragraph .denhaag-link--external {
-  display: inline-flex;
+.denhaag-card-authentication .denhaag-link__icon {
+  --denhaag-link-with-icon-vertical-align: text-top;
+
+  margin-inline-start: unset;
 }
 
 .utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
@@ -79,21 +86,8 @@ li .denhaag-link__icon {
   margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, 0.25rem);
 }
 
-/* undo change .denhaag-card-authentication */
-.denhaag-card-authentication .utrecht-paragraph .denhaag-link--external .denhaag-link__icon {
-  margin-inline-start: unset;
-}
-
-.utrecht-paragraph .denhaag-link--external.denhaag-link--with-small-icon .denhaag-link__icon {
-  vertical-align: var(--denhaag-link-external-icon-small-vertical-align, middle);
-}
-
-/* undo change .denhaag-card-authentication */
-.denhaag-card-authentication
-  .utrecht-paragraph
-  .denhaag-link--external.denhaag-link--with-small-icon
-  .denhaag-link__icon {
-  vertical-align: text-top;
+.denhaag-link--external.denhaag-link--with-small-icon {
+  --denhaag-link-with-icon-vertical-align: middle;
 }
 
 .denhaag-unordered-list li > .denhaag-link--external .denhaag-icon,

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -295,8 +295,6 @@ import readme from "../../README.md";
       href="#example-link"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
     >
-      <span class="denhaag-link__label">External link</span>
-      <span class="denhaag-link__sr-only">(External link)</span>
       <span class="denhaag-link__icon">
         <svg
           width="1em"
@@ -315,6 +313,8 @@ import readme from "../../README.md";
           />
         </svg>
       </span>
+      <span class="denhaag-link__label">External link</span>
+      <span class="denhaag-link__sr-only">(External link)</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -76,30 +76,27 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link with icon before">
-    <p class="utrecht-paragraph">
-      Quaerat doloremque molestias nisi recusandae et est voluptatem. Et est a voluptatibus.
-      <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start">
-        <span class="denhaag-link__icon">
-          <svg
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </span>
-        <span class="denhaag-link__label">Link with icon before</span>
-      </a> Quaerat doloremque molestias nisi recusandae et est voluptatem. Et est a voluptatibus.{" "}
-    </p>
+    <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start">
+      <span class="denhaag-link__icon">
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </span>
+      <span class="denhaag-link__label">Link with icon before</span>
+    </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -76,27 +76,30 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link with icon before">
-    <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start">
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-      </span>
-      <span class="denhaag-link__label">Link with icon before</span>
-    </a>
+    <p class="utrecht-paragraph">
+      Quaerat doloremque molestias nisi recusandae et est voluptatem. Et est a voluptatibus.
+      <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start">
+        <span class="denhaag-link__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </span>
+        <span class="denhaag-link__label">Link with icon before</span>
+      </a> Quaerat doloremque molestias nisi recusandae et est voluptatem. Et est a voluptatibus.{" "}
+    </p>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
@@ -292,6 +295,8 @@ import readme from "../../README.md";
       href="#example-link"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
     >
+      <span class="denhaag-link__label">External link</span>
+      <span class="denhaag-link__sr-only">(External link)</span>
       <span class="denhaag-link__icon">
         <svg
           width="1em"
@@ -310,8 +315,6 @@ import readme from "../../README.md";
           />
         </svg>
       </span>
-      <span class="denhaag-link__label">External link</span>
-      <span class="denhaag-link__sr-only">(External link)</span>
     </a>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -328,6 +331,8 @@ import readme from "../../README.md";
         href="#example-link"
         class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
       >
+        <span class="denhaag-link__label">External link</span>
+        <span class="denhaag-link__sr-only">(External link)</span>
         <span class="denhaag-link__icon">
           <svg
             width="1em"
@@ -346,8 +351,6 @@ import readme from "../../README.md";
             />
           </svg>
         </span>
-        <span class="denhaag-link__label">External link</span>
-        <span class="denhaag-link__sr-only">(External link)</span>
       </a> Repellat eum hic ullam est ut vitae praesentium. Exercitationem ratione quis placeat quas facilis deserunt.
     </p>
   </Story>
@@ -365,6 +368,8 @@ import readme from "../../README.md";
         href="#example-link"
         class="denhaag-link denhaag-link--with-icon denhaag-link--with-small-icon denhaag-link--with-icon-end denhaag-link--external"
       >
+        <span class="denhaag-link__label">External link</span>
+        <span class="denhaag-link__sr-only">(External link)</span>
         <span class="denhaag-link__icon">
           <svg
             width="1em"
@@ -383,8 +388,6 @@ import readme from "../../README.md";
             />
           </svg>
         </span>
-        <span class="denhaag-link__label">External link</span>
-        <span class="denhaag-link__sr-only">(External link)</span>
       </a> Repellat eum hic ullam est ut vitae praesentium. Exercitationem ratione quis placeat quas facilis deserunt.
     </p>
   </Story>
@@ -401,6 +404,11 @@ import readme from "../../README.md";
         href="#example-link"
         class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
       >
+        <span class="denhaag-link__label">
+          Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus. Quos aut culpa
+          nihil quibusdam qui libero.
+        </span>
+        <span class="denhaag-link__sr-only">(External link)</span>
         <span class="denhaag-link__icon">
           <svg
             width="1em"
@@ -419,11 +427,6 @@ import readme from "../../README.md";
             />
           </svg>
         </span>
-        <span class="denhaag-link__label">
-          Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus. Quos aut culpa
-          nihil quibusdam qui libero.
-        </span>
-        <span class="denhaag-link__sr-only">(External link)</span>
       </a>
     </p>
   </Story>
@@ -439,8 +442,12 @@ import readme from "../../README.md";
       <li>
         <a
           href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/757852"
-          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--added-by-js"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
         >
+          <span class="denhaag-link__label">
+            Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
           <span class="denhaag-link__icon">
             <svg
               aria-hidden="true"
@@ -457,17 +464,17 @@ import readme from "../../README.md";
               ></path>
             </svg>
           </span>
-          <span class="denhaag-link__label">
-            Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
-          </span>
-          <span class="denhaag-link__sr-only">(Externe link)</span>
         </a>
       </li>
       <li>
         <a
           href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/598806"
-          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--added-by-js"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
         >
+          <span class="denhaag-link__label">
+            At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
           <span class="denhaag-link__icon">
             <svg
               aria-hidden="true"
@@ -484,21 +491,124 @@ import readme from "../../README.md";
               ></path>
             </svg>
           </span>
-          <span class="denhaag-link__label">
-            At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
-          </span>
-          <span class="denhaag-link__sr-only">(Externe link)</span>
         </a>
       </li>
       <li>
         <a
           href="https://denhaag.test/nl/in-de-stad/verkeer-en-vervoer/ov-next-openbaar-vervoer-van-de-toekomst/"
-          class="denhaag-link denhaag-link--added-by-js"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
         >
           <span class="denhaag-link__label">Assumenda autem facilis voluptates voluptate eos eum tempore amet.</span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
         </a>
       </li>
     </ul>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Only external link in ordered list item
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Only external link in ordered list item">
+    <ol class="denhaag-ordered-list">
+      <li>
+        <a
+          href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/757852"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
+        >
+          <span class="denhaag-link__label">
+            Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/598806"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
+        >
+          <span class="denhaag-link__label">
+            At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://denhaag.test/nl/in-de-stad/verkeer-en-vervoer/ov-next-openbaar-vervoer-van-de-toekomst/"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end"
+        >
+          <span class="denhaag-link__label">Assumenda autem facilis voluptates voluptate eos eum tempore amet.</span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+        </a>
+      </li>
+    </ol>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -390,3 +390,115 @@ import readme from "../../README.md";
   </Story>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
+
+### Only external link in paragraph
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Only external link in paragraph">
+    <p class="utrecht-paragraph">
+      <a
+        href="#example-link"
+        class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
+      >
+        <span class="denhaag-link__icon">
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span class="denhaag-link__label">
+          Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus. Quos aut culpa
+          nihil quibusdam qui libero.
+        </span>
+        <span class="denhaag-link__sr-only">(External link)</span>
+      </a>
+    </p>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Only external link in unordered list item
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Only external link in unordered list item">
+    <ul class="denhaag-unordered-list">
+      <li>
+        <a
+          href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/757852"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--added-by-js"
+        >
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+          <span class="denhaag-link__label">
+            Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://denhaag.raadsinformatie.nl/modules/13/Overige%20bestuurlijke%20stukken/598806"
+          class="denhaag-link denhaag-link--external denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--added-by-js"
+        >
+          <span class="denhaag-link__icon">
+            <svg
+              aria-hidden="true"
+              class="denhaag-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              viewBox="0 0 18 18"
+              fill="none"
+            >
+              <path
+                d="M11 2C10.4477 2 10 1.55228 10 1C10 0.447715 10.4477 0 11 0H17C17.2652 0 17.5196 0.105357 17.7071 0.292894C17.8946 0.48043 18 0.734784 18 1L18 7C18 7.55229 17.5523 8 17 8C16.4477 8 16 7.55228 16 7L16 3.41422L6.70711 12.7071C6.31658 13.0976 5.68342 13.0976 5.29289 12.7071C4.90237 12.3166 4.90237 11.6834 5.29289 11.2929L14.5858 2H11ZM0 4C0 2.89543 0.895431 2 2 2H7C7.55228 2 8 2.44772 8 3C8 3.55228 7.55228 4 7 4H2V16H14V11C14 10.4477 14.4477 10 15 10C15.5523 10 16 10.4477 16 11V16C16 17.1046 15.1046 18 14 18H2C0.895431 18 0 17.1046 0 16V4Z"
+                fill="currentColor"
+              ></path>
+            </svg>
+          </span>
+          <span class="denhaag-link__label">
+            At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
+          </span>
+          <span class="denhaag-link__sr-only">(Externe link)</span>
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://denhaag.test/nl/in-de-stad/verkeer-en-vervoer/ov-next-openbaar-vervoer-van-de-toekomst/"
+          class="denhaag-link denhaag-link--added-by-js"
+        >
+          <span class="denhaag-link__label">Assumenda autem facilis voluptates voluptate eos eum tempore amet.</span>
+        </a>
+      </li>
+    </ul>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>

--- a/components/UnorderedList/src/index.scss
+++ b/components/UnorderedList/src/index.scss
@@ -17,6 +17,7 @@
 
 .denhaag-unordered-list li {
   font-weight: var(--denhaag-unordered-list-list-item-font-weight);
+  line-height: var(--utrecht-paragraph-line-height, var(--utrecht-document-line-height, inherit));
 }
 
 .denhaag-unordered-list li::marker {

--- a/proprietary/Components/src/denhaag/link.tokens.json
+++ b/proprietary/Components/src/denhaag/link.tokens.json
@@ -66,10 +66,7 @@
           "align": {
             "value": "center"
           },
-          "margin-inline-start": { "value": "{denhaag.space.inline.2xs}" },
-          "small": {
-            "vertical-align": { "value": "middle" }
-          }
+          "margin-inline-start": { "value": "{denhaag.space.inline.2xs}" }
         }
       }
     }

--- a/proprietary/Components/src/denhaag/link.tokens.json
+++ b/proprietary/Components/src/denhaag/link.tokens.json
@@ -61,10 +61,12 @@
         }
       },
       "external": {
+        "display": { "value": "initial" },
         "icon": {
           "align": {
             "value": "center"
-          }
+          },
+          "margin-inline-start": { "value": "{denhaag.space.inline.2xs}" }
         }
       }
     }

--- a/proprietary/Components/src/denhaag/link.tokens.json
+++ b/proprietary/Components/src/denhaag/link.tokens.json
@@ -66,7 +66,10 @@
           "align": {
             "value": "center"
           },
-          "margin-inline-start": { "value": "{denhaag.space.inline.2xs}" }
+          "margin-inline-start": { "value": "{denhaag.space.inline.2xs}" },
+          "small": {
+            "vertical-align": { "value": "middle" }
+          }
         }
       }
     }


### PR DESCRIPTION
### Doel:

- styling fix voor external links, wanneer ze een hele zin lang zijn, **_in een .utrecht-paragraph_**
- styling fix voor external links, wanneer ze een hele zin lang zijn, **_in een list-item_**
- styling fix voor de **_(un)ordered list-item line-height_**

### Opmerking:

- ik heb de **_bem aangepast_** voor alleen de external links: de **_volgorde van de icon_** aangepast (i.p.v. voor de tekst, erachter geplaatst)
- verder heb ik alleen de `.denhaag-link--external` en wat er in zit gestyled, de overige is verplaatst omdat de linter dat verplaatst wilde hebben: `.denhaag-link__icon { `en `li .denhaag-link__icon {`

### Screenshot VOOR aanpassingen:
![Screenshot 2022-11-18 at 14 20 46](https://user-images.githubusercontent.com/95216123/202714548-1bc0b37c-8223-447e-a689-43dab02402d5.png)

### Screenshot NA aanpassingen:
![Screenshot 2022-11-18 at 16 38 14](https://user-images.githubusercontent.com/95216123/202742837-8874f540-85f2-4526-ab85-de8dc251bdf5.png)


#closes 1148
