### PR TITLE
style(image, alert, procedure/process): fix margin styles

### DIFF
--- a/components/Alert/src/index.scss
+++ b/components/Alert/src/index.scss
@@ -9,11 +9,11 @@
   flex-direction: row;
   justify-content: space-between;
 
-  & + [class*="-paragraph"],
-  [class*="-paragraph"] + &,
+  & + [class^="utrecht-"],
+  [class^="utrecht-"] + &,
   & + [class*="-list"],
   [class*="-list"] + & {
-    margin-block-start: var(--denhaag-space-xl); // Not in design? But the client wishes to have marges.
+    margin-block-start: var(--denhaag-space-2xl); // Not in design? But the client wishes to have marges.
   }
 }
 

--- a/components/AuthenticationBlock/src/index.scss
+++ b/components/AuthenticationBlock/src/index.scss
@@ -41,11 +41,14 @@
   .denhaag-image {
     margin-block: 0 var(--denhaag-authentication-image-spacing-end);
     max-width: var(--denhaag-authentication-logo-size, 3.5rem);
+
+    & + [class^="utrecht-heading-"] {
+      margin-block-start: 0; // Reset margin of the heading after an image.
+    }
   }
 
   // Remove unnecessary of existing blocks.
-  .utrecht-heading-3,
-  p {
+  [class^="utrecht-"] {
     margin-block: 0;
   }
 

--- a/components/Image/src/index.scss
+++ b/components/Image/src/index.scss
@@ -4,6 +4,13 @@
   font-family: var(--denhaag-image-font-family, var(--denhaag-typography-sans-serif-font-family));
   margin-inline: var(--denhaag-image-margin-inline, 0);
   margin-block-end: var(--denhaag-image-margin-block-end-mobile, var(--denhaag-space-xl));
+
+  & + [class^="utrecht-"],
+  [class^="utrecht-"] + &,
+  & + [class*="-list"],
+  [class*="-list"] + & {
+    margin-block-start: var(--denhaag-space-2xl); // Not in design? But the client wishes to have marges.
+  }
 }
 
 .denhaag-image--figcaption-only {

--- a/components/Image/src/stories/bem.stories.mdx
+++ b/components/Image/src/stories/bem.stories.mdx
@@ -219,3 +219,70 @@ import readme from "../../README.md";
     </figure>
   </Story>
 </Canvas>
+
+### Between Paragraphs
+
+<Canvas>
+  <Story name="Between Paragraphs">
+    <p className="utrecht-paragraph">
+      Aliquam ullamcorper quis orci vitae porta. Praesent sagittis sit amet mi tempus tincidunt. Mauris lectus turpis,
+      accumsan quis nisi at, tempor aliquet mauris. Proin vulputate gravida efficitur. Pellentesque in eleifend magna,
+      ac tristique dolor. Nulla eget sem sit amet enim tempor elementum eget sit amet nisl. Praesent scelerisque at
+      nulla a pulvinar. Donec porttitor justo eu massa sollicitudin, accumsan consequat odio volutpat. Curabitur
+      facilisis lectus at dui commodo, id consectetur quam ornare. Mauris rutrum risus quis nulla posuere sodales.
+      Praesent congue sodales scelerisque. Nulla quis facilisis nulla. Integer finibus vitae neque eget dapibus. Donec
+      tincidunt venenatis nunc, sit amet fermentum nulla.
+    </p>
+    <figure className="denhaag-image">
+      <img
+        className="denhaag-image__image"
+        srcSet="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=480 480w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=768 768w,
+                https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290 1290w"
+        src="https://images.unsplash.com/photo-1562013042-abdaf4dc98b9?w=1290"
+        alt="Distinctio cupiditate"
+        loading="lazy"
+      />
+      <figcaption className="denhaag-image__figcaption">
+        <span className="denhaag-image__figcaption-text">
+          Distinctio cupiditate repellat placeat itaque velit iure qui Distinctio cupiditate repellat placeat itaque
+          velit iure qui.
+        </span>
+        <a
+          className="denhaag-image__figcaption-download"
+          href="https://images.unsplash.com/photo-1611402881804-8fde5b755174"
+          download="distinctio-cupiditate"
+          type="application/image"
+          aria-label="Download image: [READABLE_FILENAME] ([FILE_EXTENSION], [FILE_SIZE])"
+        >
+          <svg
+            className="denhaag-image__icon"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M21 15V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V15"
+              stroke="#1261A3"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path d="M7 10L12 15L17 10" stroke="#1261A3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M12 15V3" stroke="#1261A3" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="denhaag-image__download-text">Download afbeelding</span>
+        </a>
+      </figcaption>
+    </figure>
+    <p className="utrecht-paragraph">
+      Vestibulum iaculis mauris non ultricies pretium. Nunc id varius neque, non dignissim nibh. Ut et tortor semper ex
+      gravida consectetur eget et leo. Donec sit amet enim eu ipsum mattis consectetur. Ut semper arcu et venenatis
+      commodo. Curabitur sed dolor malesuada, eleifend enim ut, tincidunt mi. In at gravida eros, vel porta lacus. Fusce
+      nulla tellus, viverra at consectetur laoreet, fermentum in turpis.
+    </p>
+  </Story>
+</Canvas>

--- a/components/ProcessSteps/src/StepList.scss
+++ b/components/ProcessSteps/src/StepList.scss
@@ -1,5 +1,5 @@
 .denhaag-process-steps {
-  --denhaag-process-steps-step-distance: 40px;
+  --denhaag-process-steps-step-distance: var(--denhaag-space-2xl);
   --denhaag-process-steps-sub-step-distance: 24px;
 
   font-family: var(--denhaag-process-steps-font-family, var(--denhaag-typography-sans-serif-font-family));

--- a/components/ProcessSteps/src/index.scss
+++ b/components/ProcessSteps/src/index.scss
@@ -7,3 +7,9 @@
 @import "./SubStepHeading";
 @import "./SubStepList";
 @import "./SubStepMarker";
+
+.denhaag-procedure-container:not(:last-child) + * {
+  margin-block-start: var(
+    --denhaag-space-2xl
+  ); // When not the last element within the parent, It must have a margin-top of 2xl.
+}


### PR DESCRIPTION
Fix margin issues with specific blocks.

1. Headings also are prefixed with `utrecht` therefor we use that instead of `-paragraph`,
2. xl to 2xl due to message of design on Slack;
3. Apply correct margin conform design, therefor we can reduce CSS in the plugin;


closes #1620 