### PR TITLE
GDH-1647 Make all links underlined except for link group links

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -1,6 +1,7 @@
 .denhaag-cta-image-content {
   --utrecht-paragraph-font-size: var(--denhaag-typography-scale-lg-font-size);
   --utrecht-paragraph-line-height: var(--denhaag-typography-scale-lg-line-height);
+  --denhaag-link-text-decoration: none;
 
   background-color: var(--denhaag-color-white);
   border: var(--denhaag-cta-image-content-border, 1px solid var(--denhaag-color-grey-2));

--- a/components/DynamicContent/src/index.scss
+++ b/components/DynamicContent/src/index.scss
@@ -5,6 +5,7 @@
 .denhaag-dynamic-content--list {
   --denhaag-dynamic-content-grid-columns: 1;
   --denhaag-dynamic-content-row-gap: var(--denhaag-space-md);
+  --denhaag-link-text-decoration: none;
 }
 
 .denhaag-dynamic-content--list .denhaag-link {

--- a/components/FormProgress/src/index.scss
+++ b/components/FormProgress/src/index.scss
@@ -1,6 +1,8 @@
 .denhaag-form-progress {
   display: flex;
   flex-direction: column;
+
+  --denhaag-link-text-decoration: none;
 }
 
 .denhaag-form-progress__header {

--- a/components/Link/src/index.scss
+++ b/components/Link/src/index.scss
@@ -56,7 +56,6 @@
   align-items: var(--denhaag-link-align-items, baseline);
   display: inline-flex;
   gap: var(--denhaag-link-icon-gap, var(--denhaag-space-2xs));
-  text-decoration: none;
   vertical-align: var(--denhaag-link-with-icon-vertical-align, bottom);
 
   .denhaag-icon {

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -1,5 +1,6 @@
 .denhaag-link-group {
   --denhaag-link-line-height: var(--denhaag-typography-scale-base-line-height);
+  --denhaag-link-text-decoration: none;
 
   @media (min-width: 1114px) {
     --denhaag-link-group-list-margin-block-start: var(--denhaag-space-sm);
@@ -7,10 +8,6 @@
 
   [class^="utrecht-heading-"] {
     --utrecht-space-around: 0; // Sadly we need to reset this on the heading component. Not really a reusable variable.
-  }
-
-  .denhaag-link {
-    text-decoration: none;
   }
 }
 

--- a/components/LinkGroup/src/index.scss
+++ b/components/LinkGroup/src/index.scss
@@ -8,6 +8,10 @@
   [class^="utrecht-heading-"] {
     --utrecht-space-around: 0; // Sadly we need to reset this on the heading component. Not really a reusable variable.
   }
+
+  .denhaag-link {
+    text-decoration: none;
+  }
 }
 
 .denhaag-link-group__image {


### PR DESCRIPTION
text-decoration none on links with icon broke the underline for links that need it, like external links outside of link groups. Moved the text-decoration none to specifically link groups.
