### PR TITLE
feat: gdh-1237 | A11Y - Content before image

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -3,6 +3,7 @@
   border: var(--denhaag-cta-image-content-border);
   background-color: var(--denhaag-cta-image-content-background-color);
   display: var(--denhaag-cta-image-content-display);
+  flex-direction: var(--denhaag-cta-image-content-flex-direction);
 }
 
 .denhaag-cta-image-content:hover,
@@ -63,7 +64,7 @@
 
 @media (min-width: 768px) {
   .denhaag-cta-image-content {
-    --denhaag-cta-image-content-display: flex;
+    flex-direction: var(--denhaag-cta-image-content-md-flex-direction);
   }
 
   .denhaag-cta-image-content__image {

--- a/components/CtaImageContent/src/stories/bem.stories.mdx
+++ b/components/CtaImageContent/src/stories/bem.stories.mdx
@@ -29,12 +29,6 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
     <div class="denhaag-cta-image-content">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
@@ -60,6 +54,12 @@ import readme from "../../README.md";
           </span>
         </a>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -71,12 +71,6 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Filled">
     <div class="denhaag-cta-image-content denhaag-cta-image-content--filled">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
@@ -102,6 +96,12 @@ import readme from "../../README.md";
           </span>
         </a>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -113,18 +113,18 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Without action">
     <div class="denhaag-cta-image-content">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
           Explanational text about the image content link. Atque non nesciunt ducimus voluptas dolor voluptas fugit qui.
         </p>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -136,12 +136,6 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Focus">
     <div class="denhaag-cta-image-content denhaag-cta-image-content--focus">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
@@ -167,6 +161,12 @@ import readme from "../../README.md";
           </span>
         </a>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -178,12 +178,6 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Hover">
     <div class="denhaag-cta-image-content denhaag-cta-image-content--hover">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title">Title</h3>
         <p class="utrecht-paragraph denhaag-cta-image-content__text">
@@ -209,6 +203,12 @@ import readme from "../../README.md";
           </span>
         </a>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -220,12 +220,6 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Small">
     <div class="denhaag-cta-image-content">
-      <img
-        class="denhaag-cta-image-content__image"
-        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
-        alt=""
-        loading="lazy"
-      />
       <div class="denhaag-cta-image-content__content">
         <h3 class="utrecht-heading-2 denhaag-cta-image-content__title denhaag-cta-image-content__title--small">
           Title
@@ -253,6 +247,12 @@ import readme from "../../README.md";
           </span>
         </a>
       </div>
+      <img
+        class="denhaag-cta-image-content__image"
+        src="https://images.unsplash.com/photo-1569235186275-626cb53b83ce?w=650&h=350"
+        alt=""
+        loading="lazy"
+      />
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}

--- a/proprietary/Components/src/denhaag/cta-image-content.tokens.json
+++ b/proprietary/Components/src/denhaag/cta-image-content.tokens.json
@@ -4,7 +4,11 @@
       "position": { "value": "relative" },
       "background-color": { "value": "{denhaag.color.white}" },
       "border": { "value": "1px solid {denhaag.color.grey.2}" },
-      "display": { "value": "block" },
+      "display": { "value": "flex" },
+      "flex-direction": { "value": "column-reverse" },
+      "md": {
+        "flex-direction": { "value": "row-reverse" }
+      },
       "hover": {
         "box-shadow": { "value": "0 0.25rem 1rem 0 rgba(0, 0, 0, 0.16)" }
       },


### PR DESCRIPTION
Change order of image and content to ensure the readspeaker always reads the card titles and content before the image alt