### PR TITLE
Removed lerna bootstrap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "proprietary/*"
   ],
   "scripts": {
-    "bootstrap": "lerna bootstrap",
     "build": "pnpm run build:library && pnpm run build:storybook",
     "build:library": "pnpm run --recursive build",
     "build:storybook": "build-storybook",


### PR DESCRIPTION
Removed this script to prevent confusion. Bootstrap isn't supported since Lerna v7. 
