### PR TITLE
docs: add sidenavigation docs to story

### DIFF
--- a/packages/storybook/src/css/Sidenav.stories.tsx
+++ b/packages/storybook/src/css/Sidenav.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { BadgeCounter } from '@gemeente-denhaag/badge-counter';
 import { Sidenav, SidenavItem, SidenavLink, SidenavList } from '@gemeente-denhaag/sidenav';
 import { ArchiveIcon, CheckCircleIcon, GridIcon, InboxIcon, UserIcon } from '@gemeente-denhaag/icons';
-import readme from '../../../../components/Button/README.md';
+import readme from '../../../../components/Sidenav/README.md';
 
 const exampleArgs = {
   children: (

--- a/packages/storybook/src/react/Sidenav.stories.tsx
+++ b/packages/storybook/src/react/Sidenav.stories.tsx
@@ -4,7 +4,7 @@ import { ArchiveIcon, CheckCircleIcon, GridIcon, InboxIcon, UserIcon } from '@ge
 import { Sidenav, SidenavItem, SidenavLink, SidenavList } from '@gemeente-denhaag/sidenav';
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import readme from '../../../../components/Button/README.md';
+import readme from '../../../../components/Sidenav/README.md';
 import tokensDefinition from '../../../../components/Sidenav/tokens.json';
 
 const exampleArgs = {


### PR DESCRIPTION
The docs for the sidenav were still using button docs. Set them to the correct docs for the CSS and React story