### PR TITLE
build: add "packageManager" to package.json

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 9
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2
@@ -98,8 +96,6 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@v3.0.0
-        with:
-          version: 9
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4.0.2

--- a/package.json
+++ b/package.json
@@ -126,5 +126,6 @@
   "engines": {
     "node": "^20",
     "pnpm": "^9"
-  }
+  },
+  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
 }


### PR DESCRIPTION
The "packageManager" field is picked up by "pnpm/action-setup" so remove the explicit version in the workflow jobs

An environment variable `ENABLE_EXPERIMENTAL_COREPACK=1` was added to the Vercel build environment. This guarantees that Vercel will use corepack which is a workaround because at this time pnpm 9 is not officially supported yet.