### PR TITLE
fix: gdh-1221 | focus on accordion content

### DIFF
--- a/components/Accordion/src/AccordionToggle.js
+++ b/components/Accordion/src/AccordionToggle.js
@@ -1,16 +1,21 @@
 const AccordionToggle = (className = 'denhaag-accordion__title') => {
   // Select all clickable elements.
   [...document.getElementsByClassName(className)]?.forEach((element) => {
-    const parent = element.closest('.denhaag-accordion__container');
-    let accordionHeight = `${parent.querySelector('.denhaag-accordion__details-content').offsetHeight}px`;
+    const wrapper = element.closest('.denhaag-accordion__container');
+    let accordionHeight = `${wrapper.querySelector('.denhaag-accordion__details-content').offsetHeight}px`;
 
     const setAccordionHeight = (el, newHeight) => {
       el.style.setProperty('--denhaag-accordion-details-max-height', newHeight);
     };
 
+    const setAccordionDisplay = (el, value) => {
+      const content = el.querySelector('.denhaag-accordion__details');
+      content.style.display = value;
+    };
+
     // Set max-height property.
-    if (parent.querySelector('.denhaag-accordion__details-content')) {
-      setAccordionHeight(parent, accordionHeight);
+    if (wrapper.querySelector('.denhaag-accordion__details-content')) {
+      setAccordionHeight(wrapper, accordionHeight);
     }
 
     // Toggle accordion-item.
@@ -19,20 +24,30 @@ const AccordionToggle = (className = 'denhaag-accordion__title') => {
 
       if (expanded === 'false') {
         // Return correct height to show closing animation
-        setAccordionHeight(parent, accordionHeight);
+        setAccordionHeight(wrapper, accordionHeight);
 
         setTimeout(() => {
-          parent.classList.toggle('denhaag-accordion__container--open');
+          wrapper.classList.toggle('denhaag-accordion__container--open');
         }, 50);
+
+        setTimeout(() => {
+          setAccordionDisplay(wrapper, 'none');
+        }, 500);
       }
 
       if (expanded === 'true') {
-        parent.classList.toggle('denhaag-accordion__container--open');
+        setAccordionDisplay(wrapper, 'block');
+        setTimeout(() => {
+          const dynamicHeight = `${wrapper.querySelector('.denhaag-accordion__details-content').offsetHeight}px`;
+          accordionHeight = dynamicHeight;
+          setAccordionHeight(wrapper, dynamicHeight);
+          wrapper.classList.toggle('denhaag-accordion__container--open');
+        }, 50);
 
         // Wait 500 ms (transition duration) to set height to auto, to ensure the animation works
         setTimeout(() => {
-          setAccordionHeight(parent, 'auto');
-        }, 500);
+          setAccordionHeight(wrapper, 'auto');
+        }, 550);
       }
 
       // Set opposite aria-expanded.

--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -173,7 +173,7 @@
   padding-inline-end: var(--denhaag-accordion-details-margin-inline-end);
   transition: max-height var(--denhaag-accordion-transition-duration, 0ms)
     var(--denhaag-accordion-transition-timing-function, ease);
-  display: none;
+  display: var(--denhaag-accordion-details-display);
 }
 
 .denhaag-accordion__details-content {

--- a/components/Accordion/src/index.scss
+++ b/components/Accordion/src/index.scss
@@ -173,6 +173,7 @@
   padding-inline-end: var(--denhaag-accordion-details-margin-inline-end);
   transition: max-height var(--denhaag-accordion-transition-duration, 0ms)
     var(--denhaag-accordion-transition-timing-function, ease);
+  display: none;
 }
 
 .denhaag-accordion__details-content {

--- a/components/Accordion/src/stories/bem.stories.mdx
+++ b/components/Accordion/src/stories/bem.stories.mdx
@@ -122,15 +122,16 @@ import readme from "../../README.md";
               Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec justo nisi,
               tincidunt vel nulla et, tristique ornare enim. Vestibulum accumsan ac nibh sit amet fringilla. Vestibulum
               efficitur mattis tempus. Duis pretium et erat sit amet fermentum. Vivamus blandit euismod elit et aliquam.
-              Vestibulum a lectus nibh. Quisque pharetra tellus a lacinia ultricies. Maecenas sed aliquet ipsum.
-              Curabitur ultricies viverra ante sit amet consectetur.
+              Vestibulum a lectus nibh. <a href="/">Focus me</a> Quisque pharetra tellus a lacinia ultricies. Maecenas
+              sed aliquet ipsum. Curabitur ultricies viverra ante sit amet consectetur.
             </p>
             <p class="utrecht-paragraph">
               Etiam a egestas dolor. Morbi at lobortis orci. Phasellus vel magna dignissim, dictum neque vel, rutrum
-              augue. Nunc egestas a tortor non euismod. Integer ornare purus at ex porttitor tincidunt. Curabitur sit
-              amet rutrum orci, molestie auctor elit. Vestibulum sit amet pulvinar ligula. Suspendisse ultricies egestas
-              blandit. Sed tempor, tellus eget molestie mollis, nibh mi varius urna, ut suscipit sapien nisi sed justo.
-              Phasellus sem risus, bibendum et turpis eget, eleifend tempor felis.
+              augue. Nunc egestas <a href="/">Focus me too</a> a tortor non euismod. Integer ornare purus at ex
+              porttitor tincidunt. Curabitur sit amet rutrum orci, molestie auctor elit. Vestibulum sit amet pulvinar
+              ligula. Suspendisse ultricies egestas blandit. Sed tempor, tellus eget molestie mollis, nibh mi varius{" "}
+              <a href="/">Focus me three</a> urna, ut suscipit sapien nisi sed justo. Phasellus sem risus, bibendum et
+              turpis eget, eleifend tempor felis.
             </p>
           </div>
         </div>

--- a/proprietary/Components/src/denhaag/accordion.tokens.json
+++ b/proprietary/Components/src/denhaag/accordion.tokens.json
@@ -124,6 +124,7 @@
         }
       },
       "details": {
+        "display": { "value": "none" },
         "content": {
           "padding-block-start": {
             "value": 0


### PR DESCRIPTION
In de huidige opzet worden accordions op basis van height getoond of niet (height: 0 is gesloten). Maar als de height 0 is, kun je nog steeds door de content heen tabben. De fix hiervoor is om de content op display: none te zetten. Om nog steeds de open / close animatie te tonen, zetten we de content eerst op display: block en daaarna de juiste height, voordat we de open animation tonen.