### PR TITLE
Fix bad syntax in GitHub Action

### DIFF
--- a/.github/workflows/cicd-website.yml
+++ b/.github/workflows/cicd-website.yml
@@ -119,11 +119,6 @@ jobs:
           pnpm run release-denhaag-nl
 
       - name: lerna publish
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          registry-url: "https://npm.pkg.github.com/"
-          scope: "@gemeente-denhaag"
         env:
           GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
         run: |


### PR DESCRIPTION
A syntax error (the workflow step has "with" and this must be used in conjunction with "uses") prevents workflows from running on the main branch.

This targets the main branch, and the resulting change should not have any effect (because the change is under `if: github.ref == 'refs/heads/www.denhaag.nl'`) other than passing the build, allowing other PRs to be merged.