### PR TITLE
Checkbox remove custom from classname

### DIFF
--- a/components/Checkbox/src/index.scss
+++ b/components/Checkbox/src/index.scss
@@ -10,7 +10,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--utrecht-checkbox-size, var(--utrecht-checkbox-size));
+  width: var(--utrecht-checkbox-size);
   margin-inline-start: 0;
   margin-inline-end: 0;
   margin-block-start: 0;
@@ -24,7 +24,7 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  width: var(--utrecht-checkbox-size, var(--utrecht-checkbox-size));
+  width: var(--utrecht-checkbox-size);
   aspect-ratio: 1;
   background-color: var(--utrecht-checkbox-background-color, var(--utrecht-form-control-background-color));
   border-width: var(--utrecht-checkbox-border-width, var(--utrecht-form-control-border-width));

--- a/components/Checkbox/src/index.scss
+++ b/components/Checkbox/src/index.scss
@@ -10,7 +10,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: var(--utrecht-checkbox-size, var(--utrecht-custom-checkbox-size));
+  width: var(--utrecht-checkbox-size, var(--utrecht-checkbox-size));
   margin-inline-start: 0;
   margin-inline-end: 0;
   margin-block-start: 0;
@@ -24,13 +24,13 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  width: var(--utrecht-checkbox-size, var(--utrecht-custom-checkbox-size));
+  width: var(--utrecht-checkbox-size, var(--utrecht-checkbox-size));
   aspect-ratio: 1;
-  background-color: var(--utrecht-custom-checkbox-background-color, var(--utrecht-form-control-background-color));
-  border-width: var(--utrecht-custom-checkbox-border-width, var(--utrecht-form-control-border-width));
+  background-color: var(--utrecht-checkbox-background-color, var(--utrecht-form-control-background-color));
+  border-width: var(--utrecht-checkbox-border-width, var(--utrecht-form-control-border-width));
   border-style: solid;
-  border-color: var(--utrecht-custom-checkbox-border-color, var(--utrecht-form-control-border-color));
-  border-radius: var(--utrecht-custom-checkbox-border-radius, var(--utrecht-form-control-border-radius));
+  border-color: var(--utrecht-checkbox-border-color, var(--utrecht-form-control-border-color));
+  border-radius: var(--utrecht-checkbox-border-radius, var(--utrecht-form-control-border-radius));
   box-sizing: border-box;
   cursor: pointer;
 }
@@ -44,24 +44,24 @@
 }
 
 .denhaag-checkbox__input:checked + .denhaag-checkbox__icon {
-  background-color: var(--utrecht-custom-checkbox-checked-background-color);
-  border-width: var(--utrecht-custom-checkbox-checked-border-width);
-  border-color: var(--utrecht-custom-checkbox-checked-border-color);
+  background-color: var(--utrecht-checkbox-checked-background-color);
+  border-width: var(--utrecht-checkbox-checked-border-width);
+  border-color: var(--utrecht-checkbox-checked-border-color);
 }
 
 .denhaag-checkbox__input:checked + .denhaag-checkbox__icon .denhaag-icon {
   display: block;
-  font-size: var(--utrecht-custom-checkbox-icon-size);
-  color: var(--utrecht-custom-checkbox-checked-color);
+  font-size: var(--utrecht-checkbox-icon-size);
+  color: var(--utrecht-checkbox-checked-color);
 }
 
 .denhaag-checkbox.denhaag-checkbox--error .denhaag-checkbox__icon {
-  border-width: var(--utrecht-custom-checkbox-invalid-border-width, var(--utrecht-form-control-invalid-border-width));
-  border-color: var(--utrecht-custom-checkbox-invalid-border-color, var(--utrecht-form-control-invalid-border-color));
+  border-width: var(--utrecht-checkbox-invalid-border-width, var(--utrecht-form-control-invalid-border-width,));
+  border-color: var(--utrecht-checkbox-invalid-border-color, var(--utrecht-form-control-invalid-border-color));
 }
 
 .denhaag-checkbox.denhaag-checkbox--error .denhaag-checkbox__icon .denhaag-icon {
-  color: var(--utrecht-custom-checkbox-invalid-color);
+  color: var(--utrecht-checkbox-invalid-color);
 }
 
 .denhaag-checkbox:focus-within .denhaag-checkbox__icon,
@@ -77,9 +77,9 @@
 }
 
 .denhaag-checkbox .denhaag-checkbox__input:disabled + .denhaag-checkbox__icon {
-  background-color: var(--utrecht-custom-checkbox-disabled-background-color);
-  border-width: var(--utrecht-custom-checkbox-disabled-border-width);
-  border-color: var(--utrecht-custom-checkbox-disabled-border-color);
+  background-color: var(--utrecht-checkbox-disabled-background-color);
+  border-width: var(--utrecht-checkbox-disabled-border-width);
+  border-color: var(--utrecht-checkbox-disabled-border-color);
   cursor: default;
 }
 


### PR DESCRIPTION
### Remove "Custom" from checkbox classname because the name has changed to "checkbox" 

the name was changed in Utrecht so the tokens.json file also is named "checkbox" 
  
Proposal to Remove "custom" and maybe even remove the Den Haag checkbox and just use the Utrecht checkbox

