### PR TITLE
feat: add font-family for action component

### DIFF
--- a/.changeset/warm-places-hammer.md
+++ b/.changeset/warm-places-hammer.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/action": minor
+---
+
+Add font-family token to Action (Task Navigation)

--- a/components/Action/src/index.scss
+++ b/components/Action/src/index.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   flex-direction: column;
+  font-family: var(--denhaag-action-font-family);
   gap: var(--denhaag-action-gap);
   color: var(--denhaag-action-color);
   background-color: var(--denhaag-action-background-color);

--- a/proprietary/tokens/src/components/denhaag/action.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/action.tokens.json
@@ -10,6 +10,9 @@
       "background-color": {
         "value": "{denhaag.color.white}"
       },
+      "font-family": {
+        "value": "{denhaag.typography.sans-serif.font-family}"
+      },
       "padding-inline-start": {
         "value": "{denhaag.space.inline.md}"
       },


### PR DESCRIPTION
For the Task Navigation component to be part of the NLDS community it is obliged to add a font-family token. 
This PR adds that and was made during the 'Estafettemodeldag'.

**Closing issues**

closes #2032 

-