### PR TITLE
style(button): reduce tokens

### DIFF
--- a/components/Button/src/index.scss
+++ b/components/Button/src/index.scss
@@ -2,21 +2,19 @@
   --denhaag-button-focus-border-offset: calc(-1 * var(--denhaag-focus-border-width));
 
   align-items: center;
-  background-color: var(--denhaag-button-primary-action-background-color);
+  background-color: var(--denhaag-button-primary-action-background-color, var(--denhaag-color-green-3));
   border: 0;
-  border-radius: var(--denhaag-button-border-radius);
-  color: var(--denhaag-button-primary-action-color);
+  border-radius: var(--denhaag-button-border-radius, var(--denhaag-border-radius));
+  color: var(--denhaag-button-primary-action-color, var(--denhaag-color-white));
   cursor: var(--denhaag-button-cursor, default);
   display: inline-flex;
-  font-family: var(--denhaag-button-font-family);
-  font-weight: var(--denhaag-button-font-weight, 400);
+  font-family: var(--denhaag-button-font-family, var(--denhaag-typography-sans-serif-font-family));
+  font-weight: var(--denhaag-button-font-weight, var(--denhaag-typography-weight-regular));
   font-size: var(--denhaag-button-font-size, var(--denhaag-typography-scale-base-font-size));
   justify-content: center;
   line-height: 1.5;
-  padding-block-end: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
-  padding-block-start: var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block));
-  padding-inline-end: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
-  padding-inline-start: var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline));
+  padding-block: var(--denhaag-button-medium-size-padding-block);
+  padding-inline: var(--denhaag-button-medium-size-padding-inline);
   position: relative;
   text-decoration: none;
   transition-property: background-color, border-color, color, transform;
