### PR TITLE
build: update cicd workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,35 +12,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 8
+
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
         with:
-          node-version-file: ".nvmrc"
-
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8.14
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version-file: .nvmrc
+          cache: pnpm
 
       - name: Install dependencies
         run: |
@@ -64,14 +51,16 @@ jobs:
         run: pnpm run build:storybook
 
       - name: Upload storybook
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: storybook
           path: storybook-static
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v10
-        if: github.event.pull_request.draft == false
+        uses: chromaui/action@v11.3.0
+        if: |
+          github.event.pull_request.draft == false &&
+          github.action != 'dependabot[bot]'
         with:
           autoAcceptChanges: main
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -83,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: Download storybook artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           name: storybook
           path: storybook-static
@@ -103,33 +92,20 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.GH_ADMIN_TOKEN }}
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 8
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
         with:
-          node-version-file: ".nvmrc"
-
-      - uses: pnpm/action-setup@v3.0.0
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8.14
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version-file: .nvmrc
+          cache: pnpm
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Use explicit version numbers everywhere
- Move `pnpm/action-setup` before `actions/setup-node` and make the latter use the pnpm cache
- Remove `actions/cache` entirely as it is no longer needed