### PR TITLE
ci: enable pnpm audit to check for critical vulnerabilities

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Check for known security issues with npm packages
+        run: |
+          echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm audit --audit-level critical
+
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile
@@ -106,6 +111,11 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: .nvmrc
+
+      - name: Check for known security issues with npm packages
+        run: |
+          echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
And show a link for more information (i.e., what to do if your pipeline is blocked).