### PR TITLE
feat: gdh-968 | fix versioning for link grid and readspeaker

### DIFF
--- a/components/LinkGrid/package.json
+++ b/components/LinkGrid/package.json
@@ -3,7 +3,7 @@
   "description": "The Link Grid component. Grid of links.",
   "author": "Municipality of The Hague",
   "license": "EUPL-1.2",
-  "version": "0.1.3-www-denhaag-nl.46",
+  "version": "0.2.3-www-denhaag-nl.47",
   "exports": {
     ".": {
       "types": "./dist/cjs/index.d.ts",

--- a/components/ReadSpeaker/package.json
+++ b/components/ReadSpeaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemeente-denhaag/readspeaker",
-  "version": "0.2.3-www-denhaag-nl.26",
+  "version": "0.2.3-www-denhaag-nl.47",
   "description": "ReadSpeaker Component",
   "bugs": "https://github.com/nl-design-system/denhaag/issues",
   "private": false,


### PR DESCRIPTION
Fix versioning for Link Grid and Readspeaker