### PR TITLE
ci: make use of new `www.denhaag.nl` environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/www.denhaag.nl'
+    environment: www.denhaag.nl
 
     steps:
       - name: Checkout branch


### PR DESCRIPTION
Should fix the following [error in the deployment](https://github.com/nl-design-system/denhaag/actions/runs/18871589031/job/53851807489):

```
Error: Input required and not supplied: token
```