### PR TITLE
Fix: make NumberBadge universal for SideNavigation

### DIFF
--- a/.changeset/strong-readers-eat.md
+++ b/.changeset/strong-readers-eat.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/side-navigation": patch
+---
+
+Fix hardcoded number in badge in side navigation

--- a/components/SideNavigation/src/SideNavigation.tsx
+++ b/components/SideNavigation/src/SideNavigation.tsx
@@ -28,7 +28,7 @@ export const SideNavigation = ({ items }: SideNavigationProps) => {
                 {subItem.counter && subItem.counter > 0 ? (
                   <SideNavigationLinkLabel>
                     {subItem.label}
-                    <NumberBadge>2</NumberBadge>
+                    <NumberBadge>{subItem.counter}</NumberBadge>
                   </SideNavigationLinkLabel>
                 ) : (
                   subItem.label


### PR DESCRIPTION
The NumberBadge was hardcoded in the SideNavigation component, rendering it unusable.

Closing issues

closes #1852