### PR TITLE
docs: display eupl 1.2 license in storybook (#1810)

### DIFF
--- a/packages/storybook/src/denhaag/License.stories.tsx
+++ b/packages/storybook/src/denhaag/License.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react';
+import md from '../../../LICENSE.md?raw';
+
+const meta = {
+  title: 'Den Haag/License',
+  tags: ['autodocs', '!dev'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      page: md,
+    },
+  },
+} as Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/storybook/src/denhaag/License.stories.tsx
+++ b/packages/storybook/src/denhaag/License.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import md from '../../../LICENSE.md?raw';
+import md from '../../../../LICENSE.md?raw';
 
 const meta = {
   title: 'Den Haag/License',


### PR DESCRIPTION
Import the license from the root of the repository to display in Storybook, either as a separate page or as part of the introduction or README, to fulfil the requirement in step [EUPL-1.2 licentie toegepast](https://nldesignsystem.nl/handboek/estafettemodel/componenten/community-stappenplan/voor-organisaties/#eupl-12-licentie-toegepast) that the organisation's Storybook should have the EUPL-1.2 license available within Storybook.

closes #1810 