### PR TITLE
feat(icons): set icons in links 20x20 and fix multiple issues

### DIFF
--- a/components/CardAuthentication/src/story-template.tsx
+++ b/components/CardAuthentication/src/story-template.tsx
@@ -133,24 +133,22 @@ export const AuthenticationCard = ({
               href="#example-link"
               className="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
             >
-              <span className="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shapeRendering="auto"
-                >
-                  <path
-                    d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shapeRendering="auto"
+              >
+                <path
+                  d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                  fill="currentColor"
+                />
+              </svg>
               <span className="denhaag-link__label">
                 {authProvider === 'eIDAS' ? 'How does eIDAS work?' : `Vraag ${authProvider} aan`}
               </span>

--- a/components/HighlightedLinks/src/index.scss
+++ b/components/HighlightedLinks/src/index.scss
@@ -4,28 +4,20 @@
   width: 100%;
 }
 
-.denhaag-highlighted-links__list {
-  --denhaag-link-group-navigation-list-margin-block-end: 0;
-
-  display: grid;
-  gap: var(--denhaag-highlighted-links-list-gap, 0 var(--denhaag-space-3xl));
-  grid-template-columns: repeat(var(--denhaag-highlighted-links-columns, 1), 1fr);
-}
-
 @media (min-width: 48rem) {
   .denhaag-highlighted-links {
-    --denhaag-highlighted-links-columns: var(--denhaag-highlighted-links-columns-sm, 2);
+    --denhaag-link-group-list-columns: var(--denhaag-highlighted-links-columns-sm, 2);
   }
 }
 
 @media (min-width: 68.875rem) {
   .denhaag-highlighted-links {
-    --denhaag-highlighted-links-columns: var(--denhaag-highlighted-links-columns-md, 2);
+    --denhaag-link-group-list-columns: var(--denhaag-highlighted-links-columns-md, 2);
   }
 }
 
 @media (min-width: 80rem) {
   .denhaag-highlighted-links {
-    --denhaag-highlighted-links-columns: var(--denhaag-highlighted-links-columns-lg, 3);
+    --denhaag-link-group-list-columns: var(--denhaag-highlighted-links-columns-lg, 3);
   }
 }

--- a/components/Icons/src/index.scss
+++ b/components/Icons/src/index.scss
@@ -1,9 +1,10 @@
 .denhaag-icon {
+  aspect-ratio: 1;
   display: inline-block;
-  flex-shrink: 0;
-  width: 1em;
-  height: 1em;
-  font-size: 1.5rem;
   fill: currentcolor;
+  flex-shrink: 0;
+  font-size: var(--denhaag-icon-size, 1.5rem);
+  height: 1em;
   transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  width: 1em;
 }

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -1,22 +1,13 @@
 .denhaag-link {
+  --denhaag-icon-size: 1.25rem;
+
   position: relative;
   color: var(--denhaag-link-color, var(--denhaag-color-blue-3));
   cursor: var(--denhaag-link-cursor, pointer);
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  line-height: inherit;
+  line-height: var(--denhaag-link-line-height, inherit);
   padding-inline-start: var(--denhaag-link-padding-inline-start, 0);
   padding-inline-end: var(--denhaag-link-padding-inline-end, 0);
   text-decoration: var(--denhaag-link-text-decoration, underline);
-}
-
-.denhaag-link--with-icon {
-  align-items: center;
-  display: inline-flex;
-  gap: var(--denhaag-link-icon-gap, var(--denhaag-space-2xs));
-  text-decoration: none;
-  vertical-align: var(--denhaag-link-with-icon-vertical-align, bottom);
 }
 
 .denhaag-link--with-small-icon {
@@ -26,7 +17,6 @@
 
 .denhaag-link--with-icon-start {
   --denhaag-link-icon-order: 0;
-  --denhaag-link-padding-inline-start: 0;
 }
 
 .denhaag-link--external,
@@ -39,76 +29,50 @@
 
 .denhaag-link--with-icon-end {
   --denhaag-link-icon-order: 2;
-  --denhaag-link-padding-inline-end: 0;
-}
-
-.denhaag-link__icon {
-  align-items: var(--denhaag-link-icon-align, flex-start);
-  display: inline-flex;
-  height: var(--denhaag-link-icon-size, 1.25rem);
-  justify-content: center;
-  order: var(--denhaag-link-icon-order, 0);
-  position: relative;
-  vertical-align: text-top;
-  width: var(--denhaag-link-icon-size, 1.25rem);
-}
-
-li .denhaag-link__icon {
-  align-self: start;
-  flex: 1 0 auto;
 }
 
 .denhaag-link--external {
   --denhaag-link-icon-align: var(--denhaag-link-external-icon-align, center);
 }
 
-.denhaag-note .denhaag-link--external,
-.denhaag-table__cell .denhaag-link--external,
-.utrecht-paragraph .denhaag-link--external,
-.denhaag-unordered-list li > .denhaag-link--external,
-.denhaag-ordered-list li > .denhaag-link--external {
-  display: var(--denhaag-link-external-display, initial);
-}
-
-/* undo change .denhaag-card-authentication  */
-/* stylelint-disable-next-line no-descending-specificity */
-.denhaag-card-authentication .denhaag-link--external {
-  display: inline-flex;
-}
-
-.denhaag-note .denhaag-link--external .denhaag-link__icon,
-.denhaag-table__cell .denhaag-link--external .denhaag-link__icon,
-.utrecht-paragraph .denhaag-link--external .denhaag-link__icon,
-.denhaag-unordered-list .denhaag-link--external .denhaag-link__icon,
-.denhaag-ordered-list .denhaag-link--external .denhaag-link__icon {
-  margin-inline-start: var(--denhaag-link-external-icon-margin-inline-start, var(--denhaag-space-2xs));
-  width: var(--denhaag-link-icon-size, 1.25rem);
-  height: var(--denhaag-link-icon-size, 1.25rem);
-}
-
 .denhaag-link--external.denhaag-link--with-small-icon .denhaag-link__icon {
   vertical-align: middle;
-}
-
-/* undo change .denhaag-card-authentication */
-/* stylelint-disable-next-line no-descending-specificity */
-.denhaag-card-authentication .denhaag-link--external .denhaag-link__icon {
-  --denhaag-link-with-icon-vertical-align: text-top;
-
-  margin-inline-start: unset;
 }
 
 .denhaag-link--focus,
 .denhaag-link:focus-visible {
   --denhaag-link-color: var(--denhaag-link-focus-color, var(--denhaag-color-blue-4));
 
-  outline: var(--denhaag-link-focus-outline, var(--denhaag-focus-border));
+  outline: var(--denhaag-focus-border);
+  outline-offset: var(--denhaag-focus-border-width);
 }
 
 .denhaag-link--hover,
 .denhaag-link:hover {
   --denhaag-link-color: var(--denhaag-link-hover-color, var(--denhaag-color-blue-4));
   --denhaag-link-cursor: pointer;
+}
+
+.denhaag-link:has(.denhaag-icon) {
+  align-items: var(--denhaag-link-align-items, baseline);
+  display: inline-flex;
+  gap: var(--denhaag-link-icon-gap, var(--denhaag-space-2xs));
+  text-decoration: none;
+  vertical-align: var(--denhaag-link-with-icon-vertical-align, bottom);
+
+  .denhaag-icon {
+    // Centering the icon on the top of the baseline, for links with multiple lines! Otherwise we would've used align-items: center;
+    transform: translateY(
+      calc(
+        (
+            (
+                var(--denhaag-link-font-size, var(--denhaag-typography-scale-base-font-size, 1rem)) *
+                  var(--denhaag-link-line-height, var(--denhaag-typography-scale-base-line-height, 1))
+              ) - var(--denhaag-icon-size, 1.5rem)
+          ) / 2
+      )
+    );
+  }
 }
 
 .denhaag-link--disabled,
@@ -120,43 +84,15 @@ li .denhaag-link__icon {
   pointer-events: none;
 }
 
-.denhaag-link__icon > :first-child {
-  aspect-ratio: 1 / 1;
-  font-size: var(--denhaag-link-icon-font-size, 1em);
-  height: var(--denhaag-link-icon-size, 1.25rem);
-  width: var(--denhaag-link-icon-size, 1.25rem);
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
 .denhaag-link__sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding-block-start: 0;
-  padding-block-end: 0;
-  padding-inline-start: 0;
-  padding-inline-end: 0;
-  margin-block-start: -1px;
-  margin-block-end: -1px;
-  margin-inline-start: -1px;
-  margin-inline-end: -1px;
+  padding-block: 0;
+  padding-inline: 0;
+  margin-block: -1px;
+  margin-inline: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
-}
-
-p > .denhaag-link--with-icon-end.denhaag-link--external,
-.denhaag-note .denhaag-link--with-icon-end.denhaag-link--external,
-.denhaag-unordered-list li > .denhaag-link--with-icon-end.denhaag-link--external,
-.denhaag-ordered-list li > .denhaag-link--with-icon-end.denhaag-link--external {
-  --denhaag-link-external-icon-margin-inline-start: 0;
-
-  display: inline-flex;
-}
-
-.denhaag-procedure .denhaag-link--external .denhaag-link__icon {
-  --denhaag-link-external-icon-margin-inline-start: 0.25rem;
 }

--- a/components/Link/src/stories/bem.stories.mdx
+++ b/components/Link/src/stories/bem.stories.mdx
@@ -77,24 +77,22 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link with icon before">
     <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start">
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
+          fill="currentColor"
+        ></path>
+      </svg>
       <span class="denhaag-link__label">Link with icon before</span>
     </a>
   </Story>
@@ -111,24 +109,22 @@ import readme from "../../README.md";
       tabindex="0"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--hover"
     >
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
+          fill="currentColor"
+        ></path>
+      </svg>
       <span class="denhaag-link__label">Link with icon before hovered</span>
     </a>
   </Story>
@@ -145,24 +141,22 @@ import readme from "../../README.md";
       tabindex="0"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start denhaag-link--focus"
     >
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
-            fill="currentColor"
-          ></path>
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M11.7071 18.7071C11.3166 19.0976 10.6834 19.0976 10.2929 18.7071L4.29289 12.7071C4.10536 12.5196 4 12.2652 4 12C4 11.7348 4.10536 11.4804 4.29289 11.2929L10.2929 5.29289C10.6834 4.90237 11.3166 4.90237 11.7071 5.29289C12.0976 5.68342 12.0976 6.31658 11.7071 6.70711L7.41421 11L19 11C19.5523 11 20 11.4477 20 12C20 12.5523 19.5523 13 19 13L7.41421 13L11.7071 17.2929C12.0976 17.6834 12.0976 18.3166 11.7071 18.7071Z"
+          fill="currentColor"
+        ></path>
+      </svg>
       <span class="denhaag-link__label">Link with icon before hovered</span>
     </a>
   </Story>
@@ -175,24 +169,22 @@ import readme from "../../README.md";
   {/* eslint-disable react/no-unknown-property */}
   <Story name="Link with icon after">
     <a href="#example-link" tabindex="0" class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end">
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
+          fill="currentColor"
+        />
+      </svg>
       <span class="denhaag-link__label">Link with icon after</span>
     </a>
   </Story>
@@ -209,24 +201,22 @@ import readme from "../../README.md";
       tabindex="0"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--hover"
     >
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
+          fill="currentColor"
+        />
+      </svg>
       <span class="denhaag-link__label">Link with icon after</span>
     </a>
   </Story>
@@ -243,24 +233,22 @@ import readme from "../../README.md";
       tabindex="0"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--focus"
     >
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M12.2929 5.29289C12.6834 4.90237 13.3166 4.90237 13.7071 5.29289L19.7071 11.2929C19.8946 11.4804 20 11.7348 20 12C20 12.2652 19.8946 12.5196 19.7071 12.7071L13.7071 18.7071C13.3166 19.0976 12.6834 19.0976 12.2929 18.7071C11.9024 18.3166 11.9024 17.6834 12.2929 17.2929L16.5858 13L5 13C4.44772 13 4 12.5523 4 12C4 11.4477 4.44772 11 5 11L16.5858 11L12.2929 6.70711C11.9024 6.31658 11.9024 5.68342 12.2929 5.29289Z"
+          fill="currentColor"
+        />
+      </svg>
       <span class="denhaag-link__label">Link with icon after</span>
     </a>
   </Story>
@@ -292,24 +280,22 @@ import readme from "../../README.md";
       href="#example-link"
       class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
     >
-      <span class="denhaag-link__icon">
-        <svg
-          width="1em"
-          height="1em"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          class="denhaag-icon"
-          focusable="false"
-          aria-hidden="true"
-          shape-rendering="auto"
-        >
-          <path
-            d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
+      <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        class="denhaag-icon"
+        focusable="false"
+        aria-hidden="true"
+        shape-rendering="auto"
+      >
+        <path
+          d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+          fill="currentColor"
+        />
+      </svg>
       <span class="denhaag-link__label">External link</span>
       <span class="denhaag-link__sr-only">(External link)</span>
     </a>
@@ -330,24 +316,22 @@ import readme from "../../README.md";
       >
         <span class="denhaag-link__label">External link</span>
         <span class="denhaag-link__sr-only">(External link)</span>
-        <span class="denhaag-link__icon">
-          <svg
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+            fill="currentColor"
+          />
+        </svg>
       </a> Repellat eum hic ullam est ut vitae praesentium. Exercitationem ratione quis placeat quas facilis deserunt.
     </p>
   </Story>
@@ -367,24 +351,22 @@ import readme from "../../README.md";
       >
         <span class="denhaag-link__label">External link</span>
         <span class="denhaag-link__sr-only">(External link)</span>
-        <span class="denhaag-link__icon">
-          <svg
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+            fill="currentColor"
+          />
+        </svg>
       </a> Repellat eum hic ullam est ut vitae praesentium. Exercitationem ratione quis placeat quas facilis deserunt.
     </p>
   </Story>
@@ -406,24 +388,22 @@ import readme from "../../README.md";
           nihil quibusdam qui libero.
         </span>
         <span class="denhaag-link__sr-only">(External link)</span>
-        <span class="denhaag-link__icon">
-          <svg
-            width="1em"
-            height="1em"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            class="denhaag-icon"
-            focusable="false"
-            aria-hidden="true"
-            shape-rendering="auto"
-          >
-            <path
-              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-              fill="currentColor"
-            />
-          </svg>
-        </span>
+        <svg
+          width="1em"
+          height="1em"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="denhaag-icon"
+          focusable="false"
+          aria-hidden="true"
+          shape-rendering="auto"
+        >
+          <path
+            d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+            fill="currentColor"
+          />
+        </svg>
       </a>
     </p>
   </Story>
@@ -445,24 +425,22 @@ import readme from "../../README.md";
             Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
           </span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
       <li>
@@ -474,24 +452,22 @@ import readme from "../../README.md";
             At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
           </span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
       <li>
@@ -501,24 +477,22 @@ import readme from "../../README.md";
         >
           <span class="denhaag-link__label">Assumenda autem facilis voluptates voluptate eos eum tempore amet.</span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -541,24 +515,22 @@ import readme from "../../README.md";
             Iste eos fugit quisquam. Cum sit autem nostrum explicabo rerum quo impedit necessitatibus.
           </span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
       <li>
@@ -570,24 +542,22 @@ import readme from "../../README.md";
             At aspernatur beatae accusantium maxime distinctio. Eaque illum fugiat sint est.
           </span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
       <li>
@@ -597,24 +567,22 @@ import readme from "../../README.md";
         >
           <span class="denhaag-link__label">Assumenda autem facilis voluptates voluptate eos eum tempore amet.</span>
           <span class="denhaag-link__sr-only">(Externe link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </li>
     </ol>
@@ -649,24 +617,22 @@ import readme from "../../README.md";
             >
               <span class="denhaag-link__label">Deleniti reprehenderit dolor illo numquam id vitae molestiae.</span>
               <span class="denhaag-link__sr-only">(Externe link)</span>
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                  fill="currentColor"
+                />
+              </svg>
             </a>
           </td>
           <td class="denhaag-table__cell">Quo ullam molestiae quo enim.</td>
@@ -682,24 +648,22 @@ import readme from "../../README.md";
                 Et laboriosam earum non nulla. Aliquam dignissimos a sapiente possimus voluptates ipsam eos.
               </span>
               <span class="denhaag-link__sr-only">(Externe link)</span>
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                  fill="currentColor"
+                />
+              </svg>
             </a>
           </td>
           <td class="denhaag-table__cell">Eum quibusdam dolores et et.</td>
@@ -715,24 +679,22 @@ import readme from "../../README.md";
                 Fugit odit illum non. Dignissimos aliquam asperiores porro non culpa. Sed ut error at ea aut.
               </span>
               <span class="denhaag-link__sr-only">(Externe link)</span>
-              <span class="denhaag-link__icon">
-                <svg
-                  width="1em"
-                  height="1em"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="denhaag-icon"
-                  focusable="false"
-                  aria-hidden="true"
-                  shape-rendering="auto"
-                >
-                  <path
-                    d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="denhaag-icon"
+                focusable="false"
+                aria-hidden="true"
+                shape-rendering="auto"
+              >
+                <path
+                  d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                  fill="currentColor"
+                />
+              </svg>
             </a>
           </td>
           <td class="denhaag-table__cell">Molestias veniam fugit voluptatem.</td>
@@ -751,7 +713,7 @@ import readme from "../../README.md";
     <div class="denhaag-note denhaag-note--info" role="note">
       <svg
         aria-label="Info:"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         fill="none"
         height="24"
         role="img"
@@ -794,24 +756,22 @@ import readme from "../../README.md";
             quia iusto iure accusantium ea aliquid. Cum eos vitae quia et.
           </span>
           <span class="denhaag-link__sr-only">(External link)</span>
-          <span class="denhaag-link__icon">
-            <svg
-              width="1em"
-              height="1em"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              class="denhaag-icon"
-              focusable="false"
-              aria-hidden="true"
-              shape-rendering="auto"
-            >
-              <path
-                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            class="denhaag-icon"
+            focusable="false"
+            aria-hidden="true"
+            shape-rendering="auto"
+          >
+            <path
+              d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+              fill="currentColor"
+            />
+          </svg>
         </a>
       </div>
     </div>

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -1,3 +1,11 @@
+.denhaag-link-group {
+  --denhaag-link-line-height: var(--denhaag-typography-scale-base-line-height);
+
+  @media (min-width: 1114px) {
+    --denhaag-link-group-list-margin-block-start: var(--denhaag-space-sm);
+  }
+}
+
 .denhaag-link-group__image {
   margin-block-end: var(--denhaag-link-group-image-margin-block-end, var(--denhaag-space-md));
   width: var(--denhaag-link-group-image-size, 8.75rem);
@@ -5,52 +13,27 @@
   object-fit: cover;
 }
 
-.denhaag-link-group__caption {
-  margin-block: var(--denhaag-link-group-caption-margin-block, 0) !important;
-}
-
 .denhaag-link-group__list {
+  display: grid;
+  grid-template-columns: repeat(var(--denhaag-link-group-list-columns, 1), 1fr);
   margin-block-start: var(--denhaag-link-group-list-margin-block-start, var(--denhaag-space-xs));
   margin-block-end: var(--denhaag-link-group-list-margin-block-end, var(--denhaag-space-md));
-  list-style: var(--denhaag-link-group-list-list-style, none);
+  list-style: none;
   padding-inline-start: var(--denhaag-link-group-list-padding-inline-start, 0);
+  row-gap: var(--denhaag-space-xs);
+  column-gap: var(--denhaag-space-md);
+}
 
-  @media (min-width: 1114px) {
-    margin-block-start: var(--denhaag-space-sm);
+.denhaag-link-group--dark {
+  --utrecht-heading-4-color: var(--denhaag-link-group-dark-caption-color, var(--denhaag-color-ocher-3));
+
+  &,
+  *:hover,
+  *:focus-visible {
+    --denhaag-link-color: var(--denhaag-link-group-dark-link-color, var(--denhaag-color-white));
   }
 }
 
-.denhaag-link-group__list-item {
-  padding-block: var(--denhaag-link-group-list-item-padding-block, var(--denhaag-space-xs));
-  font-weight: var(--denhaag-link-group-list-item-font-weight, var(--denhaag-typography-weight-regular));
-}
-
-.denhaag-link-group--dark .denhaag-link,
-.denhaag-link-group--dark .denhaag-link:hover,
-.denhaag-link-group--dark .denhaag-link:focus-visible {
-  color: var(--denhaag-link-group-dark-link-color, var(--denhaag-color-white));
-}
-
-.denhaag-link-group--dark .denhaag-link:focus-visible {
+.denhaag-link-group--dark *:focus-visible {
   outline-color: var(--denhaag-link-group-dark-link-focus-outline-color, var(--denhaag-color-ocher-2));
-}
-
-.denhaag-link-group .denhaag-link--with-icon-start {
-  display: inline-flex;
-  padding-block: var(--denhaag-link-group-link-with-icon-start-padding-block, 0);
-}
-
-.denhaag-link-group .denhaag-link__icon {
-  font-size: var(--denhaag-link-group-link-icon-font-size, 0.75rem);
-  width: var(--denhaag-link-group-link-icon-width, 0.625rem);
-}
-
-.denhaag-link-group .denhaag-link__icon .denhaag-icon {
-  align-self: var(--denhaag-link-group-link-icon-denhaag-icon-align-self, start);
-  padding-block-start: var(--denhaag-link-group-link-icon-denhaag-icon-padding-block-start, var(--denhaag-space-3xs));
-  height: var(--denhaag-link-group-link-icon-denhaag-icon-height, 0.85rem);
-}
-
-.denhaag-link-group--dark .denhaag-link-group__caption {
-  color: var(--denhaag-link-group-dark-caption-color, var(--denhaag-color-ocher-3));
 }

--- a/components/LinkGroup/src/stories/bem.stories.mdx
+++ b/components/LinkGroup/src/stories/bem.stories.mdx
@@ -36,24 +36,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
           </a>
         </li>
@@ -62,24 +60,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
@@ -88,25 +84,39 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                fill="currentColor"
+              ></path>
+            </svg>
           </a>
         </li>
         <li class="denhaag-link-group__list-item">
@@ -114,24 +124,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
@@ -140,25 +148,111 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Verklaringen</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
+            <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
+            <span class="denhaag-link__label">Rijbewijs</span>
+          </a>
+        </li>
+        <li class="denhaag-link-group__list-item">
+          <a
+            href="https://nl-design-system.github.io/denhaag/"
+            class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
+          >
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
+            <span class="denhaag-link__label">Parkeerplaats voor huisartsen en verloskundigen</span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                fill="currentColor"
+              ></path>
+            </svg>
           </a>
         </li>
       </ul>
@@ -185,24 +279,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">
               Paspoort en identiteitskaart. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non
               dignissimos. Repudiandae rem voluptate ex. Autem est aut ratione beatae odit non dignissimos.
@@ -214,24 +306,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
@@ -240,24 +330,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
           </a>
         </li>
@@ -266,24 +354,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
@@ -292,24 +378,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Verklaringen</span>
           </a>
         </li>
@@ -332,24 +416,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Paspoort en identiteitskaart</span>
           </a>
         </li>
@@ -358,24 +440,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Rijbewijs</span>
           </a>
         </li>
@@ -384,24 +464,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Inburgeren en naturaliseren</span>
           </a>
         </li>
@@ -410,24 +488,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Akten</span>
           </a>
         </li>
@@ -436,24 +512,22 @@ import readme from "../../README.md";
             href="https://nl-design-system.github.io/denhaag/"
             class="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-start"
           >
-            <span class="denhaag-link__icon">
-              <svg
-                width="1em"
-                height="1em"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="denhaag-icon"
-                focusable="false"
-                aria-hidden="true"
-                shape-rendering="auto"
-              >
-                <path
-                  d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-            </span>
+            <svg
+              width="1em"
+              height="1em"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              class="denhaag-icon"
+              focusable="false"
+              aria-hidden="true"
+              shape-rendering="auto"
+            >
+              <path
+                d="M12.293 5.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L16.586 13H5a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                fill="currentColor"
+              ></path>
+            </svg>
             <span class="denhaag-link__label">Verklaringen</span>
           </a>
         </li>

--- a/components/Note/src/index.scss
+++ b/components/Note/src/index.scss
@@ -9,15 +9,10 @@
   line-height: var(--denhaag-note-line-height, 1.5);
   gap: var(--denhaag-note-icon-spacing, var(--denhaag-space-xs));
   padding-block: var(--denhaag-note-padding-block, var(--denhaag-space-2xs));
-}
 
-.denhaag-note__icon,
-.denhaag-note > svg {
-  aspect-ratio: 1 / 1;
-  flex: 0 0 auto;
-  height: auto;
-  color: var(--denhaag-note-icon-color, var(--denhaag-color-grey-4));
-  width: var(--denhaag-note-icon-size, calc(var(--denhaag-note-icon-spacing) * 3));
+  > .denhaag-icon {
+    color: var(--denhaag-note-icon-color, var(--denhaag-color-grey-4));
+  }
 }
 
 .denhaag-note--info {
@@ -28,6 +23,10 @@
   --denhaag-note-icon-color: var(--denhaag-note-icon-warning-color, var(--denhaag-color-white));
 }
 
-.denhaag-note .denhaag-link--with-icon-end {
-  margin-inline-end: var(--denhaag-note-icon-end-margin-inline-end, var(--denhaag-space-2xs));
+.denhaag-note .denhaag-link--external {
+  display: var(--denhaag-link-external-display, initial);
+
+  .denhaag-icon {
+    margin-inline-start: var(--denhaag-link-icon-gap, var(--denhaag-space-2xs));
+  }
 }

--- a/components/Note/src/stories/bem.stories.mdx
+++ b/components/Note/src/stories/bem.stories.mdx
@@ -33,7 +33,7 @@ import readme from "../../README.md";
       <svg
         aria-label="Note:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -80,7 +80,7 @@ import readme from "../../README.md";
       <svg
         aria-label="Info:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -127,7 +127,7 @@ import readme from "../../README.md";
       <svg
         aria-label="Warning:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -177,7 +177,7 @@ This way screenreaders will re-read the element when the component has been upda
       <svg
         aria-label="Note:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -224,7 +224,7 @@ This way screenreaders will re-read the element when the component has been upda
       <svg
         aria-label="Note:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -278,7 +278,7 @@ This way screenreaders will re-read the element when the component has been upda
       <svg
         aria-label="Note:"
         role="img"
-        class="denhaag-note__icon"
+        class="denhaag-icon"
         width="24"
         height="24"
         viewBox="0 0 24 24"

--- a/components/Procedure/src/index.scss
+++ b/components/Procedure/src/index.scss
@@ -107,20 +107,6 @@
   content: counter(denhaag-step-marker);
 }
 
-.denhaag-procedure .denhaag-link--external {
-  --denhaag-link-external-display: var(--denhaag-procedure-link-external-display, inline-flex);
-}
-
-.denhaag-procedure .denhaag-link--external .denhaag-link__icon {
-  --denhaag-link-icon-align: var(--denhaag-procedure-link-external-icon-align, bottom);
-
-  align-self: var(--denhaag-procedure-link-external-icon-align-self, unset);
-  width: var(
-    --denhaag-procedure-link-external-icon-width,
-    0.625rem
-  ) !important; /* because default uses --denhaag-link-icon-size for width and height */
-}
-
 @media (max-width: 767px) {
   .denhaag-procedure .denhaag-process-steps__step + .denhaag-process-steps__step::after {
     left: calc(var(--denhaag-step-marker-size, 32px) / 2);

--- a/components/Procedure/src/stories/bem.stories.mdx
+++ b/components/Procedure/src/stories/bem.stories.mdx
@@ -65,24 +65,22 @@ import "../index.scss";
                 >
                   <span class="denhaag-link__label">Bekijk wat u moet meenemen</span>
                   <span class="denhaag-link__sr-only">External link</span>
-                  <span class="denhaag-link__icon">
-                    <svg
-                      width="1em"
-                      height="1em"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      class="denhaag-icon"
-                      focusable="false"
-                      aria-hidden="true"
-                      shape-rendering="auto"
-                    >
-                      <path
-                        d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
-                        fill="currentColor"
-                      ></path>
-                    </svg>
-                  </span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shape-rendering="auto"
+                  >
+                    <path
+                      d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
                 </a>
               </p>
             </div>

--- a/components/UnorderedList/src/index.scss
+++ b/components/UnorderedList/src/index.scss
@@ -1,6 +1,8 @@
 @import "~@utrecht/components/unordered-list/css";
 
 .denhaag-unordered-list {
+  --denhaag-link-with-icon-vertical-align: baseline;
+
   @extend .utrecht-unordered-list;
 
   color: var(--denhaag-unordered-list-color);
@@ -8,16 +10,6 @@
 
   .denhaag-link__label {
     hyphens: var(--denhaag-unordered-list-link-label-hyphens);
-  }
-
-  .denhaag-link--with-icon {
-    --denhaag-link-with-icon-vertical-align: baseline;
-
-    display: var(--denhaag-unordered-list-link-with-icon-display);
-  }
-
-  .denhaag-link__icon {
-    flex: unset;
   }
 }
 

--- a/components/UnorderedList/src/stories/bem.stories.mdx
+++ b/components/UnorderedList/src/stories/bem.stories.mdx
@@ -29,10 +29,10 @@ import "../index.scss";
   <Story name="Unordered list">
     <ul class="denhaag-unordered-list">
       <li>
-        Molestias{" "}
+        Molestias
         <a href="https://www.denhaag.nl" class="denhaag-link">
           <span class="denhaag-link__label">assumenda</span>
-        </a>{" "}
+        </a>
         ratione in dolore aut consequatur accusantium corporis.
       </li>
       <li>


### PR DESCRIPTION
Goed controleren graag (door o.a. eerst www-denhaag-nl/reduce-unused~ binnen te halen en daarna deze branch);


En om issues te voorkomen: 
1. `git checkout www-denhaag-nl/reduce-unused-css; git pull; yarn run build; yarn storybook`
2. `git checkout www-denhaag-nl/reduce-unused-css--check-multiple-components; git pull; yarn run build; yarn storybook`


*Hoe/wat/waarom*
1. Icons waren op meerdere manieren gedefineerd;
2. Icons in links moesten 20x20 worden i.p.v. gekke formaten;
3. Code in links (en andere blocks waarin links gebruikt worden) nagelopen;
4. Wrapper van denhaag-link__icon weggehaald, zorgde puur voor problemen, voegde niks toe wat de <SVG> zelf niet kan.