### PR TITLE
Fix: make NumberBadge universal for SideNavigation

### DIFF
--- a/components/SideNavigation/src/SideNavigation.tsx
+++ b/components/SideNavigation/src/SideNavigation.tsx
@@ -28,7 +28,7 @@ export const SideNavigation = ({ items }: SideNavigationProps) => {
                 {subItem.counter && subItem.counter > 0 ? (
                   <SideNavigationLinkLabel>
                     {subItem.label}
-                    <NumberBadge>2</NumberBadge>
+                    <NumberBadge>{subItem.counter}</NumberBadge>
                   </SideNavigationLinkLabel>
                 ) : (
                   subItem.label


### PR DESCRIPTION
See issue [#1852]

The NumberBadge was hardcoded in the SideNavigation, rendering it unusable.

**Closing issues**

closes #1852
