### PR TITLE
feat: add border-radius for file and action components

### DIFF
--- a/.changeset/upset-lands-fold.md
+++ b/.changeset/upset-lands-fold.md
@@ -1,0 +1,7 @@
+---
+"@gemeente-denhaag/design-tokens": minor
+"@gemeente-denhaag/action": minor
+"@gemeente-denhaag/file": minor
+---
+
+Add border-radius token to File and Action (Task Navigation)

--- a/components/Action/src/index.scss
+++ b/components/Action/src/index.scss
@@ -6,6 +6,7 @@
   gap: var(--denhaag-action-gap);
   color: var(--denhaag-action-color);
   background-color: var(--denhaag-action-background-color);
+  border-radius: var(--denhaag-action-border-radius);
   padding-inline-start: var(--denhaag-action-padding-inline-start);
   padding-inline-end: var(--denhaag-action-padding-inline-end);
   padding-block-start: var(--denhaag-action-padding-block-start);

--- a/components/File/src/index.scss
+++ b/components/File/src/index.scss
@@ -12,6 +12,7 @@
   align-items: normal;
   line-height: inherit;
   box-sizing: border-box;
+  border-radius: var(--denhaag-file-border-radius);
   border-width: var(--denhaag-file-border-width);
   border-color: var(--denhaag-file-border-color);
   border-style: var(--denhaag-file-border-style);

--- a/proprietary/tokens/src/components/denhaag/action.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/action.tokens.json
@@ -13,6 +13,9 @@
       "font-family": {
         "value": "{denhaag.typography.sans-serif.font-family}"
       },
+      "border-radius": {
+        "value": "0"
+      },
       "padding-inline-start": {
         "value": "{denhaag.space.inline.md}"
       },

--- a/proprietary/tokens/src/components/denhaag/file.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/file.tokens.json
@@ -3,6 +3,7 @@
     "file": {
       "border-width": { "value": "1px" },
       "border-color": { "value": "{denhaag.color.grey.2}" },
+      "border-radius": { "value": "0" },
       "border-style": { "value": "solid" },
       "hover": {
         "color": { "value": "{denhaag.color.blue.4}" }


### PR DESCRIPTION
To make designs more consistent and to make it possible to combine components that all have a border-radius with each other in the same page templates.

**Closing issues**

Closes #2034