@@ -42,14 +40,13 @@ a.denhaag-button {
 .denhaag-button:hover {
   --denhaag-button-transform-y: var(--denhaag-button-hover-transform-y);
 
-  background-color: var(--denhaag-button-primary-action-hover-background-color);
-  color: var(--denhaag-button-primary-action-hover-color);
+  background-color: var(--denhaag-button-primary-action-hover-background-color, var(--denhaag-color-green-4));
+  color: var(--denhaag-button-primary-action-hover-color, var(--denhaag-color-white));
 }
 
 .denhaag-button--focus-visible::after,
 .denhaag-button:focus-visible::after {
   border: var(--denhaag-focus-border);
-  border-radius: var(--denhaag-border-radius);
   bottom: var(--denhaag-button-focus-border-offset);
   content: "";
   display: block;
@@ -70,67 +67,57 @@ a.denhaag-button {
 
 .denhaag-button.denhaag-button--disabled,
 .denhaag-button.denhaag-button:disabled {
-  background-color: var(--denhaag-button-primary-action-disabled-background-color);
-  color: var(--denhaag-button-primary-action-disabled-color);
+  background-color: var(--denhaag-button-primary-action-disabled-background-color, var(--denhaag-color-grey-2));
+  color: var(--denhaag-button-primary-action-disabled-color, var(--denhaag-color-white));
 }
 
 .denhaag-button--secondary-action {
   // Due to the accessibility focus outline overlapping with the border, the outline needs to be repositioned for the border variant.
   --denhaag-button-focus-border-offset: calc(-1 * (var(--denhaag-focus-border-width) * 1.5));
 
-  background-color: var(--denhaag-button-secondary-action-background-color);
-  border-color: var(--denhaag-button-secondary-action-border-color);
+  background-color: var(--denhaag-button-secondary-action-background-color, var(--denhaag-color-white));
+  border-color: var(--denhaag-button-secondary-action-border-color, var(--denhaag-color-green-3));
   border-style: solid;
-  border-width: var(--denhaag-button-border-width);
-  color: var(--denhaag-button-secondary-action-color);
-  padding-block-end: calc(
-    var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) -
-      var(--denhaag-button-border-width)
-  );
-  padding-block-start: calc(
-    var(--denhaag-button-medium-size-padding-block, var(--denhaag-button-padding-block)) -
-      var(--denhaag-button-border-width)
-  );
+  border-width: var(--denhaag-button-border-width, 1px);
+  color: var(--denhaag-button-secondary-action-color, var(--denhaag-color-green-3));
+  padding-block-end: calc(var(--denhaag-button-medium-size-padding-block) - var(--denhaag-button-border-width));
+  padding-block-start: calc(var(--denhaag-button-medium-size-padding-block) - var(--denhaag-button-border-width));
   padding-inline-end: calc(
-    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) -
-      var(--denhaag-button-border-width)
+    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-space-md)) - var(--denhaag-button-border-width)
   );
   padding-inline-start: calc(
-    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-button-padding-inline)) -
-      var(--denhaag-button-border-width)
+    var(--denhaag-button-medium-size-padding-inline, var(--denhaag-space-md)) - var(--denhaag-button-border-width)
   );
 }
 
 .denhaag-button--secondary-action.denhaag-button--hover,
 .denhaag-button--secondary-action:hover {
-  background-color: var(--denhaag-button-secondary-action-hover-background-color);
-  border-color: var(--denhaag-button-secondary-action-hover-border-color);
-  color: var(--denhaag-button-secondary-action-hover-color);
+  background-color: var(--denhaag-button-secondary-action-hover-background-color, var(--denhaag-color-white));
+  border-color: var(--denhaag-button-secondary-action-hover-border-color, var(--denhaag-color-green-4));
+  color: var(--denhaag-button-secondary-action-hover-color, var(--denhaag-color-green-4));
 }
 
 .denhaag-button--secondary-action.denhaag-button--disabled,
 .denhaag-button--secondary-action.denhaag-button:disabled {
-  background-color: var(--denhaag-button-secondary-action-disabled-background-color);
-  border-color: var(--denhaag-button-secondary-action-disabled-border-color);
-  color: var(--denhaag-button-secondary-action-disabled-color);
+  background-color: var(--denhaag-button-secondary-action-disabled-background-color, var(--denhaag-color-white));
+  border-color: var(--denhaag-button-secondary-action-disabled-border-color, var(--denhaag-color-grey-2));
+  color: var(--denhaag-button-secondary-action-disabled-color, var(--denhaag-color-grey-2));
 }
 
 .denhaag-button--large {
   --denhaag-button-font-size: var(--denhaag-typography-scale-lg-font-size);
   --denhaag-button-medium-size-padding-block: var(--denhaag-button-large-size-padding-block);
-  --denhaag-button-medium-size-padding-inline: var(--denhaag-button-large-size-padding-inline);
+  --denhaag-button-medium-size-padding-inline: var(--denhaag-button-large-size-padding-inline, var(--denhaag-space-lg));
 
   line-height: var(--denhaag-button-large-size-line-height);
 }
 
 .denhaag-button--large.denhaag-button--secondary-action {
   --denhaag-button-medium-size-padding-block: calc(
-    var(--denhaag-button-large-size-padding-block, var(--denhaag-button-padding-block)) -
-      var(--denhaag-button-border-width)
+    var(--denhaag-button-large-size-padding-block) - var(--denhaag-button-border-width)
   );
   --denhaag-button-medium-size-padding-inline: calc(
-    var(--denhaag-button-large-size-padding-inline, var(--denhaag-button-padding-inline)) -
-      var(--denhaag-button-border-width)
+    var(--denhaag-button-large-size-padding-inline, var(--denhaag-space-lg)) - var(--denhaag-button-border-width)
   );
 }
 
@@ -178,5 +165,5 @@ a.denhaag-button {
 }
 
 .denhaag-button--icon-only .denhaag-button__icon {
-  height: var(--denhaag-button-icon-only-icon-height);
+  height: var(--denhaag-button-icon-only-icon-height, var(--denhaag-space-lg));
 }

--- a/components/Button/src/stories/bem.stories.mdx
+++ b/components/Button/src/stories/bem.stories.mdx
@@ -28,9 +28,9 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button">Button</button>
-      <button class="denhaag-button denhaag-button--secondary-action">Button</button>
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button">Button</button>
+      <button className="denhaag-button denhaag-button--secondary-action">Button</button>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -41,15 +41,15 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - icon left">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--start-icon">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--start-icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -58,14 +58,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -84,16 +84,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - icon right">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--end-icon">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -101,15 +101,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -127,19 +127,19 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - hover">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--hover">Button</button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--hover">Button</button>
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--hover">Button</button>
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--hover">Button</button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--start-icon denhaag-button--hover">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--start-icon denhaag-button--hover">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -148,14 +148,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--hover">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--hover">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -165,16 +165,16 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--hover">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--end-icon denhaag-button--hover">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -182,15 +182,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--hover">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--hover">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -208,23 +208,23 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - disabled">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--disabled">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--disabled">
         Button
       </button>
