### PR TITLE
Undefined document.title CSS injection bug fix

### DIFF
--- a/components/Sidenav/src/index.tsx
+++ b/components/Sidenav/src/index.tsx
@@ -1,6 +1,11 @@
 import './index.scss';
 
-export * from './Sidenav';
-export * from './SidenavItem';
-export * from './SidenavList';
-export * from './SidenavLink';
+// export * from './Sidenav';
+// export * from './SidenavItem';
+// export * from './SidenavList';
+// export * from './SidenavLink';
+
+export { default as Sidenav } from './Sidenav';
+export { default as SidenavItem } from './SidenavItem';
+export { default as SidenavList } from './SidenavList';
+export { default as SidenavLink } from './SidenavLink';

--- a/components/Sidenav/src/index.tsx
+++ b/components/Sidenav/src/index.tsx
@@ -1,11 +1,6 @@
 import './index.scss';
 
-// export * from './Sidenav';
-// export * from './SidenavItem';
-// export * from './SidenavList';
-// export * from './SidenavLink';
-
-export { default as Sidenav } from './Sidenav';
-export { default as SidenavItem } from './SidenavItem';
-export { default as SidenavList } from './SidenavList';
-export { default as SidenavLink } from './SidenavLink';
+export * from './Sidenav';
+export * from './SidenavItem';
+export * from './SidenavList';
+export * from './SidenavLink';

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -39,6 +39,8 @@ const createConfig = ({ dir, format, baseUrl }) => ({
       minimize: true,
       inject: (css, { insertAt } = {}) => {
         return `  
+        if (typeof document !== 'undefined') { 
+
           const head = document.head || document.getElementsByTagName('head')[0]
           const style = document.createElement('style')
           style.type = 'text/css'
@@ -59,9 +61,11 @@ const createConfig = ({ dir, format, baseUrl }) => ({
           } else {
             style.appendChild(document.createTextNode(${css}))
           }
+        }
         `;
       },
     }),
+
     nodeResolve(),
     commonjs({ include: /node_modules/ }),
     svgr({ icon: true, svgo: true, memo: true }),


### PR DESCRIPTION
Bij het implementeren van de sidenav-component van Den Haag kwam ik een fout tegen. We gebruiken React-componenten zoals sidenav in Next.js, maar er gaat iets mis bij server-side rendering. Telkens wanneer de component wordt gebruikt, krijgen we een foutmelding door de CSS-injectiecode: `document is undefined`

Met deze kleine check `if (typeof document !== 'undefined') { ... } ` wordt de CSS-injectie overgeslagen tijdens server-side rendering, hopelijk werken alle componenten nu goed in Next.js.