### PR TITLE
fix(procedure): move css variables refactor

### DIFF
--- a/components/Procedure/src/StepList.scss
+++ b/components/Procedure/src/StepList.scss
@@ -1,8 +1,5 @@
 /* tokens copy-pasted from main branch process-steps.tokens.json to www.denhaag.nl branch procedure.tokens.json */
 .denhaag-procedure {
-  --denhaag-process-steps-step-distance: 32px;
-  --denhaag-process-steps-sub-step-distance: 24px;
-
   font-family: var(--denhaag-procedure-font-family);
   font-size: var(--denhaag-procedure-font-size);
   line-height: var(--denhaag-procedure-line-height);

--- a/components/Procedure/src/index.scss
+++ b/components/Procedure/src/index.scss
@@ -13,8 +13,10 @@
 /* procedure specific styling */
 .denhaag-procedure {
   --denhaag-procedure-step-heading-line-height: var(--utrecht-heading-4-line-height);
-  --denhaag-step-marker-size: var(--denhaag-procedure-step-marker-mobile-size);
+  --denhaag-process-steps-step-distance: 32px;
+  --denhaag-process-steps-sub-step-distance: 24px;
   --denhaag-step-marker-font-size: var(--denhaag-procedure-step-marker-mobile-font-size);
+  --denhaag-step-marker-size: var(--denhaag-procedure-step-marker-mobile-size);
 
   counter-reset: denhaag-step-marker;
 }


### PR DESCRIPTION
### Issue:
- binnen WordPress wordt verkeerde css variabel waarde geladen voor de afstand tussen list items /markers(in storybook wel correct)

### Doel:
- zowel in WordPress als Storybook de correcte weergave van de afstand tussen list items/markers

### Aanpassing:
- twee css variabel overwrites verhuist van file, voor correcte werking

closes #1240