-      <button disabled class="denhaag-button denhaag-button--secondary-action denhaag-button--disabled">
+      <button disabled className="denhaag-button denhaag-button--secondary-action denhaag-button--disabled">
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--start-icon denhaag-button--disabled">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--start-icon denhaag-button--disabled">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -235,15 +235,15 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--disabled"
+        className="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--disabled"
       >
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -253,16 +253,16 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--end-icon denhaag-button--disabled">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--end-icon denhaag-button--disabled">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -272,16 +272,16 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--disabled"
+        className="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--disabled"
       >
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -299,19 +299,19 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - focus">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--focus">Button</button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--focus">Button</button>
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--focus">Button</button>
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--focus">Button</button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--start-icon denhaag-button--focus">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--start-icon denhaag-button--focus">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -320,14 +320,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--focus">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--focus">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -337,16 +337,16 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--end-icon denhaag-button--focus">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--end-icon denhaag-button--focus">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -354,15 +354,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--focus">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--focus">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -380,9 +380,9 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Default - Reduced motion">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--reduced-motion">Button</button>
-      <button class="denhaag-button denhaag-button--reduced-motion denhaag-button--secondary-action">Button</button>
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--reduced-motion">Button</button>
+      <button className="denhaag-button denhaag-button--reduced-motion denhaag-button--secondary-action">Button</button>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -393,9 +393,9 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large">Button</button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action">Button</button>
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large">Button</button>
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action">Button</button>
     </div>
   </Story>
   {/* eslint-enable react/no-unknown-property */}
@@ -406,15 +406,15 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large - icon left">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--start-icon">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--start-icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -423,14 +423,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -449,16 +449,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large - icon right">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--end-icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--end-icon">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -466,15 +466,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -492,21 +492,21 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large - hover">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--hover">Button</button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--hover">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--hover">Button</button>
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--hover">
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--hover">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--hover">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -515,14 +515,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--hover">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--hover">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -532,16 +532,16 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--hover">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--hover">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -549,15 +549,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--hover">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--hover">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -575,26 +575,29 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large - disabled">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--large denhaag-button--disabled">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--large denhaag-button--disabled">
         Button
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--disabled"
+        className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--disabled"
       >
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--disabled">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button
+        disabled
+        className="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--disabled"
+      >
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -605,15 +608,15 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--disabled"
+        className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--disabled"
       >
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -623,16 +626,19 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--disabled">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button
+        disabled
+        className="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--disabled"
+      >
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -642,16 +648,16 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--disabled"
+        className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--disabled"
       >
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -669,21 +675,21 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Large - focus">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--focus">Button</button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--focus">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--focus">Button</button>
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--focus">
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--focus">
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--start-icon denhaag-button--focus">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -692,14 +698,14 @@ import readme from "../../README.md";
         </span>
         Button
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--focus">
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--start-icon denhaag-button--focus">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -709,16 +715,16 @@ import readme from "../../README.md";
         Button
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--focus">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--large denhaag-button--end-icon denhaag-button--focus">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -726,15 +732,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--focus">
+      <button className="denhaag-button denhaag-button--large denhaag-button--secondary-action denhaag-button--end-icon denhaag-button--focus">
         Button
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -752,16 +758,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -769,15 +775,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -786,16 +792,16 @@ import readme from "../../README.md";
         </span>
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -806,15 +812,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--icon-only">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--icon-only">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -835,16 +841,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - hover">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -852,15 +858,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--hover">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--hover">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -869,16 +875,16 @@ import readme from "../../README.md";
         </span>
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -889,15 +895,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--hover">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--hover">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -918,16 +924,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - disabled">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -937,16 +943,16 @@ import readme from "../../README.md";
       </button>
       <button
         disabled
-        class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--disabled"
+        className="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--disabled"
       >
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -955,16 +961,16 @@ import readme from "../../README.md";
         </span>
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button disabled className="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -975,15 +981,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button disabled class="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button disabled className="denhaag-button denhaag-button--icon-only denhaag-button--disabled">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -1004,16 +1010,16 @@ import readme from "../../README.md";
 <Canvas>
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Icon only - focus">
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -1021,15 +1027,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--focus">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--secondary-action denhaag-button--icon-only denhaag-button--focus">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -1038,16 +1044,16 @@ import readme from "../../README.md";
         </span>
       </button>
     </div>
