### PR TITLE
style(dynamic-content): fix broken css token

### DIFF
--- a/proprietary/Components/src/denhaag/dynamic-content.tokens.json
+++ b/proprietary/Components/src/denhaag/dynamic-content.tokens.json
@@ -66,7 +66,7 @@
           "value": "0%"
         },
         "size": { "value": "{denhaag.space.block.xl}" },
-        "border-radius": { "value": "denhaag.border.radius" }
+        "border-radius": { "value": "{denhaag.border.radius}" }
       },
       "image": {
         "background-color": {


### PR DESCRIPTION
CSS token was broken:

![Scherm­afbeelding 2023-08-07 om 14 20 42](https://github.com/nl-design-system/denhaag/assets/94894596/eff28709-4dbc-4798-baa4-82bc75a8f61a)

Miste `{}` rondom  in de tokens.json