### PR TITLE
docs: add cc0 license to side navigation (#1812)

### DIFF
--- a/components/SideNavigation/README.md
+++ b/components/SideNavigation/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Side Navigation
 
 Verticale navigatie die de mogelijkheid biedt om tussen pagina's te navigeren.


### PR DESCRIPTION
Include the CC0.1.0 license at the top of the component README, using `<!-- @license CC0-1.0 -->` so that anyone is allowed to freely use the component.

closes #1812
