### PR TITLE
fix(image): firefox fontweight fix

### DIFF
--- a/components/Image/src/index.scss
+++ b/components/Image/src/index.scss
@@ -31,6 +31,7 @@
   grid-area: image-figcaption;
   color: var(--denhaag-image-figcaption-text-color);
   font-size: var(--denhaag-image-figcaption-text-font-size);
+  font-weight: var(--denhaag-image-figcaption-text-font-weight);
   line-height: var(--denhaag-image-figcaption-text-line-height);
 }
 

--- a/proprietary/Components/src/denhaag/image.tokens.json
+++ b/proprietary/Components/src/denhaag/image.tokens.json
@@ -84,6 +84,9 @@
           "font-size": {
             "value": "{denhaag.typography.scale.s.font-size}"
           },
+          "font-weight": {
+            "value": "initial"
+          },
           "line-height": {
             "value": "1.5"
           }


### PR DESCRIPTION
Firefox font weight fix:
`.denhaag-image__figcaption-text` hoort de font-weight van de parent element `.denhaag-image__figcaption` te erven, maar dat doet het niet in firefox.

