### PR TITLE
feature: SideNavigation with sub items

### DIFF
--- a/.changeset/gold-mirrors-battle.md
+++ b/.changeset/gold-mirrors-battle.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/side-navigation": minor
+---
+
+Allow `subItems` to be added to an item in order to render a sub menu

--- a/.changeset/polite-clubs-cross.md
+++ b/.changeset/polite-clubs-cross.md
@@ -1,0 +1,5 @@
+---
+"@gemeente-denhaag/iconbutton": minor
+---
+
+Added a forwardRef so the `<button>` element can be focused from a parent component

--- a/components/IconButton/src/index.tsx
+++ b/components/IconButton/src/index.tsx
@@ -21,12 +21,16 @@ export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
  * @param props The properties of an IconButton component.
  * @constructor Constructs an instance of IconButton.
  */
-export const IconButton: React.FC<IconButtonProps> = ({ ...props }: IconButtonProps) => {
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(({ ...props }, ref) => {
   const rootClassNames = clsx('denhaag-icon-button', props.className);
 
   return (
-    <button {...props} className={rootClassNames}>
+    <button ref={ref} {...props} className={rootClassNames}>
       {props.children}
     </button>
   );
-};
+});
+
+IconButton.displayName = 'IconButton';
+
+export default IconButton;

--- a/components/SideNavigation/package.json
+++ b/components/SideNavigation/package.json
@@ -31,6 +31,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@gemeente-denhaag/iconbutton": "workspace:*",
+    "@gemeente-denhaag/icons": "workspace:*",
     "@gemeente-denhaag/number-badge": "workspace:*",
     "clsx": "2.1.1"
   },

--- a/components/SideNavigation/src/SideNavigation.tsx
+++ b/components/SideNavigation/src/SideNavigation.tsx
@@ -1,19 +1,10 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { SideNavigationBase } from './SideNavigationBase';
 import { SideNavigationList } from './SideNavigationList';
