### PR TITLE
Bugfixes www-denhaag-nl/gdhs-60

### DIFF
--- a/components/ImageBanner/src/index.scss
+++ b/components/ImageBanner/src/index.scss
@@ -8,6 +8,10 @@
   @media (prefers-reduced-motion: reduce) {
     --denhaag-image-banner-transition: none;
   }
+
+  .utrecht-paragraph + & {
+    margin-block-start: var(--denhaag-space-2xl); // Set to "friendly" margin.
+  }
 }
 
 .denhaag-image-banner--reduced-motion {

--- a/components/Procedure/src/stories/bem.stories.mdx
+++ b/components/Procedure/src/stories/bem.stories.mdx
@@ -109,3 +109,89 @@ import "../index.scss";
     </div>
   </Story>
 </Canvas>
+
+### Small
+
+<Canvas>
+  <Story name="Small">
+    <div className="denhaag-procedure-container" style={{ maxWidth: "616px" }}>
+      <h3 className="denhaag-procedure__heading">Small preview on 616px</h3>
+      <ol className="denhaag-process-steps denhaag-procedure">
+        <li className="denhaag-process-steps__step denhaag-process-steps__step--current">
+          <div className="denhaag-process-steps__step-header">
+            <div className="denhaag-step-marker denhaag-step-marker--current"></div>
+            <p className="denhaag-process-steps__step-heading utrecht-heading-4">Maak een afspraak</p>
+          </div>
+          <div className="denhaag-process-steps__step-body">
+            <div className="denhaag-step-marker__connector denhaag-step-marker__connector--current denhaag-step-marker__connector--main-to-nested"></div>
+            <div className="denhaag-process-steps__step-meta">
+              <p className="utrecht-paragraph">
+                Voor het aanvragen van een nieuw paspoort moet u langskomen op Stadhuis Spui of stadskantoor Leyweg. U
+                maakt daarvoor een afspraak.
+              </p>
+            </div>
+          </div>
+        </li>
+        <li className="denhaag-process-steps__step denhaag-process-steps__step--current">
+          <div className="denhaag-process-steps__step-header">
+            <div className="denhaag-step-marker denhaag-step-marker--current"></div>
+            <p className="denhaag-process-steps__step-heading utrecht-heading-4">
+              Kom goed voorbereid naar de afspraak
+            </p>
+          </div>
+          <div className="denhaag-process-steps__step-body">
+            <div className="denhaag-step-marker__connector denhaag-step-marker__connector--current denhaag-step-marker__connector--main-to-nested"></div>
+            <div className="denhaag-process-steps__step-meta">
+              <p className="utrecht-paragraph">
+                U heeft een aantal dingen nodig tijdens de afspraak.
+                <br />
+                <a
+                  href="https://denhaag.nl"
+                  className="denhaag-link denhaag-link--with-icon denhaag-link--with-icon-end denhaag-link--external"
+                  rel="noreferrer noopener nofollow"
+                >
+                  <span className="denhaag-link__label">Bekijk wat u moet meenemen</span>
+                  <span className="denhaag-link__sr-only">External link</span>
+                  <svg
+                    width="1em"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="denhaag-icon"
+                    focusable="false"
+                    aria-hidden="true"
+                    shapeRendering="auto"
+                  >
+                    <path
+                      d="M14 5C13.4477 5 13 4.55228 13 4C13 3.44772 13.4477 3 14 3H20C20.2652 3 20.5196 3.10536 20.7071 3.29289C20.8946 3.48043 21 3.73478 21 4L21 10C21 10.5523 20.5523 11 20 11C19.4477 11 19 10.5523 19 10L19 6.41422L9.70711 15.7071C9.31658 16.0976 8.68342 16.0976 8.29289 15.7071C7.90237 15.3166 7.90237 14.6834 8.29289 14.2929L17.5858 5H14ZM3 7C3 5.89543 3.89543 5 5 5H10C10.5523 5 11 5.44772 11 6C11 6.55228 10.5523 7 10 7H5V19H17V14C17 13.4477 17.4477 13 18 13C18.5523 13 19 13.4477 19 14V19C19 20.1046 18.1046 21 17 21H5C3.89543 21 3 20.1046 3 19V7Z"
+                      fill="currentColor"
+                    ></path>
+                  </svg>
+                </a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <li className="denhaag-process-steps__step denhaag-process-steps__step--current">
+          <div className="denhaag-process-steps__step-header">
+            <div className="denhaag-step-marker denhaag-step-marker--current"></div>
+            <p className="denhaag-process-steps__step-heading utrecht-heading-4">Haal uw paspoort op</p>
+          </div>
+          <div className="denhaag-process-steps__step-body">
+            <div className="denhaag-step-marker__connector denhaag-step-marker__connector--current denhaag-step-marker__connector--main-to-nested"></div>
+            <div className="denhaag-process-steps__step-meta">
+              <p className="utrecht-paragraph">
+                Na 5 werkdagen is uw paspoort klaar en kunt u het ophalen.
+                <br />
+                <a href="#example-link" className="denhaag-link">
+                  <span className="denhaag-link__label">Bekijk wat u nodig heeft bij het ophalen</span>
+                </a>
+              </p>
+            </div>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </Story>
+</Canvas>

--- a/components/ProcessSteps/src/Step.scss
+++ b/components/ProcessSteps/src/Step.scss
@@ -1,7 +1,6 @@
 .denhaag-process-steps__step {
   position: relative;
-  padding-block-end: 0;
-  padding-block-start: 0;
+  padding-block: 0;
 }
 
 .denhaag-process-steps__step + .denhaag-process-steps__step {
@@ -13,8 +12,8 @@
   content: "";
   position: absolute;
   left: calc(max(var(--denhaag-process-steps-step-marker-size, var(--denhaag-space-lg)), var(--denhaag-space-2xl)) / 2);
-  top: calc(-1 * (var(--denhaag-process-steps-step-distance) + 10px));
-  height: calc(var(--denhaag-process-steps-step-distance) + 10px);
+  top: calc(0px - var(--denhaag-process-steps-step-distance));
+  height: var(--denhaag-process-steps-step-distance);
   outline: 1px dashed var(--denhaag-process-steps-step-line-color, var(--denhaag-color-grey-1));
 }
 


### PR DESCRIPTION
- Set marge between paragraph and image-banner, set to "Friendly" due to input of design.
- Remove offset of 10px in the steps, the 10px was causing a whitespace;
- Added a smaller preview, due to the issue only appear on smaller screens.

Cleanup closed branches:
Closes #1675 #1620 #1698 #1697 