-    <div class="denhaag-button-group denhaag-button-group--multiple">
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+    <div className="denhaag-button-group denhaag-button-group--multiple">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >
@@ -1058,15 +1064,15 @@ import readme from "../../README.md";
           </svg>
         </span>
       </button>
-      <button class="denhaag-button denhaag-button--icon-only denhaag-button--focus">
-        <span class="denhaag-button__sr-only">describing text</span>
-        <span class="denhaag-button__icon">
+      <button className="denhaag-button denhaag-button--icon-only denhaag-button--focus">
+        <span className="denhaag-button__sr-only">describing text</span>
+        <span className="denhaag-button__icon">
           <svg
             width="1em"
             height="1em"
             viewBox="0 0 20 20"
             xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
+            className="denhaag-icon"
             focusable="false"
             aria-hidden="true"
           >

--- a/proprietary/Components/src/denhaag/button.tokens.json
+++ b/proprietary/Components/src/denhaag/button.tokens.json
@@ -1,72 +1,27 @@
 {
   "denhaag": {
     "button": {
-      "border-radius": { "value": "{denhaag.border-radius}" },
       "border-width": { "value": "1px" },
-      "font-family": { "value": "{denhaag.typography.sans-serif.font-family}" },
-      "font-weight": { "value": "{denhaag.typography.weight.regular}" },
-      "font-size": {
-        "value": "{denhaag.typography.scale.base.font-size}"
-      },
-      "padding-block": { "value": "{denhaag.space.xs}" },
-      "padding-inline": { "value": "{denhaag.space.md}" },
       "focus": {
-        "border-color": { "value": "{denhaag.focus.border-color}" },
-        "border-width": { "value": "{denhaag.focus.border-width}" },
-        "border-style": { "value": "{denhaag.focus.border-style}" },
         "transform-y": {
           "value": "-1px"
         }
-      },
-      "disabled": {
-        "color": {}
       },
       "hover": {
         "transform-y": {
           "value": "-2px"
         }
       },
-      "primary-action": {
-        "background-color": { "value": "{denhaag.color.green.3}" },
-        "color": { "value": "{denhaag.color.white}" },
-        "hover": {
-          "background-color": { "value": "{denhaag.color.green.4}" },
-          "color": { "value": "{denhaag.color.white}" }
-        },
-        "disabled": {
-          "background-color": { "value": "{denhaag.color.grey.2}" },
-          "color": { "value": "{denhaag.color.white}" }
-        }
-      },
-      "secondary-action": {
-        "background-color": { "value": "{denhaag.color.white}" },
-        "color": { "value": "{denhaag.color.green.3}" },
-        "border-color": { "value": "{denhaag.color.green.3}" },
-        "hover": {
-          "background-color": { "value": "{denhaag.color.white}" },
-          "border-color": { "value": "{denhaag.color.green.4}" },
-          "color": { "value": "{denhaag.color.green.4}" }
-        },
-        "disabled": {
-          "background-color": { "value": "{denhaag.color.white}" },
-          "border-color": { "value": "{denhaag.color.grey.2}" },
-          "color": { "value": "{denhaag.color.grey.2}" }
-        }
-      },
       "large-size": {
         "padding-block": { "value": "0.40625rem" },
-        "padding-inline": { "value": "{denhaag.space.lg}" },
         "line-height": { "value": "1.75" }
       },
       "medium-size": {
-        "padding-block": { "value": "{denhaag.button.padding-block}" },
-        "padding-inline": { "value": "{denhaag.button.padding-inline}" }
+        "padding-block": { "value": "{denhaag.space.xs}" },
+        "padding-inline": { "value": "{denhaag.space.md}" }
       },
       "icon-only": {
-        "height": { "value": "2.6875rem" },
-        "icon": {
-          "height": { "value": "{denhaag.space.lg}" }
-        }
+        "height": { "value": "2.6875rem" }
       },
       "transition": {
         "delay": {


### PR DESCRIPTION
Hey Paul, deze moet even heel goed gecheckt worden.

Deze had ik laten staan omdat er die calc() functies in zitten die het gebruiken.
Als zou medium ook nog aangepast kunnen worden naar default? Ik vond het een beetje een lastige.

```
 "medium-size": {
    "padding-block": { "value": "{denhaag.space.xs}" },
    "padding-inline": { "value": "{denhaag.space.md}" }
},
```