### PR TITLE
docs: add cc0 license to case card (#1814)

### DIFF
--- a/.changeset/empty-mice-raise.md
+++ b/.changeset/empty-mice-raise.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/case-card-element": patch
+---
+
+Include the CC0.1.0 license at the top of the component README, using <!-- @license CC0-1.0 --> so that anyone is allowed to freely use the component.

--- a/packages/web-components/case-card/README.md
+++ b/packages/web-components/case-card/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # `denhaag-case-card` Web Component
 
 Use this web component in your page as follows:


### PR DESCRIPTION
Include the CC0.1.0 license at the top of the component README, using `<!-- @license CC0-1.0 -->` so that anyone is allowed to freely use the component.

closes #1814
