### PR TITLE
fix: fixed wrong margin calculations due to incorrect marker-size var…

### DIFF
--- a/components/ContactTimeline/src/_ContactTimelineStep.scss
+++ b/components/ContactTimeline/src/_ContactTimelineStep.scss
@@ -1,5 +1,6 @@
 .denhaag-contact-timeline__step {
   &.denhaag-process-steps__step {
     --denhaag-process-steps-step-padding-block-end: var(--denhaag-contact-timeline-step-padding-block-end);
+    --denhaag-step-marker-size: var(--denhaag-step-marker-nested-size);
   }
 }


### PR DESCRIPTION
Contact timeline heeft geen normale step-marker, dus zou altijd de nested-marker size moeten gebruiken in de margin calcs. En niet de default step-marker-size van 32px.