### PR TITLE
Modal actions align right

### DIFF
--- a/components/Modal/src/_modal-footer.scss
+++ b/components/Modal/src/_modal-footer.scss
@@ -1,6 +1,7 @@
 .denhaag-modal {
   &__footer {
     display: flex;
+    justify-content: var(--denhaag-modal-footer-justify-content);
     flex-direction: var(--denhaag-modal-footer-direction);
     gap: var(--denhaag-modal-gap, var(--denhaag-modal-padding-block));
     padding-block-start: var(--denhaag-modal-footer-padding-block);

--- a/proprietary/Components/src/denhaag/modal.tokens.json
+++ b/proprietary/Components/src/denhaag/modal.tokens.json
@@ -116,6 +116,9 @@
           "inline": {
             "value": "{denhaag.space.inline.md.value}"
           }
+        },
+        "justify-content": {
+          "value": "flex-end"
         }
       }
     }


### PR DESCRIPTION
Nieuw design heeft de buttons in de model rechts uitgelijnd. 

https://www.figma.com/design/E2xRxGbRd5qboVllqkADIQ/🛖-Vakantieverhuur---MijnDenHaag?node-id=9482-11120&node-type=INSTANCE&m=dev