### PR TITLE
fix: husky 9 configuration

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit "$1"
+pnpm exec commitlint --edit "$1"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname $0)/_/husky.sh"
-
 pnpm install --frozen-lockfile

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#!/bin/sh
-
-npx lint-staged
+pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:js": "eslint --ext .js,.json,.jsx,.mdx,.mjs,.ts,.tsx --report-unused-disable-directives .",
     "lint:package": "npmPkgJsonLint \"**/package.json\"",
     "lint:prettier": "prettier --check .",
-    "postinstall": "husky",
+    "prepare": "husky",
     "postpublish": "pinst --enable",
     "preinstall": "npx only-allow pnpm",
     "prepublishOnly": "pinst --disable",


### PR DESCRIPTION
- Clean up hook scripts
- Use `pnpm exec` instead of `npx` in hook scripts
- Replace package.json#postinstall with package.json#prepare

