### PR TITLE
feat: replace file wrapper with div and add anchor and real button

### DIFF
--- a/.changeset/sour-frogs-ring.md
+++ b/.changeset/sour-frogs-ring.md
@@ -1,0 +1,7 @@
+---
+"@gemeente-denhaag/storybook": minor
+"@gemeente-denhaag/design-tokens": minor
+"@gemeente-denhaag/file": minor
+---
+
+replace file wrapper with anchor and add real button

--- a/components/File/src/File.tsx
+++ b/components/File/src/File.tsx
@@ -17,7 +17,7 @@ interface FileProps {
 
 export const File = ({
   name,
-  href = '#',
+  href,
   size,
   lastUpdated,
   className,
@@ -26,7 +26,7 @@ export const File = ({
   removableLabel = 'Verwijderen',
   onClick,
 }: FileProps) => {
-  const extension = href?.lastIndexOf('.') >= 0 ? href.substring(href.lastIndexOf('.') + 1, href.length) : undefined;
+  const extension = href && href.lastIndexOf('.') >= 0 ? href.substring(href.lastIndexOf('.') + 1) : undefined;
   const lastUpdatedDate = lastUpdated ? new Date(lastUpdated).toLocaleDateString() : null;
   const FileTypeIcon = ({ ...props }) => {
     switch (extension) {
@@ -37,58 +37,46 @@ export const File = ({
     }
   };
 
-  const defaultProps = {
-    className: clsx('denhaag-file', { 'denhaag-file--loading': loading }, className),
-    'aria-labelledby': 'name',
-    'aria-describedby': 'description',
-  };
-
-  const Wrapper = ({ children }: { children: React.ReactNode }) =>
-    onClick ? (
-      <button onClick={onClick} {...defaultProps}>
-        {children}
-      </button>
-    ) : (
-      <a href={href} download={name} {...defaultProps}>
-        {children}
-      </a>
-    );
-
   return (
-    <Wrapper>
+    <div
+      className={clsx(
+        'denhaag-file',
+        {
+          'denhaag-file--loading': loading,
+          'denhaag-file--removable': removable,
+        },
+        className,
+      )}
+    >
       <div className="denhaag-file__left">
         {loading ? <SpinnerIcon /> : <FileTypeIcon className="denhaag-file__icon" />}
       </div>
       <div className="denhaag-file__right">
         <div className="denhaag-file__label">
-          <span id="name">
+          <span>
             <URLData>{name}</URLData>
           </span>
           <span> </span>
           {(extension || size || lastUpdated) && (
-            <span id="description">({[extension, size, lastUpdatedDate].filter(Boolean).join(', ')})</span>
+            <span>({[extension, size, lastUpdatedDate].filter(Boolean).join(', ')})</span>
           )}
         </div>
         {!loading && (
           <>
-            {!removable ? (
-              <div className="denhaag-file__link">
-                <DownloadIcon className="denhaag-file__link__icon" />
-                <div className="utrecht-link" tabIndex={-1}>
-                  Download
-                </div>
-              </div>
-            ) : (
-              <div className="denhaag-file__link denhaag-file__link--remove">
+            {removable ? (
+              <button className="denhaag-file__link denhaag-file__link--remove" onClick={onClick} type="button">
                 <TrashIcon className="denhaag-file__link__icon" />
-                <div className="utrecht-link" tabIndex={-1}>
-                  {removableLabel}
-                </div>
-              </div>
-            )}
+                <span>{removableLabel}</span>
+              </button>
+            ) : href ? (
+              <a href={href} download={typeof name === 'string' ? name : undefined} className="denhaag-file__link">
+                <DownloadIcon className="denhaag-file__link__icon" />
+                <span>Download</span>
+              </a>
+            ) : null}
           </>
         )}
       </div>
-    </Wrapper>
+    </div>
   );
 };

--- a/components/File/src/index.scss
+++ b/components/File/src/index.scss
@@ -1,12 +1,10 @@
 .denhaag-file {
   width: 100%;
   display: flex;
-  color: inherit;
   font-family: inherit;
   font-size: inherit;
-  text-decoration: inherit;
   text-align: inherit;
-  cursor: pointer;
+  cursor: default;
   background: none;
   padding: 0;
   align-items: normal;
@@ -16,16 +14,10 @@
   border-width: var(--denhaag-file-border-width);
   border-color: var(--denhaag-file-border-color);
   border-style: var(--denhaag-file-border-style);
+  position: relative;
 
   & + & {
     border-top: none;
-  }
-
-  &--focus,
-  &:focus {
-    outline-color: var(--denhaag-file-focus-outline-color);
-    outline-width: var(--denhaag-file-focus-outline-width);
-    outline-style: var(--denhaag-file-focus-outline-style);
   }
 
   &__link {
@@ -34,11 +26,45 @@
     color: var(--denhaag-file-link-color);
     gap: var(--denhaag-file-link-gap);
     word-break: initial;
+    text-decoration: none;
 
     --utrecht-link-text-decoration: none;
 
     & &__icon {
       width: var(--denhaag-file-link-icon-width);
+    }
+
+    &:focus {
+      outline-color: var(--denhaag-file-focus-outline-color);
+      outline-width: var(--denhaag-file-focus-outline-width);
+      outline-style: var(--denhaag-file-focus-outline-style);
+    }
+
+    &--remove {
+      background-color: var(--denhaag-file-link-remove-background-color);
+      border-width: var(--denhaag-file-link-remove-border-width);
+      border-style: none;
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      margin: 0;
+      cursor: pointer;
+
+      &:focus {
+        outline-color: var(--denhaag-file-focus-outline-color);
+        outline-width: var(--denhaag-file-focus-outline-width);
+        outline-style: var(--denhaag-file-focus-outline-style);
+      }
+    }
+  }
+
+  &:not(&--removable) {
+    .denhaag-file__link {
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+      }
     }
   }
 
@@ -58,7 +84,8 @@
     align-items: center;
     padding-inline-start: var(--denhaag-file-left-padding-inline-start);
     padding-inline-end: var(--denhaag-file-left-padding-inline-end);
-    background-color: var(--denhaag-file-left-background-color, --denhaag-color-warmgrey-1);
+    background-color: var(--denhaag-file-left-background-color);
+    border-radius: var(--denhaag-file-border-radius);
 
     .denhaag-file__icon {
       fill: none;

--- a/packages/storybook/src/css/File.stories.tsx
+++ b/packages/storybook/src/css/File.stories.tsx
@@ -37,13 +37,21 @@ export const Focus: Story = {
   args: { ...Default.args, className: 'denhaag-file--focus' },
 };
 
-export const Button: Story = {
+export const Removable: Story = {
   args: {
     ...Default.args,
+    removable: true,
     onClick: (event) => {
       event.preventDefault();
-      console.log('File clicked');
+      console.log('File removed');
     },
+  },
+};
+
+export const WithoutLink: Story = {
+  args: {
+    ...Default.args,
+    href: undefined,
   },
 };
 

--- a/packages/storybook/src/react/File.stories.tsx
+++ b/packages/storybook/src/react/File.stories.tsx
@@ -37,14 +37,26 @@ export const Focus: Story = {
   args: { ...Default.args, className: 'denhaag-file--focus' },
 };
 
-export const Button: Story = {
+export const Removable: Story = {
   args: {
     ...Default.args,
+    removable: true,
     onClick: (event) => {
       event.preventDefault();
-      console.log('File clicked');
+      console.log('File removed');
     },
   },
+};
+
+export const WithoutLink: Story = {
+  args: {
+    ...Default.args,
+    href: undefined,
+  },
+};
+
+export const Loading: Story = {
+  args: { ...Default.args, loading: true },
 };
 
 export const List: Story = {
@@ -55,12 +67,4 @@ export const List: Story = {
       <File {...exampleArgs} />
     </>
   ),
-};
-
-export const Loading: Story = {
-  args: { ...Default.args, loading: true },
-};
-
-export const Removable: Story = {
-  args: { ...Default.args, removable: true },
 };

--- a/proprietary/tokens/src/components/denhaag/file.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/file.tokens.json
@@ -31,6 +31,10 @@
         "icon": {
           "width": { "value": "20px" }
         }
+      },
+      "remove": {
+        "background-color": { "value": "transparent" },
+        "border-width": { "value": "0" }
       }
     }
   }


### PR DESCRIPTION
Replacing the wrapper with a div element so that the entire File is only visually a link (so is still hoverable completely with the `::after` style), but in code will contain seprate elements that conform to accessibility.
Also: using a true Button for when the File component is used to Remove a file.

in this PR:

- [x] Remove the `<Wrapper>` pattern entirely
- [x] Change the root to a `<div>`
- [x] Make the download a real `<a>` tag
- [x] Make the delete/removable a real `<button>` tag
- [x] Remove the `tabIndex={-1}` from the inner divs
- [ ] check/improve accessibility issues
- [x] make a CSS :after to wrap the 'Download' version of file component so that it looks like a very large link.

still to do and still in Open Inwoner:

- oip- prefixed classes that add things Den Haag simply doesn't have, like the extension/size span styling and text-transform: uppercase
- MaterialIcon instead of SVG icons
- OIP formatFileSize logic
- OIP deleteUrl + confirm() handler
- OIP isImage prop and image icon logic so icon will look different if type of file is text or image or PDF... etc.
- lastUpdated formatting differences

**Closing issues**

Closes #2026 
