### PR TITLE
fix: add deprecated ProcessSteps export

### DIFF
--- a/components/ProcessSteps/src/index.tsx
+++ b/components/ProcessSteps/src/index.tsx
@@ -1,6 +1,18 @@
 import Status from './Status';
 
-export default Status;
+/*
+ As some other Design Systems already depend on ProcessSteps
+ Let's export Status as default and ProcessSteps 
+ And mark it as deprecated
+ */
+
+/**
+ * @deprecated `ProcessSteps` is the component group. Use `import { Status }` instead.
+ */
+const ProcessSteps = Status;
+
+export { ProcessSteps };
+export default ProcessSteps;
 
 export * from './Status';
 export * from './Step';


### PR DESCRIPTION
Both Conduction and Utrecht are using `{ ProcessSteps }`. Renaming makes it harder for them to upgrade.

Of course we only release `alpha` packages, but it is harmless to support `ProcessSteps` for a while longer anyway.

Added the export back but with a deprecation warning for now.