### PR TITLE
fix: gdh-1105 | news card flex-direction reverse

### DIFF
--- a/components/CardNews/src/index.scss
+++ b/components/CardNews/src/index.scss
@@ -5,6 +5,7 @@
   border: var(--denhaag-card-news-border);
   display: flex;
   flex-direction: column-reverse;
+  justify-content: flex-end;
   gap: var(--denhaag-card-news-gap);
   height: var(--denhaag-card-news-height);
   margin-inline-start: var(--denhaag-card-news-margin);

--- a/components/CardNews/src/index.scss
+++ b/components/CardNews/src/index.scss
@@ -4,7 +4,7 @@
 
   border: var(--denhaag-card-news-border);
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   gap: var(--denhaag-card-news-gap);
   height: var(--denhaag-card-news-height);
   margin-inline-start: var(--denhaag-card-news-margin);

--- a/components/CardNews/src/stories/bem.stories.mdx
+++ b/components/CardNews/src/stories/bem.stories.mdx
@@ -30,13 +30,6 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
     <div class="denhaag-card-news">
-      <div class="denhaag-card-news__image-container">
-        <img
-          class="denhaag-card-news__image"
-          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
-          alt=""
-        />
-      </div>
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -65,6 +58,13 @@ import "../storybook.scss";
             />
           </svg>
         </div>
+      </div>
+      <div class="denhaag-card-news__image-container">
+        <img
+          class="denhaag-card-news__image"
+          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
+          alt=""
+        />
       </div>
     </div>
   </Story>
@@ -77,13 +77,6 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hover">
     <div class="denhaag-card-news denhaag-card-news--hover">
-      <div class="denhaag-card-news__image-container">
-        <img
-          class="denhaag-card-news__image"
-          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
-          alt=""
-        />
-      </div>
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -112,6 +105,13 @@ import "../storybook.scss";
             />
           </svg>
         </div>
+      </div>
+      <div class="denhaag-card-news__image-container">
+        <img
+          class="denhaag-card-news__image"
+          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
+          alt=""
+        />
       </div>
     </div>
   </Story>
@@ -124,13 +124,6 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
     <div class="denhaag-card-news denhaag-card-news--focus">
-      <div class="denhaag-card-news__image-container">
-        <img
-          class="denhaag-card-news__image"
-          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
-          alt=""
-        />
-      </div>
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -159,6 +152,13 @@ import "../storybook.scss";
             />
           </svg>
         </div>
+      </div>
+      <div class="denhaag-card-news__image-container">
+        <img
+          class="denhaag-card-news__image"
+          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
+          alt=""
+        />
       </div>
     </div>
   </Story>
@@ -171,13 +171,6 @@ import "../storybook.scss";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Reduced motion">
     <div class="denhaag-card-news denhaag-card-news--reduced-motion">
-      <div class="denhaag-card-news__image-container">
-        <img
-          class="denhaag-card-news__image"
-          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
-          alt=""
-        />
-      </div>
       <div class="denhaag-card-news__content">
         <h4 class="utrecht-heading-4 denhaag-card-news__heading">
           <a class="denhaag-card-news__link" href="#example-url">
@@ -206,6 +199,13 @@ import "../storybook.scss";
             />
           </svg>
         </div>
+      </div>
+      <div class="denhaag-card-news__image-container">
+        <img
+          class="denhaag-card-news__image"
+          src="https://images.unsplash.com/photo-1612799675078-ac368b17e488?w=507&h=353"
+          alt=""
+        />
       </div>
     </div>
   </Story>


### PR DESCRIPTION
Storybook update voor A11Y News Card 
Todo: Gutenberg block