### PR TITLE
GDHS-63 Bugfix Authenticationblock eHerkenning

### DIFF
--- a/components/AuthenticationBlock/src/index.scss
+++ b/components/AuthenticationBlock/src/index.scss
@@ -66,6 +66,7 @@
 
     .denhaag-image {
       align-self: flex-end;
+      aspect-ratio: var(--denhaag-image-image-aspect-ratio);
     }
 
     @media (min-width: 375px) {


### PR DESCRIPTION
Difference in height of images causes difference in white space. Add aspect-ratio variable to the parent denhaag-image class to compensate.
