### PR TITLE
Fix/gdh 1200 hero theme image

### DIFF
--- a/components/Hero/src/heroThemeImage.js
+++ b/components/Hero/src/heroThemeImage.js
@@ -1,16 +1,23 @@
-const HeroThemeImage = (classname = '.denhaag-hero--theme-image') => {
+const HeroThemeImage = (mainclass = '.denhaag-hero--theme-image') => {
   // Elements.
-  const imageElement = document.querySelector(`${classname} .denhaag-hero__image`);
-  const heroImageElement = document.querySelector(classname);
+  const imageElement = document.querySelector(`${mainclass} .denhaag-hero__image`);
+  const heroImageElement = document.querySelector(mainclass);
+  const contentElement = document.querySelector(`${mainclass} .denhaag-hero__content`);
 
-  // Get realtime image height.
+  // Get realtime element heights.
   const imageElementHeight = imageElement?.clientHeight;
-  console.log('imageElementHeight: ', imageElementHeight);
+  const contentElementHeight = contentElement?.clientHeight;
 
-  // Assign image height to css variable used by heroImageElement.
-  setTimeout(() => {
+  // Set height of heroImageElement.
+  if (contentElementHeight > imageElementHeight) {
+    const heightDifference = contentElementHeight - imageElementHeight;
+    heroImageElement?.style.setProperty(
+      '--denhaag-hero--theme-image-height',
+      `${imageElementHeight + heightDifference}px`,
+    );
+  } else {
     heroImageElement?.style.setProperty('--denhaag-hero--theme-image-height', `${imageElementHeight}px`);
-  }, 1);
+  }
 };
 
 export default HeroThemeImage;

--- a/components/Hero/src/heroThemeImage.js
+++ b/components/Hero/src/heroThemeImage.js
@@ -1,0 +1,16 @@
+const HeroThemeImage = (classname = '.denhaag-hero--theme-image') => {
+  // Elements.
+  const imageElement = document.querySelector(`${classname} .denhaag-hero__image`);
+  const heroImageElement = document.querySelector(classname);
+
+  // Get realtime image height.
+  const imageElementHeight = imageElement?.clientHeight;
+  console.log('imageElementHeight: ', imageElementHeight);
+
+  // Assign image height to css variable used by heroImageElement.
+  setTimeout(() => {
+    heroImageElement?.style.setProperty('--denhaag-hero--theme-image-height', `${imageElementHeight}px`);
+  }, 1);
+};
+
+export default HeroThemeImage;

--- a/components/Hero/src/heroThemeImage.js
+++ b/components/Hero/src/heroThemeImage.js
@@ -12,11 +12,11 @@ const HeroThemeImage = (mainclass = '.denhaag-hero--theme-image') => {
   if (contentElementHeight > imageElementHeight) {
     const heightDifference = contentElementHeight - imageElementHeight;
     heroImageElement?.style.setProperty(
-      '--denhaag-hero--theme-image-height',
+      '--denhaag-hero-theme-image-height',
       `${imageElementHeight + heightDifference}px`,
     );
   } else {
-    heroImageElement?.style.setProperty('--denhaag-hero--theme-image-height', `${imageElementHeight}px`);
+    heroImageElement?.style.setProperty('--denhaag-hero-theme-image-height', `${imageElementHeight}px`);
   }
 };
 

--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -296,6 +296,7 @@
     --denhaag-hero-theme-image-image-height: var(--denhaag-hero-theme-image-image-height-s);
 
     height: var(--denhaag-hero--theme-image-height);
+    margin-block-end: 48px;
   }
 
   .denhaag-hero--theme-image .denhaag-hero__container {
@@ -309,6 +310,9 @@
 
   .denhaag-hero--theme-image .denhaag-hero__content {
     --denhaag-hero-theme-image-content-width: var(--denhaag-hero-theme-image-content-width-s);
+
+    position: absolute;
+    bottom: 0;
   }
 }
 

