### PR TITLE
Feature/gdh 1690 style(link-grid): remove margin and add border to link-grid without image

### DIFF
--- a/components/LinkGrid/src/index.scss
+++ b/components/LinkGrid/src/index.scss
@@ -206,6 +206,7 @@
 
   .denhaag-link-grid__container {
     padding-inline-end: 0;
+    margin-inline: 0;
   }
 
   .denhaag-link-grid__title {
@@ -261,8 +262,8 @@
         border-left: var(--denhaag-link-grid-item-no-border);
       }
       &:nth-child(4n + 1) {
-        border-left: var(--denhaag-link-grid-item-default-border, 1px solid) var
-          (--denhaag-link-grid-item-border-color, var(--denhaag-color-blue-1));
+        border-left: var(--denhaag-link-grid-item-default-border, 1px solid)
+          var(--denhaag-link-grid-item-border-color, var(--denhaag-color-blue-1)) !important;
       }
     }
 


### PR DESCRIPTION
Removed inline margin for link-grid without image, and fixed broken border on the left side of link-grid without image.
