### PR TITLE
build: fix missing file component import

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -37,6 +37,7 @@
     "@gemeente-denhaag/checkbox": "workspace:*",
     "@gemeente-denhaag/datepicker": "workspace:*",
     "@gemeente-denhaag/divider": "workspace:*",
+    "@gemeente-denhaag/file": "workspace:*",
     "@gemeente-denhaag/form-field": "workspace:*",
     "@gemeente-denhaag/form-progress": "workspace:*",
     "@gemeente-denhaag/formcontrol": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -1269,6 +1273,9 @@ importers:
       '@gemeente-denhaag/divider':
         specifier: workspace:*
         version: link:../../components/Divider
+      '@gemeente-denhaag/file':
+        specifier: workspace:*
+        version: link:../../components/File
       '@gemeente-denhaag/form-field':
         specifier: workspace:*
         version: link:../../components/FormField
@@ -25060,7 +25067,3 @@ packages:
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Fixes missing file import

> Hoi! Ik probeerde in een Storybook Status te importeren uit @gemeente-denhaag/components-react en kreeg toen ik 'm probeerde te gebruiken in Storybook deze error:
ERROR in ../../node_modules/.pnpm/@gemeente-denhaag+components-react@0.1.1-alpha.267_react-dom@17.0.2_react@16.14.0/node_modules/@gemeente-denhaag/components-react/dist/mjs/index.js 1:626-662

> Module not found: Error: Can't resolve '@gemeente-denhaag/file' in '/Users/hdv/Code/nl-design-system/themes/node_modules/.pnpm/@gemeente-denhaag+components-react@0.1.1-alpha.267_react-dom@17.0.2_react@16.14.0/node_modules/@gemeente-denhaag/components-react/dist/mjs'
> Die is te verhelpen door file los te installeren, maar wel gek? Zit er op de één of andere manier een relatie tussen file en progress-steps? (edited) 
> 