### PR TITLE
feat: gdh-1106 | feedback conditions component

### DIFF
--- a/components/Conditions/src/index.scss
+++ b/components/Conditions/src/index.scss
@@ -12,7 +12,6 @@
 }
 
 .denhaag-conditions__label {
-  background-color: var(--denhaag-conditions-label-background-color);
   color: var(--denhaag-conditions-label-color);
   display: var(--denhaag-conditions-label-display);
   height: calc(var(--denhaag-conditions-label-height) - var(--denhaag-space-block-xs));
@@ -22,28 +21,18 @@
   width: var(--denhaag-conditions-label-width);
 }
 
-.denhaag-conditions__label::before,
-.denhaag-conditions__label::after {
-  background-color: var(--denhaag-conditions-label-before-after-background-color);
-  content: "";
-  position: var(--denhaag-conditions-label-before-after-position);
-  height: var(--denhaag-conditions-label-before-after-size);
-  width: var(--denhaag-conditions-label-before-after-size);
-  bottom: var(--denhaag-conditions-label-before-after-bottom);
-}
-
 .denhaag-conditions__label::before {
-  left: var(--denhaag-conditions-label-before-left);
-  transform: var(--denhaag-conditions-label-before-transform);
-}
-
-.denhaag-conditions__label::after {
-  right: var(--denhaag-conditions-label-after-right);
-  transform: var(--denhaag-conditions-label-after-transform);
+  content: "";
+  position: var(--denhaag-conditions-label-before-position);
+  background-color: var(--denhaag-conditions-label-before-background-color);
+  clip-path: var(--denhaag-conditions-label-before-clip-path);
+  height: calc(var(--denhaag-conditions-label-height) - var(--denhaag-space-block-xs));
+  width: var(--denhaag-conditions-label-width);
 }
 
 .denhaag-conditions__label-icon {
   margin-block-start: var(--denhaag-conditions-label-icon-margin-block-start);
+  z-index: 2;
 }
 
 .denhaag-conditions .denhaag-list__subheader {
@@ -98,9 +87,8 @@
     --denhaag-conditions-label-width: var(--denhaag-conditions-label-width-desktop);
   }
 
-  .denhaag-conditions__label::before,
-  .denhaag-conditions__label::after {
-    --denhaag-conditions-label-before-after-size: var(--denhaag-space-block-5xl);
+  .denhaag-conditions__label::before {
+    --denhaag-conditions-label-before-size: var(--denhaag-space-block-5xl);
   }
 
   .denhaag-conditions .denhaag-list__subheader {

--- a/proprietary/Components/src/denhaag/conditions.tokens.json
+++ b/proprietary/Components/src/denhaag/conditions.tokens.json
@@ -30,9 +30,6 @@
         }
       },
       "label": {
-        "background-color": {
-          "value": "{denhaag.color.green.3}"
-        },
         "color": {
           "value": "{denhaag.color.white}"
         },
@@ -58,34 +55,21 @@
           "value": "5rem"
         }
       },
-      "label-before-after": {
+      "label-before": {
         "background-color": {
-          "value": "#f9fbf9"
+          "value": "{denhaag.color.green.3}"
         },
         "position": {
           "value": "absolute"
+        },
+        "clip-path": {
+          "value": "polygon(100% 0, 100% 50%, 50% 100%, 0% 50%, 0 0)"
         },
         "size": {
           "value": "3.5rem"
         },
         "bottom": {
           "value": "-72%"
-        }
-      },
-      "label-before": {
-        "left": {
-          "value": "-42%"
-        },
-        "transform": {
-          "value": "rotate(36deg)"
-        }
-      },
-      "label-after": {
-        "right": {
-          "value": "-42%"
-        },
-        "transform": {
-          "value": "rotate(-36deg)"
         }
       },
       "label-icon": {


### PR DESCRIPTION
Closes GDH-1106: feedback UX conditions component.
Using clip-path instead of :before and :after pseudo elements