### PR TITLE
fix: step-marker-connector-warning-outline-color

### DIFF
--- a/proprietary/Components/src/denhaag/step-marker.tokens.json
+++ b/proprietary/Components/src/denhaag/step-marker.tokens.json
@@ -57,7 +57,7 @@
           "outline-color": { "value": "{denhaag.color.green.3}" }
         },
         "warning": {
-          "outline-color": { "value": "{denhaag.color.orange.5}" }
+          "outline-color": { "value": "{denhaag.color.orange.4}" }
         },
         "error": {
           "outline-color": { "value": "{denhaag.color.red.3}" }


### PR DESCRIPTION
Typo, used `denhaag.color.orange.5` where the connector should have the same color as the border `denhaag.color.orange.4`