--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -157,7 +157,7 @@
 }
 
 .denhaag-hero--theme-image .denhaag-hero__container {
-  --denhaag-hero-theme-image-container-padding-inline: 0.5rem;
+  --denhaag-hero-theme-image-container-padding-inline: 1.5rem;
 
   align-items: var(--denhaag-hero-theme-image-container-align-items);
   display: var(--denhaag-hero-theme-image-container-display);
@@ -166,9 +166,9 @@
   margin-inline-end: var(--denhaag-hero-theme-image-container-margin-inline);
   margin-inline-start: var(--denhaag-hero-theme-image-container-margin-inline);
   max-width: var(--denhaag-hero-theme-image-container-max-width);
-  padding-inline-end: 1.5rem;
-  padding-inline-start: 1.5rem;
-  padding-block-end: 3rem;
+  padding-block-end: calc(2 * var(--denhaag-hero-theme-image-container-padding-inline));
+  padding-inline-end: var(--denhaag-hero-theme-image-container-padding-inline);
+  padding-inline-start: var(--denhaag-hero-theme-image-container-padding-inline);
 }
 
 .denhaag-hero--theme-image .denhaag-hero__content {
@@ -295,8 +295,8 @@
   .denhaag-hero--theme-image {
     --denhaag-hero-theme-image-image-height: var(--denhaag-hero-theme-image-image-height-s);
 
-    height: var(--denhaag-hero--theme-image-height);
-    margin-block-end: 48px;
+    height: var(--denhaag-hero-theme-image-height);
+    margin-block-end: var(--denhaag-hero-theme-image-margin-block-end);
   }
 
   .denhaag-hero--theme-image .denhaag-hero__container {
@@ -311,8 +311,8 @@
   .denhaag-hero--theme-image .denhaag-hero__content {
     --denhaag-hero-theme-image-content-width: var(--denhaag-hero-theme-image-content-width-s);
 
-    position: absolute;
-    bottom: 0;
+    position: var(--denhaag-hero-theme-image-content-position);
+    bottom: var(--denhaag-hero-theme-image-content-bottom);
   }
 }
 

--- a/components/Hero/src/index.scss
+++ b/components/Hero/src/index.scss
@@ -166,8 +166,9 @@
   margin-inline-end: var(--denhaag-hero-theme-image-container-margin-inline);
   margin-inline-start: var(--denhaag-hero-theme-image-container-margin-inline);
   max-width: var(--denhaag-hero-theme-image-container-max-width);
-  padding-inline-end: var(--denhaag-hero-theme-image-container-padding-inline);
-  padding-inline-start: var(--denhaag-hero-theme-image-container-padding-inline);
+  padding-inline-end: 1.5rem;
+  padding-inline-start: 1.5rem;
+  padding-block-end: 3rem;
 }
 
 .denhaag-hero--theme-image .denhaag-hero__content {
@@ -293,6 +294,8 @@
 
   .denhaag-hero--theme-image {
     --denhaag-hero-theme-image-image-height: var(--denhaag-hero-theme-image-image-height-s);
+
+    height: var(--denhaag-hero--theme-image-height);
   }
 
   .denhaag-hero--theme-image .denhaag-hero__container {

--- a/components/Hero/src/stories/bem.stories.mdx
+++ b/components/Hero/src/stories/bem.stories.mdx
@@ -4,6 +4,7 @@ import pkg from "../../package.json";
 import readme from "../../README.md";
 import "../index.scss";
 import "../storybook.scss";
+import "../storybook";
 
 export const heroImage = (h, w, id = "photo-1513384312027-9fa69a360337") =>
   `https://images.unsplash.com/${id}?fit=crop&w=${w}&h=${h}`;
@@ -129,17 +130,110 @@ export const heroImage = (h, w, id = "photo-1513384312027-9fa69a360337") =>
   {/* eslint-enable react/no-unknown-property */}
 </Canvas>
 
-### Theme Page - image
+### Theme Image - title only
 
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
-  <Story name="Theme Image">
+  <Story name="Theme Image - title only">
+    <section class="denhaag-hero denhaag-hero--theme-page denhaag-hero--theme-image">
+      <div class="denhaag-hero__container">
+        <div class="denhaag-hero__content">
+          <h1 class="denhaag-hero__title utrecht-heading-1">Lorem ipsum dolor sit amet consectetur </h1>
+        </div>
+      </div>
+      <img
+        class="denhaag-hero__image"
+        src="https://images.unsplash.com/photo-1593439426324-71b3f44ca9ee?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
+        alt="auto in parkeervak"
+      />
+    </section>
+    <section class="page-container page-container--has-columns-first">
+      <div class="page-container__columns">
+        <section class="denhaag-columns denhaag-columns--single">
+          <div class="denhaag-column">
+            <p class="utrecht-paragraph">
+              Et inventore quod adipisci et quaerat aut praesentium in. In voluptatibus atque ex voluptate laudantium
+              deleniti et sed. Reiciendis qui alias placeat rerum. Quibusdam eveniet in soluta omnis similique. Eum ut
+              maxime illo voluptate.
+            </p>
+            <p class="utrecht-paragraph">
+              Corrupti quasi accusantium ducimus nostrum molestias autem est. Et iusto dolore recusandae officiis non.
+              Quae tempore sed saepe quo nihil labore. Repudiandae nisi nihil maxime deleniti. Eum voluptatem et
+              consequatur dolorem quae.
+            </p>
+          </div>
+        </section>
+        <div class="denhaag-article-meta denhaag-article-meta--responsive">
+          <p class="denhaag-article-meta__item">Gepubliceerd: 26 april 2023</p>
+          <p class="denhaag-article-meta__item">Gewijzigd: 31 mei 2023</p>
+        </div>
+      </div>
+    </section>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Theme Image - title + text
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Theme Image - title + text">
     <section class="denhaag-hero denhaag-hero--theme-page denhaag-hero--theme-image">
       <div class="denhaag-hero__container">
         <div class="denhaag-hero__content">
           <h1 class="denhaag-hero__title utrecht-heading-1">Lorem ipsum dolor sit amet consectetur </h1>
           <p class="utrecht-paragraph denhaag-hero__text">
-            Duis egestas, augue eget varius tellus arcu sollicitudin ipsum.
+            Duis egestas, augue eget varius feugiat, tellus arcu sollicitudin ipsum, vel interdum purus libero convallis
+            leo. Cras mollis vitae metus ac porttitor. Vestibulum interdum, diam sit amet malesuada commodo, tellus eros
+            viverra nunc, aliquam ultricies mi lorem nec lorem.
+          </p>
+        </div>
+      </div>
+      <img
+        class="denhaag-hero__image"
+        src="https://images.unsplash.com/photo-1593439426324-71b3f44ca9ee?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
+        alt="auto in parkeervak"
+      />
+    </section>
+    <section class="page-container page-container--has-columns-first">
+      <div class="page-container__columns">
+        <section class="denhaag-columns denhaag-columns--single">
+          <div class="denhaag-column">
+            <p class="utrecht-paragraph">
+              Et inventore quod adipisci et quaerat aut praesentium in. In voluptatibus atque ex voluptate laudantium
+              deleniti et sed. Reiciendis qui alias placeat rerum. Quibusdam eveniet in soluta omnis similique. Eum ut
+              maxime illo voluptate.
+            </p>
+            <p class="utrecht-paragraph">
+              Corrupti quasi accusantium ducimus nostrum molestias autem est. Et iusto dolore recusandae officiis non.
+              Quae tempore sed saepe quo nihil labore. Repudiandae nisi nihil maxime deleniti. Eum voluptatem et
+              consequatur dolorem quae.
+            </p>
+          </div>
+        </section>
+        <div class="denhaag-article-meta denhaag-article-meta--responsive">
+          <p class="denhaag-article-meta__item">Gepubliceerd: 26 april 2023</p>
+          <p class="denhaag-article-meta__item">Gewijzigd: 31 mei 2023</p>
+        </div>
+      </div>
+    </section>
+  </Story>
+  {/* eslint-enable react/no-unknown-property */}
+</Canvas>
+
+### Theme Image - title + text + link
+
+<Canvas>
+  {/* eslint-disable react/no-unknown-property */}
+  <Story name="Theme Image - title + text + link">
+    <section class="denhaag-hero denhaag-hero--theme-page denhaag-hero--theme-image">
+      <div class="denhaag-hero__container">
+        <div class="denhaag-hero__content">
+          <h1 class="denhaag-hero__title utrecht-heading-1">Lorem ipsum dolor sit amet consectetur </h1>
+          <p class="utrecht-paragraph denhaag-hero__text">
+            Duis egestas, augue eget varius feugiat, tellus arcu sollicitudin ipsum, vel interdum purus libero convallis
+            leo. Cras mollis vitae metus ac porttitor. Vestibulum interdum, diam sit amet malesuada commodo, tellus eros
+            viverra nunc, aliquam ultricies mi lorem nec lorem.
           </p>
           <a
             href="#example-link"
@@ -173,6 +267,28 @@ export const heroImage = (h, w, id = "photo-1513384312027-9fa69a360337") =>
         src="https://images.unsplash.com/photo-1593439426324-71b3f44ca9ee?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
         alt="auto in parkeervak"
       />
+    </section>
+    <section class="page-container page-container--has-columns-first">
+      <div class="page-container__columns">
+        <section class="denhaag-columns denhaag-columns--single">
+          <div class="denhaag-column">
+            <p class="utrecht-paragraph">
+              Et inventore quod adipisci et quaerat aut praesentium in. In voluptatibus atque ex voluptate laudantium
+              deleniti et sed. Reiciendis qui alias placeat rerum. Quibusdam eveniet in soluta omnis similique. Eum ut
+              maxime illo voluptate.
+            </p>
+            <p class="utrecht-paragraph">
+              Corrupti quasi accusantium ducimus nostrum molestias autem est. Et iusto dolore recusandae officiis non.
+              Quae tempore sed saepe quo nihil labore. Repudiandae nisi nihil maxime deleniti. Eum voluptatem et
+              consequatur dolorem quae.
+            </p>
+          </div>
+        </section>
+        <div class="denhaag-article-meta denhaag-article-meta--responsive">
+          <p class="denhaag-article-meta__item">Gepubliceerd: 26 april 2023</p>
+          <p class="denhaag-article-meta__item">Gewijzigd: 31 mei 2023</p>
+        </div>
+      </div>
     </section>
   </Story>
   {/* eslint-enable react/no-unknown-property */}

--- a/components/Hero/src/storybook.js
+++ b/components/Hero/src/storybook.js
@@ -1,0 +1,9 @@
+import HeroThemeImage from './heroThemeImage';
+
+window.addEventListener('DOMContentLoaded', () => {
+  HeroThemeImage();
+});
+
+window.addEventListener('resize', () => {
+  HeroThemeImage();
+});

--- a/components/Hero/src/storybook.scss
+++ b/components/Hero/src/storybook.scss
@@ -1,5 +1,5 @@
 /* This file is meant only for storybook overwrites. NOT FOR EXPORT! */
-.denhaag-hero {
+.denhaag-hero:not(.denhaag-hero--theme-image) {
   margin-block-start: -1rem;
   margin-block-end: -1rem;
   margin-inline-start: -1rem;

--- a/proprietary/Components/src/denhaag/hero.tokens.json
+++ b/proprietary/Components/src/denhaag/hero.tokens.json
@@ -396,6 +396,9 @@
           }
         },
         "content": {
+          "bottom": {
+            "value": "0"
+          },
           "clip-path": {
             "value": " polygon(0 0, 100% 0, 100% 97%, 0% 100%)"
           },
@@ -407,6 +410,9 @@
           },
           "padding-inline": {
             "value": "{denhaag.space.inline.2xl}"
+          },
+          "position": {
+            "value": "absolute"
           },
           "text-align": {
             "value": "left"
@@ -458,6 +464,9 @@
           "object-position": {
             "value": "center"
           }
+        },
+        "margin-block-end": {
+          "value": "{denhaag.space.block.4xl}"
         },
         "title": {
           "font-size": {


### PR DESCRIPTION
### Fix voor verticale uitlijning groene tekstbox.
Op verzoek en overleg met Joni:

- onder uitgelijnd
- wanneer hoger dan image, bovenin 32px marge + onder verder uitsteken i.p.v. boven
- hero hoogte gebaseerd op de realtime image hoogte

### Toelichting:
JS was hiervoor nodig aangezien je niet in de hand hebt hoeveel content in de tekstblok komt.
Ter illustratie even een container met tekst eronder geplakt, zonder enige styling.
Dit om te tonen dat het niet onder de hero kruipt.

### Figma: 
https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/Den-Haag-Design-System?type=design&node-id=24917%3A125160&t=eUN7kgsgZjpB81lN-1

### Screen captures:
Alleen met titel.

https://github.com/nl-design-system/denhaag/assets/95216123/fea9e50d-8dcc-4105-976c-53fc04c7d89c




Titel + tekst.

https://github.com/nl-design-system/denhaag/assets/95216123/59525457-2c70-4635-a7fb-b45e53fe3e07




Titel + tekst + link.


https://github.com/nl-design-system/denhaag/assets/95216123/f272e1cf-4dd5-443e-9b9f-5b29e4842f8f




closes #1252