### PR TITLE
docs: add cc0 license to case card in react (#1814)

### DIFF
--- a/.changeset/afraid-buses-bet.md
+++ b/.changeset/afraid-buses-bet.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/card": patch
+---
+
+Include the CC0.1.0 license at the top of the component README, using <!-- @license CC0-1.0 --> so that anyone is allowed to freely use the component.

--- a/components/Card/README.md
+++ b/components/Card/README.md
@@ -1,0 +1,9 @@
+<!-- @license CC0-1.0 -->
+
+# Case Card
+
+Toont meta-informatie over een zaak en biedt de mogelijkheid hier naartoe te navigeren.
+
+## References
+
+[https://nldesignsystem.nl/case-card/](https://nldesignsystem.nl/case-card/)


### PR DESCRIPTION
Include the CC0.1.0 license at the top of the component README, using `<!-- @license CC0-1.0 -->` so that anyone is allowed to freely use the component.

Previously done for web components in https://github.com/nl-design-system/denhaag/pull/1815.

closes #1814