### PR TITLE
fix(external link): fix inside unordered list

### DIFF
--- a/components/UnorderedList/src/index.scss
+++ b/components/UnorderedList/src/index.scss
@@ -11,6 +11,8 @@
   }
 
   .denhaag-link--with-icon {
+    --denhaag-link-with-icon-vertical-align: baseline;
+
     display: var(--denhaag-unordered-list-link-with-icon-display);
   }
 

--- a/proprietary/Components/src/denhaag/unordered-list.tokens.json
+++ b/proprietary/Components/src/denhaag/unordered-list.tokens.json
@@ -16,7 +16,7 @@
       },
       "link-with-icon": {
         "display": {
-          "value": "flex"
+          "value": "inline-flex"
         }
       },
       "list-item": {


### PR DESCRIPTION
### Doel:
- fixen van verkeerde weergave wanneer een externe link in een unordered list met tekst gebruikt wordt

### Screenshot BEFORE
![Screenshot 2023-07-25 at 17 16 14](https://github.com/nl-design-system/denhaag/assets/95216123/097f8c5f-f10d-442b-8625-5c6333de37b9)

### Screenshot AFTER
![Screenshot 2023-07-25 at 17 16 14](https://github.com/nl-design-system/denhaag/assets/95216123/b1bb8fe4-16c7-4e97-8ee4-baa745b34fa7)
