### PR TITLE
Default export

### DIFF
--- a/components/ButtonLink/src/index.tsx
+++ b/components/ButtonLink/src/index.tsx
@@ -2,3 +2,4 @@ import { ButtonLink, ButtonLinkProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { ButtonLink, ButtonLinkProps };
+export default ButtonLink;

--- a/components/Checkbox/src/index.tsx
+++ b/components/Checkbox/src/index.tsx
@@ -2,3 +2,4 @@ import { Checkbox, CheckboxProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { Checkbox, CheckboxProps };
+export default Checkbox;

--- a/components/FormField/src/index.tsx
+++ b/components/FormField/src/index.tsx
@@ -2,3 +2,4 @@ import { FormField, FormFieldProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { FormField, FormFieldProps };
+export default FormField;

--- a/components/FormFieldDescription/src/index.tsx
+++ b/components/FormFieldDescription/src/index.tsx
@@ -2,3 +2,4 @@ import { FormFieldDescription, FormFieldDescriptionProps } from '@utrecht/compon
 import './index.scss';
 
 export { FormFieldDescription, FormFieldDescriptionProps };
+export default FormFieldDescription;

--- a/components/FormFieldErrorMessage/src/index.tsx
+++ b/components/FormFieldErrorMessage/src/index.tsx
@@ -2,3 +2,4 @@ import { FormFieldErrorMessage, FormFieldErrorMessageProps } from '@utrecht/comp
 import './index.scss';
 
 export { FormFieldErrorMessage, FormFieldErrorMessageProps };
+export default FormFieldErrorMessage;

--- a/components/FormFieldSet/src/index.tsx
+++ b/components/FormFieldSet/src/index.tsx
@@ -2,3 +2,4 @@ import { Fieldset, FieldsetProps, FieldsetLegend, FieldsetLegendProps } from '@u
 import './index.scss';
 
 export { Fieldset, FieldsetProps, FieldsetLegend, FieldsetLegendProps };
+export default Fieldset;

--- a/components/FormLabel/src/index.tsx
+++ b/components/FormLabel/src/index.tsx
@@ -2,3 +2,4 @@ import { FormLabel, FormLabelProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { FormLabel, FormLabelProps };
+export default FormLabel;

--- a/components/LinkButton/src/index.tsx
+++ b/components/LinkButton/src/index.tsx
@@ -2,3 +2,4 @@ import { LinkButton, LinkButtonProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { LinkButton, LinkButtonProps };
+export default LinkButton;

--- a/components/OrderedList/src/index.tsx
+++ b/components/OrderedList/src/index.tsx
@@ -2,3 +2,4 @@ import { OrderedList, OrderedListProps, OrderedListItem, OrderedListItemProps } 
 import './index.scss';
 
 export { OrderedList, OrderedListProps, OrderedListItem, OrderedListItemProps };
+export default OrderedList;

--- a/components/RadioButton/src/index.tsx
+++ b/components/RadioButton/src/index.tsx
@@ -2,3 +2,4 @@ import { RadioButton, RadioButtonProps } from '@utrecht/component-library-react'
 import './index.scss';
 
 export { RadioButton, RadioButtonProps };
+export default RadioButton;

--- a/components/StatusBadge/src/index.tsx
+++ b/components/StatusBadge/src/index.tsx
@@ -2,3 +2,4 @@ import { StatusBadge, StatusBadgeProps } from '@utrecht/component-library-react'
 import './index.scss';
 
 export { StatusBadge, StatusBadgeProps };
+export default StatusBadge;

--- a/components/TextInput/src/index.tsx
+++ b/components/TextInput/src/index.tsx
@@ -2,3 +2,4 @@ import { Textbox as TextInput, TextboxProps as TextInputProps } from '@utrecht/c
 import './index.scss';
 
 export { TextInput, TextInputProps };
+export default TextInput;

--- a/components/Textarea/src/index.tsx
+++ b/components/Textarea/src/index.tsx
@@ -2,3 +2,4 @@ import { Textarea, TextareaProps } from '@utrecht/component-library-react';
 import './index.scss';
 
 export { Textarea, TextareaProps };
+export default Textarea;

--- a/components/UnorderedList/src/index.tsx
+++ b/components/UnorderedList/src/index.tsx
@@ -18,3 +18,4 @@ const UnorderedList = ({ className, nested, ...props }: UnorderedListProps) => {
 };
 
 export { UnorderedList, UnorderedListProps, UnorderedListItem, UnorderedListItemProps };
+export default UnorderedList;


### PR DESCRIPTION
Om de volgende melding te voorkomen bij het gebruik van de package:

SyntaxError: Cannot use import statement outside a module
Module /Users/borai/Developer/nl-portal-frontend-libraries/node_modules/.pnpm/@gemeente-denhaag+status-badge@0.3.0-alpha.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/@gemeente-denhaag/status-badge/dist/mjs/index.js:1 seems to be an ES Module but shipped in a CommonJS package. You might want to create an issue to the package "@gemeente-denhaag/status-badge" asking them to ship the file in .mjs extension or add "type": "module" in their package.json.