### PR TITLE
style(breadcrumbs): remove links from current page item

### DIFF
--- a/components/Breadcrumb/src/index.scss
+++ b/components/Breadcrumb/src/index.scss
@@ -85,7 +85,6 @@ ol.denhaag-breadcrumb__list {
   outline: var(--denhaag-focus-border);
 }
 
-.denhaag-breadcrumb__link--current .denhaag-breadcrumb__link,
 .denhaag-breadcrumb__item:last-child .denhaag-breadcrumb__link {
   pointer-events: bounding-box;
 }
@@ -104,12 +103,6 @@ ol.denhaag-breadcrumb__list {
     --denhaag-breadcrumb-dots-hover-background-color,
     var(--denhaag-color-grey-2)
   );
-}
-
-.denhaag-breadcrumb__link--current,
-.denhaag-breadcrumb__link.denhaag-link--current,
-.denhaag-breadcrumb__item:last-child > .denhaag-breadcrumb__link {
-  --denhaag-breadcrumb-link-color: var(--denhaag-breadcrumb-current-color, var(--denhaag-color-grey-4));
 }
 
 // SVG for the separator.
@@ -136,6 +129,10 @@ ol.denhaag-breadcrumb__list {
   position: var(--denhaag-breadcrumb-text-position, relative); // absolute on hidden items.
   text-overflow: var(--denhaag-breadcrumb-text-text-overflow, ellipsis);
   white-space: var(--denhaag-breadcrumb-text-white-space, nowrap);
+}
+
+.denhaag-breadcrumb__item > .denhaag-breadcrumb__text {
+  padding-inline-start: var(--denhaag-breadcrumb-spacing, var(--denhaag-space-2xs));
 }
 
 .denhaag-breadcrumb__item--hidden .denhaag-breadcrumb__text {

--- a/components/Breadcrumb/src/stories/bem.stories.mdx
+++ b/components/Breadcrumb/src/stories/bem.stories.mdx
@@ -97,17 +97,10 @@ import "../story.js";
           itemProp="itemListElement"
           aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>
@@ -187,18 +180,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>
@@ -278,18 +265,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>
@@ -369,18 +350,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>
@@ -543,18 +518,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/c/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Ut aspernatur qui quidem ipsum alias asperiores
-            </span>
-            <meta itemProp="position" content="4" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Ut aspernatur qui quidem ipsum alias asperiores
+          </span>
+          <meta itemProp="position" content="4" />
         </li>
       </ol>
     </nav>
@@ -670,18 +639,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/c/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="4" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="4" />
         </li>
       </ol>
     </nav>
@@ -801,18 +764,12 @@ import "../story.js";
           itemScope
           itemType="https://schema.org/ListItem"
           itemProp="itemListElement"
+          aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/c/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="4" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="4" />
         </li>
       </ol>
     </nav>
@@ -867,14 +824,8 @@ import "../story.js";
             </svg>
           </a>
         </li>
-        <li className="denhaag-breadcrumb__item">
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text">Kliko&apos;s</span>
-          </a>
+        <li className="denhaag-breadcrumb__item" aria-current="page">
+          <span className="denhaag-breadcrumb__text">Kliko&apos;s</span>
         </li>
       </ol>
     </nav>
@@ -952,17 +903,10 @@ import "../story.js";
           itemProp="itemListElement"
           aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              1e inschrijving BRP voor EU/EER burgers en Zwitsers uit het buitenland (u heeft nog geen BSN)
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            1e inschrijving BRP voor EU/EER burgers en Zwitsers uit het buitenland (u heeft nog geen BSN)
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>
@@ -1098,17 +1042,10 @@ import "../story.js";
           itemProp="itemListElement"
           aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/c/d/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              1e inschrijving BRP voor EU/EER burgers en Zwitsers uit het buitenland (u heeft nog geen BSN)
-            </span>
-            <meta itemProp="position" content="5" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            1e inschrijving BRP voor EU/EER burgers en Zwitsers uit het buitenland (u heeft nog geen BSN)
+          </span>
+          <meta itemProp="position" content="5" />
         </li>
       </ol>
     </nav>

--- a/components/Container/src/stories/bem.stories.mdx
+++ b/components/Container/src/stories/bem.stories.mdx
@@ -245,17 +245,10 @@ import "../index.scss";
           itemProp="itemListElement"
           aria-current="page"
         >
-          <a
-            className="denhaag-breadcrumb__link denhaag-breadcrumb__link--current"
-            href="https://example.com/a/b/"
-            itemProp="item"
-            aria-current="page"
-          >
-            <span className="denhaag-breadcrumb__text" itemProp="name">
-              Kliko&apos;s
-            </span>
-            <meta itemProp="position" content="3" />
-          </a>
+          <span className="denhaag-breadcrumb__text" itemProp="name">
+            Kliko&apos;s
+          </span>
+          <meta itemProp="position" content="3" />
         </li>
       </ol>
     </nav>


### PR DESCRIPTION
Removed links from the current page item and added inline padding to the denhaag-breadcrumb__text when it's not inside an `<a>` tag, which only happens on the current page item.
