### PR TITLE
feat(tab): add indicator prop to display badge alongside tab label

### DIFF
--- a/.changeset/spotty-carrots-stop.md
+++ b/.changeset/spotty-carrots-stop.md
@@ -1,0 +1,7 @@
+---
+"@gemeente-denhaag/storybook": minor
+"@gemeente-denhaag/design-tokens": minor
+"@gemeente-denhaag/tab": minor
+---
+
+Add optional `indicator` prop to `Tabs` component to support rendering a badge or any React node alongside the tab label.

--- a/.changeset/spotty-carrots-stop.md
+++ b/.changeset/spotty-carrots-stop.md
@@ -4,4 +4,4 @@
 "@gemeente-denhaag/tab": minor
 ---
 
-Add optional `indicator` prop to `Tabs` component to support rendering a badge or any React node alongside the tab label.
+Add optional `indicator` prop to `Tabs` component to support rendering a number badge alongside the tab label.

--- a/components/Tab/README.md
+++ b/components/Tab/README.md
@@ -22,6 +22,7 @@ Tabs consists of:
 2. Line: this line shows the state of a tab
 3. Trailing icon: this icon shows that it is possible to view all tabs that are not visible on the screen
 4. Container
+5. Badge (optional): a numeric badge that can be added to a tab label to communicate a count, such as the number of open items. Any component can be passed here, but the NumberBadge component is recommended.
 
 ## (Interactive) states
 
@@ -111,5 +112,7 @@ Tabs should:
 ## References
 
 [https://www.bbc.co.uk/gel/guidelines/tabs](https://www.bbc.co.uk/gel/guidelines/tabs)
+
 [https://www.carbondesignsystem.com/components/tabs/usage](https://www.carbondesignsystem.com/components/tabs/usage)
+
 [https://www.freshconsulting.com/insights/blog/uiux-principle-21-when-and-when-not-to-use-tabs/](https://www.freshconsulting.com/insights/blog/uiux-principle-21-when-and-when-not-to-use-tabs/)

--- a/components/Tab/package.json
+++ b/components/Tab/package.json
@@ -31,6 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@nl-design-system-candidate/number-badge-css": "1.1.5",
     "@nl-design-system-candidate/number-badge-react": "1.3.2",
     "clsx": "2.1.1",
     "uuid": "14.0.1"

--- a/components/Tab/package.json
+++ b/components/Tab/package.json
@@ -31,6 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@nl-design-system-candidate/number-badge-react": "1.3.2",
     "clsx": "2.1.1",
     "uuid": "14.0.1"
   },

--- a/components/Tab/package.json
+++ b/components/Tab/package.json
@@ -31,8 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@nl-design-system-candidate/number-badge-css": "1.1.5",
-    "@nl-design-system-candidate/number-badge-react": "1.3.2",
+    "@gemeente-denhaag/number-badge": "workspace:*",
     "clsx": "2.1.1",
     "uuid": "14.0.1"
   },

--- a/components/Tab/src/index.tsx
+++ b/components/Tab/src/index.tsx
@@ -16,7 +16,7 @@ export * from './TabsContainer';
 export * from './TabText';
 
 export interface TabsProps {
-  tabData: Array<{ label: string; panelContent: React.ReactNode }>;
+  tabData: Array<{ label: string; indicator?: React.ReactNode; panelContent: React.ReactNode }>;
   onChange?: (index: number) => void;
 }
 
@@ -140,6 +140,7 @@ export const Tabs = ({ tabData, onChange }: TabsProps) => {
               onFocus={() => handleTabFocus(tabRef)}
             >
               <TabText>{tab.label}</TabText>
+              {tab.indicator}
             </Tab>
           ))}
         </TabList>

--- a/components/Tab/src/index.tsx
+++ b/components/Tab/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, RefObject, createRef, useEffect, useLayoutEffect, useState } from 'react';
 import './index.scss';
-import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
+import { NumberBadge } from '@gemeente-denhaag/number-badge';
 import { TabsContainer } from './TabsContainer';
 import { TabIndicator } from './TabIndicator';
 import { TabList } from './TabList';

--- a/components/Tab/src/index.tsx
+++ b/components/Tab/src/index.tsx
@@ -1,5 +1,6 @@
 import React, { KeyboardEvent, RefObject, createRef, useEffect, useLayoutEffect, useState } from 'react';
 import './index.scss';
+import { NumberBadge } from '@nl-design-system-candidate/number-badge-react';
 import { TabsContainer } from './TabsContainer';
 import { TabIndicator } from './TabIndicator';
 import { TabList } from './TabList';
@@ -16,7 +17,7 @@ export * from './TabsContainer';
 export * from './TabText';
 
 export interface TabsProps {
-  tabData: Array<{ label: string; indicator?: React.ReactNode; panelContent: React.ReactNode }>;
+  tabData: Array<{ label: string; indicator?: number; panelContent: React.ReactNode }>;
   onChange?: (index: number) => void;
 }
 
