### PR TITLE
TabIndicator width

### DIFF
--- a/.changeset/brown-months-wink.md
+++ b/.changeset/brown-months-wink.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/tab": patch
+---
+
+Fix selectedIndicator width


### PR DESCRIPTION
In chromatic zien we wel eens een story waarbij zonder dat je wat aangepast hebt toch de TabIndicator als change wordt gezien. Dit komt omdat de tab bij de eerste render niet altijd ready is. Dan krijg je een race condition of hij wel de juist breedte kan ophalen en verwerken in de TabIndicator. 