### PR TITLE
fix(conditions): fix icon vertical alignment

### DIFF
--- a/components/Conditions/src/index.scss
+++ b/components/Conditions/src/index.scss
@@ -78,6 +78,8 @@
 .denhaag-conditions__list-item {
   --denhaag-list-item-padding-inline: var(--denhaag-conditions-list-item-padding-inline);
 
+  align-items: var(--denhaag-conditions-list-item-align-items) !important;
+
   @media (min-width: 768px) {
     --denhaag-list-item-padding-inline: var(--denhaag-space-inline-2xl);
   }
@@ -86,6 +88,9 @@
 .denhaag-conditions__item-icon {
   --denhaag-list-item-icon-color: var(--denhaag-conditions-item-icon-color);
   --denhaag-list-item-icon-margin-inline-end: var(--denhaag-conditions-item-icon-margin-inline-end);
+
+  display: var(--denhaag-conditions-item-icon-display) !important;
+  padding-block-start: var(--denhaag-conditions-item-icon-padding-block-start);
 }
 
 .denhaag-conditions__text-content {

--- a/components/Conditions/src/index.scss
+++ b/components/Conditions/src/index.scss
@@ -98,3 +98,8 @@
   --denhaag-list-item-text-primary-font-size: var(--denhaag-conditions-text-content-font-size);
   --denhaag-list-item-text-primary-line-height: var(--denhaag-conditions-text-content-line-height);
 }
+
+.denhaag-conditions .denhaag-icon {
+  height: var(--denhaag-conditions-denhaag-icon-height);
+  width: var(--denhaag-conditions-denhaag-icon-width);
+}

--- a/components/Conditions/src/stories/bem.stories.mdx
+++ b/components/Conditions/src/stories/bem.stories.mdx
@@ -68,7 +68,10 @@ import "../index.scss";
             </svg>
           </div>
           <div class="denhaag-list__item-text denhaag-conditions__text">
-            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">ListItem</span>
+            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">
+              Ab consequatur quia quisquam id. Eaque harum rerum voluptatem et sint est nisi dolores. Optio est non
+              itaque.
+            </span>
           </div>
         </li>
         <li class="denhaag-list__item denhaag-conditions__list-item">
@@ -88,7 +91,10 @@ import "../index.scss";
             </svg>
           </div>
           <div class="denhaag-list__item-text denhaag-conditions__text">
-            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">ListItem</span>
+            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">
+              Eligendi fugiat est architecto eum. Temporibus modi odio quisquam dolorem eaque debitis. Natus iusto
+              minima ab vero nisi porro aliquam.
+            </span>
           </div>
         </li>
         <li class="denhaag-list__item denhaag-conditions__list-item">
@@ -108,7 +114,9 @@ import "../index.scss";
             </svg>
           </div>
           <div class="denhaag-list__item-text denhaag-conditions__text">
-            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">ListItem</span>
+            <span class="denhaag-list__item-text-primary denhaag-conditions__text-content">
+              Rerum et aut et quia enim similique modi expedita.
+            </span>
           </div>
         </li>
       </ul>

--- a/components/Conditions/src/stories/bem.stories.mdx
+++ b/components/Conditions/src/stories/bem.stories.mdx
@@ -54,6 +54,7 @@ import "../index.scss";
         <li class="denhaag-list__item denhaag-conditions__list-item">
           <div class="denhaag-list__item-icon denhaag-conditions__item-icon">
             <svg
+              class="denhaag-icon"
               aria-hidden="true"
               width="16"
               height="12"
@@ -77,6 +78,7 @@ import "../index.scss";
         <li class="denhaag-list__item denhaag-conditions__list-item">
           <div class="denhaag-list__item-icon denhaag-conditions__item-icon">
             <svg
+              class="denhaag-icon"
               aria-hidden="true"
               width="16"
               height="12"
@@ -100,6 +102,7 @@ import "../index.scss";
         <li class="denhaag-list__item denhaag-conditions__list-item">
           <div class="denhaag-list__item-icon denhaag-conditions__item-icon">
             <svg
+              class="denhaag-icon"
               aria-hidden="true"
               width="16"
               height="12"

--- a/proprietary/Components/src/denhaag/conditions.tokens.json
+++ b/proprietary/Components/src/denhaag/conditions.tokens.json
@@ -4,6 +4,14 @@
       "background-color": {
         "value": "#f9fbf9"
       },
+      "denhaag-icon": {
+        "height": {
+          "value": ".75rem"
+        },
+        "width": {
+          "value": "{denhaag.space.inline.md}"
+        }
+      },
       "padding-block": {
         "value": "0"
       },

--- a/proprietary/Components/src/denhaag/conditions.tokens.json
+++ b/proprietary/Components/src/denhaag/conditions.tokens.json
@@ -108,6 +108,9 @@
         }
       },
       "list-item": {
+        "align-items": {
+          "value": "normal"
+        },
         "padding-inline": {
           "value": "{denhaag.space.inline.xl}"
         }
@@ -116,8 +119,14 @@
         "color": {
           "value": "{denhaag.color.green.5}"
         },
+        "display": {
+          "value": "block"
+        },
         "margin-inline-end": {
           "value": "0.625rem"
+        },
+        "padding-block-start": {
+          "value": "2px"
         }
       },
       "text-content": {


### PR DESCRIPTION
Solve:
- vertical icon alignment correction (at top of list text instead of vertically in the middle)

Ticket comment:
- https://acato-nl.atlassian.net/browse/GDH-1018?focusedCommentId=115626

Screenshot before:
![Screenshot 2023-04-05 at 17 05 58](https://user-images.githubusercontent.com/95216123/230123284-8a94272c-91a4-4b3f-ae2f-abad7f47bd15.png)

Screenhot after:
![Screenshot 2023-04-05 at 17 07 47](https://user-images.githubusercontent.com/95216123/230123751-400e658f-e943-4703-a6de-05f96b60d919.png)


closes #1204