### PR TITLE
fix: gdh-1169 | removed gap from card as content already has padding-top

### DIFF
--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -32,7 +32,6 @@
 
   display: flex;
   flex-direction: column;
-  gap: var(--denhaag-dynamic-content-card-gap);
   position: relative;
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
@robbieatacato Dit component heeft zowel een gap als een padding-top. Ik heb dus de gap weggehaald omdat de padding-top al op 16px staat. Is dit de beste oplossing, of denk je dat ik beter de padding-top van de `card-content` weg kan halen?

![Screenshot 2023-06-19 at 11 28 26](https://github.com/nl-design-system/denhaag/assets/131674048/cdeb7512-d706-4d4b-90bf-49aae8886dca)

![Screenshot 2023-06-19 at 11 28 38](https://github.com/nl-design-system/denhaag/assets/131674048/d0841caa-3460-4ca9-a5af-896134851361)