-import { SideNavigationItem } from './SideNavigationItem';
-import { SideNavigationLink } from './SideNavigationLink';
-import { SideNavigationLinkLabel } from './SideNavigationLinkLabel';
-import { NumberBadge } from '@gemeente-denhaag/number-badge';
+import { SideNavigationTreeItem, SideNavigationTreeItemProps } from './SideNavigationTreeItem';
 
 export interface SideNavigationProps {
-  items: {
-    href: string;
-    label: string;
-    icon: ReactNode;
-    current?: boolean;
-    counter?: number;
-  }[][];
+  items: SideNavigationTreeItemProps[][];
 }
 
 export const SideNavigation = ({ items }: SideNavigationProps) => {
@@ -22,19 +13,7 @@ export const SideNavigation = ({ items }: SideNavigationProps) => {
       {items.map((item, index) => (
         <SideNavigationList key={index}>
           {item.map((subItem, subIndex) => (
-            <SideNavigationItem key={subIndex}>
-              <SideNavigationLink href={subItem.href} current={subItem.current}>
-                {subItem.icon}
-                {subItem.counter && subItem.counter > 0 ? (
-                  <SideNavigationLinkLabel>
-                    {subItem.label}
-                    <NumberBadge>{subItem.counter}</NumberBadge>
-                  </SideNavigationLinkLabel>
-                ) : (
-                  subItem.label
-                )}
-              </SideNavigationLink>
-            </SideNavigationItem>
+            <SideNavigationTreeItem key={subIndex} {...subItem} />
           ))}
         </SideNavigationList>
       ))}

--- a/components/SideNavigation/src/SideNavigation.tsx
+++ b/components/SideNavigation/src/SideNavigation.tsx
@@ -4,16 +4,18 @@ import { SideNavigationList } from './SideNavigationList';
 import { SideNavigationTreeItem, SideNavigationTreeItemProps } from './SideNavigationTreeItem';
 
 export interface SideNavigationProps {
+  openLabel?: string;
+  closeLabel?: string;
   items: SideNavigationTreeItemProps[][];
 }
 
-export const SideNavigation = ({ items }: SideNavigationProps) => {
+export const SideNavigation = ({ items, openLabel, closeLabel }: SideNavigationProps) => {
   return (
     <SideNavigationBase>
       {items.map((item, index) => (
         <SideNavigationList key={index}>
           {item.map((subItem, subIndex) => (
-            <SideNavigationTreeItem key={subIndex} {...subItem} />
+            <SideNavigationTreeItem key={subIndex} {...subItem} openLabel={openLabel} closeLabel={closeLabel} />
           ))}
         </SideNavigationList>
       ))}

--- a/components/SideNavigation/src/SideNavigationExpandButton.tsx
+++ b/components/SideNavigation/src/SideNavigationExpandButton.tsx
@@ -5,18 +5,22 @@ import { ChevronDownIcon } from '@gemeente-denhaag/icons';
 
 export type SideNavigationExpandIconProps = IconButtonProps;
 
-export const SideNavigationExpandButton = (props: SideNavigationExpandIconProps) => {
-  const className = clsx(
-    'denhaag-side-navigation__expand-button',
-    { 'denhaag-side-navigation__expand-button--expanded': props['aria-expanded'] },
-    props.className,
-  );
+export const SideNavigationExpandButton = React.forwardRef<HTMLButtonElement, SideNavigationExpandIconProps>(
+  (props, ref) => {
+    const className = clsx(
+      'denhaag-side-navigation__expand-button',
+      { 'denhaag-side-navigation__expand-button--expanded': props['aria-expanded'] },
+      props.className,
+    );
 
-  return (
-    <IconButton {...props} className={className}>
-      <ChevronDownIcon />
-    </IconButton>
-  );
-};
+    return (
+      <IconButton ref={ref} {...props} className={className}>
+        <ChevronDownIcon />
+      </IconButton>
+    );
+  },
+);
+
+SideNavigationExpandButton.displayName = 'SideNavigationExpandButton';
 
 export default SideNavigationExpandButton;

--- a/components/SideNavigation/src/SideNavigationExpandButton.tsx
+++ b/components/SideNavigation/src/SideNavigationExpandButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import clsx from 'clsx';
+import { IconButton, IconButtonProps } from '@gemeente-denhaag/iconbutton';
+import { ChevronDownIcon } from '@gemeente-denhaag/icons';
+
+export type SideNavigationExpandIconProps = IconButtonProps;
+
+export const SideNavigationExpandButton = (props: SideNavigationExpandIconProps) => {
+  const className = clsx(
+    'denhaag-side-navigation__expand-button',
+    { 'denhaag-side-navigation__expand-button--expanded': props['aria-expanded'] },
+    props.className,
+  );
+
+  return (
+    <IconButton {...props} className={className}>
+      <ChevronDownIcon />
+    </IconButton>
+  );
+};
+
+export default SideNavigationExpandButton;

--- a/components/SideNavigation/src/SideNavigationExpandSeparator.tsx
+++ b/components/SideNavigation/src/SideNavigationExpandSeparator.tsx
@@ -1,0 +1,12 @@
+import React, { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export type SideNavigationExpandSeparatorProps = HTMLAttributes<HTMLSpanElement>;
+
+export const SideNavigationExpandSeparator = (props: SideNavigationExpandSeparatorProps) => {
+  const className = clsx('denhaag-side-navigation__expand-separator', props.className);
+
+  return <span className={className}></span>;
+};
+
+export default SideNavigationExpandSeparator;

--- a/components/SideNavigation/src/SideNavigationTreeItem.tsx
+++ b/components/SideNavigation/src/SideNavigationTreeItem.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+import { SideNavigationItem } from './SideNavigationItem';
+import { SideNavigationLink } from './SideNavigationLink';
+import { SideNavigationLinkLabel } from './SideNavigationLinkLabel';
+import { NumberBadge } from '@gemeente-denhaag/number-badge';
+
+export interface SideNavigationTreeItemProps {
+  href: string;
+  label: string;
+  icon: ReactNode;
+  current?: boolean;
+  counter?: number;
+}
+
+export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
+  return (
+    <SideNavigationItem>
+      <SideNavigationLink href={props.href} current={props.current}>
+        {props.icon}
+        {props.counter && props.counter > 0 ? (
+          <SideNavigationLinkLabel>
+            {props.label}
+            <NumberBadge>{props.counter}</NumberBadge>
+          </SideNavigationLinkLabel>
+        ) : (
+          props.label
+        )}
+      </SideNavigationLink>
+    </SideNavigationItem>
+  );
+};
+
+export default SideNavigationTreeItem;

--- a/components/SideNavigation/src/SideNavigationTreeItem.tsx
+++ b/components/SideNavigation/src/SideNavigationTreeItem.tsx
@@ -16,6 +16,8 @@ export interface SideNavigationTreeItemProps {
   expanded?: boolean;
   items?: SideNavigationTreeItemProps[];
   closeParent?: () => void;
+  openLabel?: string;
+  closeLabel?: string;
 }
 
 export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
@@ -61,7 +63,7 @@ export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
           <SideNavigationExpandButton
             ref={toggleRef}
             onClick={togglePanel}
-            aria-label={`${isExpanded ? 'Sluit' : 'Open'} submenu ${props.label}`}
+            aria-label={`${isExpanded ? props.closeLabel || 'Sluit' : props.openLabel || 'Open'} submenu ${props.label}`}
             aria-expanded={isExpanded}
             onKeyDown={handleEscapeOnToggle}
           />

--- a/components/SideNavigation/src/SideNavigationTreeItem.tsx
+++ b/components/SideNavigation/src/SideNavigationTreeItem.tsx
@@ -1,7 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useId, useState } from 'react';
 import { SideNavigationItem } from './SideNavigationItem';
 import { SideNavigationLink } from './SideNavigationLink';
 import { SideNavigationLinkLabel } from './SideNavigationLinkLabel';
+import { SideNavigationList } from './SideNavigationList';
+import { SideNavigationExpandButton } from './SideNavigationExpandButton';
+import { SideNavigationExpandSeparator } from './SideNavigationExpandSeparator';
 import { NumberBadge } from '@gemeente-denhaag/number-badge';
 
 export interface SideNavigationTreeItemProps {
@@ -10,9 +13,16 @@ export interface SideNavigationTreeItemProps {
   icon: ReactNode;
   current?: boolean;
   counter?: number;
+  expanded?: boolean;
+  items?: SideNavigationTreeItemProps[];
 }
 
 export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
+  const id = useId();
+  const [isExpanded, setIsExpanded] = useState<boolean>(Boolean(props.expanded));
+
+  const togglePanel = () => setIsExpanded(!isExpanded);
+
   return (
     <SideNavigationItem>
       <SideNavigationLink href={props.href} current={props.current}>
@@ -26,6 +36,20 @@ export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
           props.label
         )}
       </SideNavigationLink>
+
+      {props.items?.length && (
+        <>
+          <SideNavigationExpandSeparator />
+          <SideNavigationExpandButton onClick={togglePanel} aria-expanded={isExpanded} />
+          {isExpanded && (
+            <SideNavigationList id={id}>
+              {props.items.map((subItem, subIndex) => (
+                <SideNavigationTreeItem key={subIndex} {...subItem} />
+              ))}
+            </SideNavigationList>
+          )}
+        </>
+      )}
     </SideNavigationItem>
   );
 };

--- a/components/SideNavigation/src/SideNavigationTreeItem.tsx
+++ b/components/SideNavigation/src/SideNavigationTreeItem.tsx
@@ -45,36 +45,39 @@ export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
 
   return (
     <SideNavigationItem>
-      <SideNavigationLink href={props.href} current={props.current} onKeyDown={handleEscapeOnLink}>
-        {props.icon}
-        {props.counter && props.counter > 0 ? (
-          <SideNavigationLinkLabel>
-            {props.label}
-            <NumberBadge>{props.counter}</NumberBadge>
-          </SideNavigationLinkLabel>
-        ) : (
-          props.label
-        )}
-      </SideNavigationLink>
-
-      {props.items?.length && (
-        <>
-          <SideNavigationExpandSeparator />
-          <SideNavigationExpandButton
-            ref={toggleRef}
-            onClick={togglePanel}
-            aria-label={`${isExpanded ? props.closeLabel || 'Sluit' : props.openLabel || 'Open'} submenu ${props.label}`}
-            aria-expanded={isExpanded}
-            onKeyDown={handleEscapeOnToggle}
-          />
-          {isExpanded && (
-            <SideNavigationList id={id}>
-              {props.items.map((subItem, subIndex) => (
-                <SideNavigationTreeItem key={subIndex} {...subItem} closeParent={closePanel} />
-              ))}
-            </SideNavigationList>
+      <span className="denhaag-side-navigation__tree-item-label-wrapper">
+        <SideNavigationLink href={props.href} current={props.current} onKeyDown={handleEscapeOnLink}>
+          {props.icon}
+          {props.counter && props.counter > 0 ? (
+            <SideNavigationLinkLabel>
+              {props.label}
+              <NumberBadge>{props.counter}</NumberBadge>
+            </SideNavigationLinkLabel>
+          ) : (
+            props.label
           )}
-        </>
+        </SideNavigationLink>
+
+        {props.items?.length && (
+          <>
+            <SideNavigationExpandSeparator />
+            <SideNavigationExpandButton
+              ref={toggleRef}
+              onClick={togglePanel}
+              aria-label={`${isExpanded ? props.closeLabel || 'Sluit' : props.openLabel || 'Open'} submenu ${props.label}`}
+              aria-expanded={isExpanded}
+              onKeyDown={handleEscapeOnToggle}
+            />
+          </>
+        )}
+      </span>
+
+      {props.items?.length && isExpanded && (
+        <SideNavigationList id={id}>
+          {props.items.map((subItem, subIndex) => (
+            <SideNavigationTreeItem key={subIndex} {...subItem} closeParent={closePanel} />
+          ))}
+        </SideNavigationList>
       )}
     </SideNavigationItem>
   );

--- a/components/SideNavigation/src/SideNavigationTreeItem.tsx
+++ b/components/SideNavigation/src/SideNavigationTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useId, useState } from 'react';
+import React, { KeyboardEvent, ReactNode, useId, useRef, useState } from 'react';
 import { SideNavigationItem } from './SideNavigationItem';
 import { SideNavigationLink } from './SideNavigationLink';
 import { SideNavigationLinkLabel } from './SideNavigationLinkLabel';
@@ -15,17 +15,35 @@ export interface SideNavigationTreeItemProps {
   counter?: number;
   expanded?: boolean;
   items?: SideNavigationTreeItemProps[];
+  closeParent?: () => void;
 }
 
 export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
   const id = useId();
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const [isExpanded, setIsExpanded] = useState<boolean>(Boolean(props.expanded));
 
   const togglePanel = () => setIsExpanded(!isExpanded);
+  const closePanel = () => {
+    setIsExpanded(false);
+    toggleRef?.current?.focus();
+  };
+
+  const handleEscapeOnToggle = (event: KeyboardEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+    if (event.code === 'Escape') {
+      closePanel();
+    }
+  };
+
+  const handleEscapeOnLink = (event: KeyboardEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+    if (event.code === 'Escape') {
+      props?.closeParent?.();
+    }
+  };
 
   return (
     <SideNavigationItem>
-      <SideNavigationLink href={props.href} current={props.current}>
+      <SideNavigationLink href={props.href} current={props.current} onKeyDown={handleEscapeOnLink}>
         {props.icon}
         {props.counter && props.counter > 0 ? (
           <SideNavigationLinkLabel>
@@ -40,11 +58,17 @@ export const SideNavigationTreeItem = (props: SideNavigationTreeItemProps) => {
       {props.items?.length && (
         <>
           <SideNavigationExpandSeparator />
-          <SideNavigationExpandButton onClick={togglePanel} aria-expanded={isExpanded} />
+          <SideNavigationExpandButton
+            ref={toggleRef}
+            onClick={togglePanel}
+            aria-label={`${isExpanded ? 'Sluit' : 'Open'} submenu ${props.label}`}
+            aria-expanded={isExpanded}
+            onKeyDown={handleEscapeOnToggle}
+          />
           {isExpanded && (
             <SideNavigationList id={id}>
               {props.items.map((subItem, subIndex) => (
-                <SideNavigationTreeItem key={subIndex} {...subItem} />
+                <SideNavigationTreeItem key={subIndex} {...subItem} closeParent={closePanel} />
               ))}
             </SideNavigationList>
           )}

--- a/components/SideNavigation/src/index.scss
+++ b/components/SideNavigation/src/index.scss
@@ -37,6 +37,13 @@
   }
 }
 
+.denhaag-side-navigation__tree-item-label-wrapper {
+  display: flex;
+  flex-basis: 100%;
+  flex-direction: row;
+  align-items: center;
+}
+
 .denhaag-side-navigation__link {
   text-decoration: none;
   color: var(--denhaag-side-navigation-link-color);
@@ -78,7 +85,7 @@
   justify-content: center;
   align-items: center;
   transform: var(--denhaag-side-navigation-expand-button-transform, rotate(0deg));
-  transition: var(--denhaag-side-navigation-expand-button-transition, transform 200ms ease-in-out);
+  transition: var(--denhaag-side-navigation-expand-button-transition, "transform 200ms ease-in-out");
 
   @media (prefers-reduced-motion) {
     transition: none;
@@ -91,12 +98,13 @@
 }
 
 .denhaag-side-navigation__expand-separator {
+  flex-shrink: 0;
   display: inline-block;
   color: var(--denhaag-side-navigation-expand-separator-color);
   background-color: currentColor;
-  inline-size: var(--denhaag-side-navigation-expand-separator-inline-size);
-  padding-block-end: var(--denhaag-side-navigation-expand-separator-padding-block-end);
-  padding-block-start: var(--denhaag-side-navigation-expand-separator-padding-block-start);
-  margin-inline-end: var(--denhaag-side-navigation-expand-separator-margin-block-end);
-  margin-inline-start: var(--denhaag-side-navigation-expand-separator-margin-block-start);
+  inline-size: var(--denhaag-side-navigation-expand-separator-inline-size, 1px);
+  padding-block-end: var(--denhaag-side-navigation-expand-separator-padding-block-end, 8px);
+  padding-block-start: var(--denhaag-side-navigation-expand-separator-padding-block-start, 8px);
+  margin-inline-end: var(--denhaag-side-navigation-expand-separator-margin-block-end, 8px);
+  margin-inline-start: var(--denhaag-side-navigation-expand-separator-margin-block-start, 8px);
 }

--- a/components/SideNavigation/src/index.scss
+++ b/components/SideNavigation/src/index.scss
@@ -26,6 +26,15 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+
+  &:has(> .denhaag-side-navigation__list) {
+    flex-wrap: wrap;
+  }
+
+  & > .denhaag-side-navigation__list {
+    flex-basis: 100%;
+    margin-inline-start: var(--denhaag-side-navigation-list-margin-inline-start);
+  }
 }
 
 .denhaag-side-navigation__link {
@@ -60,4 +69,34 @@
 .denhaag-side-navigation__link--current {
   color: var(--denhaag-side-navigation-link-active-color);
   font-weight: var(--denhaag-side-navigation-link-active-font-weight);
+}
+
+.denhaag-side-navigation__expand-button {
+  inline-size: var(--denhaag-side-navigation-expand-button-inline-size);
+  block-size: var(--denhaag-side-navigation-expand-button-inline-size);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  transform: var(--denhaag-side-navigation-expand-button-transform, rotate(0deg));
+  transition: var(--denhaag-side-navigation-expand-button-transition, transform 200ms ease-in-out);
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+.denhaag-side-navigation__expand-button[aria-expanded="true"],
+.denhaag-side-navigation__expand-button--expanded {
+  transform: var(--denhaag-side-navigation-expand-button-expanded-transform, rotate(180deg));
+}
+
+.denhaag-side-navigation__expand-separator {
+  display: inline-block;
+  color: var(--denhaag-side-navigation-expand-separator-color);
+  background-color: currentColor;
+  inline-size: var(--denhaag-side-navigation-expand-separator-inline-size);
+  padding-block-end: var(--denhaag-side-navigation-expand-separator-padding-block-end);
+  padding-block-start: var(--denhaag-side-navigation-expand-separator-padding-block-start);
+  margin-inline-end: var(--denhaag-side-navigation-expand-separator-margin-block-end);
+  margin-inline-start: var(--denhaag-side-navigation-expand-separator-margin-block-start);
 }

--- a/components/SideNavigation/src/index.tsx
+++ b/components/SideNavigation/src/index.tsx
@@ -3,6 +3,8 @@ import './index.scss';
 export * from './SideNavigation';
 export * from './SideNavigationBase';
 export * from './SideNavigationItem';
+export * from './SideNavigationTreeItem';
+export * from './SideNavigationExpandButton';
 export * from './SideNavigationList';
 export * from './SideNavigationLink';
 export * from './SideNavigationLinkLabel';

--- a/packages/storybook/src/react/SideNavigation.stories.tsx
+++ b/packages/storybook/src/react/SideNavigation.stories.tsx
@@ -60,3 +60,40 @@ const meta = {
 export default meta;
 
 export const Default: Story = {};
+
+const nestedArgs = [
+  [
+    {
+      href: '#',
+      label: 'Mijn taken',
+      icon: <CheckCircleIcon />,
+    },
+    {
+      href: '#',
+      label: 'Mijn berichten',
+      icon: <InboxIcon />,
+      counter: 2,
+      items: [
+        {
+          href: '#',
+          label: 'Inbox',
+          counter: 2,
+          icon: <InboxIcon />,
+        },
+        {
+          href: '#',
+          label: 'Archief',
+          icon: <InboxIcon />,
+        },
+      ],
+    },
+    {
+      href: '#',
+      label: 'Mijn zaken',
+      icon: <ArchiveIcon />,
+    },
+  ],
+];
+export const Nested: Story = {
+  args: { items: nestedArgs },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,12 @@ importers:
 
   components/SideNavigation:
     dependencies:
+      '@gemeente-denhaag/iconbutton':
+        specifier: workspace:*
+        version: link:../IconButton
+      '@gemeente-denhaag/icons':
+        specifier: workspace:*
+        version: link:../Icons
       '@gemeente-denhaag/number-badge':
         specifier: workspace:*
         version: link:../NumberBadge

--- a/proprietary/tokens/src/components/denhaag/side-navigation.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/side-navigation.tokens.json
@@ -43,7 +43,7 @@
         "block-size": { "value": "{denhaag.space.block.3xl}" },
         "inline-size": { "value": "{denhaag.space.inline.3xl}" },
         "transform": { "value": "rotate(0deg)" },
-        "transition": { "value": "transform 400ms ease-in-out" },
+        "transition": { "value": "transform 200ms ease-in-out" },
         "expanded": {
           "transform": { "value": "rotate(180deg)" }
         }

--- a/proprietary/tokens/src/components/denhaag/side-navigation.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/side-navigation.tokens.json
@@ -21,6 +21,9 @@
         "margin-inline-start": { "value": "0" },
         "margin-inline-end": { "value": "0" }
       },
+      "list": {
+        "margin-inline-start": { "value": "{denhaag.space.inline.3xl}" }
+      },
       "link": {
         "label": {
           "gap": { "value": "{denhaag.space.inline.xs}" }
@@ -35,6 +38,23 @@
           "color": { "value": "{denhaag.color.green.3}" },
           "font-weight": { "value": "{basis.text.font-weight.bold}" }
         }
+      },
+      "expand-button": {
+        "block-size": { "value": "{denhaag.space.block.3xl}" },
+        "inline-size": { "value": "{denhaag.space.inline.3xl}" },
+        "transform": { "value": "rotate(0deg)" },
+        "transition": { "value": "transform 400ms ease-in-out" },
+        "expanded": {
+          "transform": { "value": "rotate(180deg)" }
+        }
+      },
+      "expand-separator": {
+        "color": { "value": "{denhaag.color.grey.2}" },
+        "inline-size": { "value": "{denhaag.size.25}" },
+        "margin-inline-end": { "value": "{denhaag.space.inline.xs}" },
+        "margin-inline-start": { "value": "{denhaag.space.inline.xs}" },
+        "padding-block-end": { "value": "{denhaag.side-navigation.link.padding-block-end}" },
+        "padding-block-start": { "value": "{denhaag.side-navigation.link.padding-block-start}" }
       }
     }
   }


### PR DESCRIPTION
<!--

IMPORTANT: Please do not create a Pull Request without creating an issue first.
Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

Explain the details for making this change. What existing problem does the pull request solve?
Example: When "Adding a function to do X", explain why it is necessary to have a way to do X.

-->

Adding sub items to the `SideNavigation` which can be shown or hidden via a toggle button. 

I would like to use the `SideNavigation` component of Den Haag as the primary navigation component for the nldesignsystem.nl website. However, we would like to display a tree structure. The current implementation of the `SideNavigation` does not allow for sub items. Hence this proposed solution.

## Explanation of the changes

### New components

In order to recursively render sub menu's, I wanted needed a component that could render itself recursively. The original implementation of an item is was done in `SideNavigation.tsx` with all the logic as _children_ of `SideNavigationItem`. Because `SideNavigationItem` is a mere wrapper around an `<li>` element makes `SideNavigationItem` not suitable for recursively calling itself. As such, I introduced an `SideNavigationTreeItem` component and moved the implementation details inside of that component. 

Moving the children of `SideNavigationItem` inside of `SideNavigationItem` itself, would introduce a breaking change in the API of `SideNavigation`. The introduction of `SideNavigationTreeItem` prevents that.

The `SideNavigationExpandButton` and `SideNavigationExpandSeparator` are added to provide a way of showing / hiding the sub items and separate the toggle visually from the link in `SideNavigationItem`.

### Changed components

To allow the closing of the sub items via the keyboard and then focusing the toggle button, the `IconButton` component needed to receive a `forwardRef`

## Added tokens

For the new components, new design tokens have been added. Although not all tokens show up in storybook. Maybe I did something wrong?

## Areas of feedback

Before this PR should be merged, I would like to receive feedback on the decision to introduce the `SideNavigationTreeItem` component. Should the `SideNavigationItem` have been refactored instead (and thus introduce a breaking change)? 

**Closing issues**
closes: #2055
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
