### PR TITLE
style(cta-image-content): fix img scaling

### DIFF
--- a/components/CtaImageContent/src/index.scss
+++ b/components/CtaImageContent/src/index.scss
@@ -35,19 +35,20 @@
   }
 
   &__image-container {
-    padding-block-start: var(
+    overflow: hidden;
+    margin-block-start: var(
       --denhaag-cta-image-content-image-container-padding-block-start,
       var(--denhaag-cta-image-content-image-container-padding)
     );
-    padding-block-end: var(
+    margin-block-end: var(
       --denhaag-cta-image-content-image-container-padding-block-end,
       var(--denhaag-cta-image-content-image-container-padding)
     );
-    padding-inline-start: var(
+    margin-inline-start: var(
       --denhaag-cta-image-content-image-container-padding-inline-start,
       var(--denhaag-cta-image-content-image-container-padding)
     );
-    padding-inline-end: var(
+    margin-inline-end: var(
       --denhaag-cta-image-content-image-container-padding-inline-end,
       var(--denhaag-cta-image-content-image-container-padding)
     );
@@ -140,7 +141,7 @@
 .denhaag-cta-image-content:hover {
   transform: translateY(calc(0px - var(--denhaag-space-3xs)));
 
-  &:is(.denhaag-cta-image-content--illustration-variant) .denhaag-cta-image-content__image {
+  .denhaag-cta-image-content__image {
     transform: scale(1.02);
     transform-origin: center;
   }


### PR DESCRIPTION
Made a mistake with the img scaling, it's needed on both variants, but required overflow:hidden on the container. Sadly had to use margins instead of padding for the overflow:hidden to work.
