### PR TITLE
Update tabs when data change

### DIFF
--- a/components/Tab/src/index.tsx
+++ b/components/Tab/src/index.tsx
@@ -35,7 +35,7 @@ interface CustomCSSProperties extends React.CSSProperties {
  * @constructor Constructs an instance of Tabs.
  */
 export const Tabs: React.FC<TabsProps> = ({ tabData }: TabsProps) => {
-  const [tabs] = useState(
+  const [tabs, setTabs] = useState(
     tabData.map((tab) => {
       const tabRef = createRef<HTMLDivElement>();
       const id = uuidv4();
@@ -53,6 +53,10 @@ export const Tabs: React.FC<TabsProps> = ({ tabData }: TabsProps) => {
   const [focussedTab, setFocussedTab] = useState<TabRef | undefined>();
 
   const [tabIndicatorPosition, setTabIndicatorPosition] = useState<TabIndicatorPosition>();
+
+  useEffect(() => {
+    setTabs(tabs.map((tab, index) => ({ ...tab, tab: { ...tabData[index] } })));
+  }, [tabData]);
 
   useEffect(() => {
     if (focussedTab !== undefined) {

--- a/packages/storybook/src/react/Tabs.stories.tsx
+++ b/packages/storybook/src/react/Tabs.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Tabs, TabsProps } from '@gemeente-denhaag/tab';
 import readme from '../../../../components/Tab/README.md';
+import { useEffect, useState } from 'react';
+import React from 'react';
 
 const exampleArgs: TabsProps = {
   tabData: [
@@ -29,3 +31,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const UpdateTabContent: Story = {
+  render: () => {
+    const [seconds, setSeconds] = useState(1);
+
+    useEffect(() => {
+      const interval = setInterval(() => {
+        setSeconds((seconds: number) => seconds + 1);
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }, []);
+
+    return (
+      <Tabs
+        tabData={[
+          { label: 'A tab with timer', panelContent: <>Update timer: {seconds}</> },
+          { label: 'Another tab', panelContent: 'Item Two' },
+          { label: 'Yet another tab', panelContent: 'Item Three' },
+        ]}
+      />
+    );
+  },
+};

--- a/packages/storybook/src/react/Tabs.stories.tsx
+++ b/packages/storybook/src/react/Tabs.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { Tabs, TabsProps } from '@gemeente-denhaag/tab';
 import readme from '../../../../components/Tab/README.md';
-import { useEffect, useState } from 'react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const exampleArgs: TabsProps = {
   tabData: [


### PR DESCRIPTION
Wanneer een tab child geüpdatet wordt vind er op dit moment geen rerender plaats omdat de tabData opgeslagen wordt in de state van de het tab component. Door een useEffect toe te voegen als de tabData veranderd is dit nu opgelost. 