@@ -140,7 +141,7 @@ export const Tabs = ({ tabData, onChange }: TabsProps) => {
               onFocus={() => handleTabFocus(tabRef)}
             >
               <TabText>{tab.label}</TabText>
-              {tab.indicator}
+              {tab.indicator !== undefined && <NumberBadge>{tab.indicator}</NumberBadge>}
             </Tab>
           ))}
         </TabList>

--- a/components/Tab/src/styles/_tab.scss
+++ b/components/Tab/src/styles/_tab.scss
@@ -1,9 +1,12 @@
 .denhaag-tabs__tab {
+  display: flex;
+  align-items: center;
   padding-block-start: var(--denhaag-tabs-tab-padding-block-start);
   padding-inline-start: var(--denhaag-tabs-tab-padding-inline-start);
   padding-block-end: var(--denhaag-tabs-tab-padding-block-end);
   padding-inline-end: var(--denhaag-tabs-tab-padding-inline-end);
   color: var(--denhaag-tabs-tab-color);
+  gap: var(--denhaag-tabs-tab-gap);
   font-size: var(--denhaag-tabs-tab-font-size);
   font-weight: var(--denhaag-tabs-tab-font-weight);
   font-family: var(--denhaag-tabs-tab-font-family);

--- a/packages/storybook/src/react/Tabs.stories.tsx
+++ b/packages/storybook/src/react/Tabs.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
+import { NumberBadge } from '@gemeente-denhaag/number-badge';
 import { Tabs, TabsProps } from '@gemeente-denhaag/tab';
 import readme from '../../../../components/Tab/README.md?raw';
 import React, { useEffect, useState } from 'react';
@@ -28,6 +29,16 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const WithBadge: Story = {
+  args: {
+    tabData: [
+      { label: 'Open doelen', indicator: <NumberBadge value="3">3</NumberBadge>, panelContent: 'Item One' },
+      { label: 'Afgerond', indicator: <NumberBadge value="0">0</NumberBadge>, panelContent: 'Item Two' },
+      { label: 'Yet another tab', panelContent: 'Item Three' },
+    ],
+  },
+};
 
 export const UpdateTabContent: Story = {
   render: () => {

--- a/packages/storybook/src/react/Tabs.stories.tsx
+++ b/packages/storybook/src/react/Tabs.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { NumberBadge } from '@gemeente-denhaag/number-badge';
 import { Tabs, TabsProps } from '@gemeente-denhaag/tab';
 import readme from '../../../../components/Tab/README.md?raw';
 import React, { useEffect, useState } from 'react';
@@ -33,8 +32,8 @@ export const Default: Story = {};
 export const WithBadge: Story = {
   args: {
     tabData: [
-      { label: 'Open doelen', indicator: <NumberBadge value="3">3</NumberBadge>, panelContent: 'Item One' },
-      { label: 'Afgerond', indicator: <NumberBadge value="0">0</NumberBadge>, panelContent: 'Item Two' },
+      { label: 'Open doelen', indicator: 3, panelContent: 'Item One' },
+      { label: 'Afgerond', indicator: 0, panelContent: 'Item Two' },
       { label: 'Yet another tab', panelContent: 'Item Three' },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,9 @@ importers:
 
   components/Tab:
     dependencies:
+      '@nl-design-system-candidate/number-badge-react':
+        specifier: 1.3.2
+        version: 1.3.2(@babel/runtime@7.29.7)(react@19.2.7)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,9 @@ importers:
 
   components/Tab:
     dependencies:
+      '@nl-design-system-candidate/number-badge-css':
+        specifier: 1.1.5
+        version: 1.1.5
       '@nl-design-system-candidate/number-badge-react':
         specifier: 1.3.2
         version: 1.3.2(@babel/runtime@7.29.7)(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,12 +896,9 @@ importers:
 
   components/Tab:
     dependencies:
-      '@nl-design-system-candidate/number-badge-css':
-        specifier: 1.1.5
-        version: 1.1.5
-      '@nl-design-system-candidate/number-badge-react':
-        specifier: 1.3.2
-        version: 1.3.2(@babel/runtime@7.29.7)(react@19.2.7)
+      '@gemeente-denhaag/number-badge':
+        specifier: workspace:*
+        version: link:../NumberBadge
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/proprietary/tokens/src/components/denhaag/tabs.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/tabs.tokens.json
@@ -17,6 +17,7 @@
         "padding-block-end": { "value": "{denhaag.space.block.xs}" },
         "padding-inline-start": { "value": "{denhaag.space.inline.md}" },
         "padding-inline-end": { "value": "{denhaag.space.inline.md}" },
+        "gap": { "value": "{denhaag.space.inline.xs}" },
         "selected": {
           "font-weight": { "value": "{basis.text.font-weight.bold}" },
           "color": { "value": "{denhaag.color.green.3}" }


### PR DESCRIPTION
For MijnServices 'MijnPlan' design we need a more explicit use of the number badge within the Tabs, which creates the need for spacing as well (space between text and number badge): https://github.com/nl-design-system/mijn-services/issues/490 

<img width="303" height="54" alt="Screenshot 2026-07-21 at 14 10 16" src="https://github.com/user-attachments/assets/1a32029d-5ffb-4e3f-961f-be7c379425dc" />
