### PR TITLE
feat(action-single): add row and option to add indicator for task status

### DIFF
--- a/.changeset/tangy-years-relax.md
+++ b/.changeset/tangy-years-relax.md
@@ -4,4 +4,4 @@
 "@gemeente-denhaag/action": minor
 ---
 
-Add optional `indicator` and `hasIndicator` props to ActionSingle to display a leading status icon (e.g. for completed tasks), with corresponding layout and design tokens.
+Add optional `indicator` prop to ActionSingle to display a leading status icon (e.g. for completed tasks), with corresponding layout, design tokens, and Storybook stories.

--- a/.changeset/tangy-years-relax.md
+++ b/.changeset/tangy-years-relax.md
@@ -1,0 +1,7 @@
+---
+"@gemeente-denhaag/storybook": minor
+"@gemeente-denhaag/design-tokens": minor
+"@gemeente-denhaag/action": minor
+---
+
+Add optional `indicator` and `hasIndicator` props to ActionSingle to display a leading status icon (e.g. for completed tasks), with corresponding layout and design tokens.

--- a/components/Action/README.md
+++ b/components/Action/README.md
@@ -24,11 +24,7 @@ Een task is een interactief element dat je navigeert naar een andere pagina en a
 
 Een task bestaat uit:
 
-1. Leading icon (optional): biedt ondersteuning bij de bevestiging. In de React-implementatie bestaat dit uit twee samenwerkende props op `ActionSingle`:
-   - `indicator` (`React.ReactNode`): bepaalt wélk icoon wordt getoond, bijvoorbeeld een `CheckedIcon` uit `@gemeente-denhaag/icons` bij een afgeronde taak. De implementatie bepaalt zelf welk icoon bij welke status hoort; het component schrijft geen vaste set statussen voor.
-   - `hasIndicator` (`boolean`): bepaalt of er ruimte voor het leading icon wordt gereserveerd in de layout, onafhankelijk van wat er als `indicator` wordt meegegeven. Wanneer `hasIndicator` `true` is, schuift de datum/context-sectie mee op zodat deze uitlijnt onder de label-tekst in plaats van onder het icoon — ook op smalle schermen.
-
-   Beide props zijn nodig om de component correct weer te geven. `indicator` bepaalt welk icoon wordt getoond, terwijl `hasIndicator` aangeeft dat er ruimte voor een indicator moet worden gereserveerd, zodat de inhoud correct wordt uitgelijnd. Gebruik daarom altijd beide props samenm voor een correcte uitlijning.
+1. Leading icon (optional): biedt ondersteuning bij de bevestiging. In de React-implementatie wordt dit gerenderd via de `indicator` prop op `ActionSingle`. De prop accepteert elk React-element, bijvoorbeeld een `CheckedIcon` uit `@gemeente-denhaag/icons` bij een afgeronde taak. Het component schrijft geen vaste set statussen voor; de implementatie bepaalt zelf welk icoon bij welke status hoort. Wanneer `indicator` aanwezig is, wordt automatisch ruimte gereserveerd in de layout en schuift de datum/context-sectie op zodat deze uitlijnt onder de label-tekst — ook op smalle schermen. Wanneer geen `indicator` wordt meegegeven, valt de layout terug op het standaardgedrag zonder inspringing.
 2. Label: communiceert de taak die je gaat uitvoeren.
 3. Subtext: biedt ondersteuning aan de label.
 4. Deadline icon (optional): geeft weer dat er een waarschuwing is waar je op moet letten.
@@ -47,7 +43,7 @@ De task bevat de staten:
 - checked
 - focus
 
-De `checked` status wordt niet automatisch afgeleid door het component; de implementatie geeft zelf aan of een taak is afgerond door zowel `hasIndicator={true}` te zetten als een geschikt icoon (bijvoorbeeld `CheckedIcon`) mee te geven via de `indicator` prop. Wanneer `hasIndicator` niet wordt meegegeven (of `false` is), wordt er geen ruimte voor een leading icon gereserveerd en valt de layout terug op het standaardgedrag zonder indicator.
+De `checked` status wordt niet automatisch afgeleid door het component; de implementatie geeft zelf aan of een taak is afgerond door een geschikt icoon (bijvoorbeeld `CheckedIcon`) mee te geven via de `indicator` prop. Wanneer geen `indicator` wordt meegegeven, wordt er geen leading icon getoond en valt de layout terug op het standaardgedrag zonder inspringing.
 
 ## Design properties
 
@@ -68,8 +64,8 @@ Default:
 - Leading icon: svg color Blue/3 (standaardwaarde; via design tokens per implementatie aan te passen, bijvoorbeeld naar een groene kleur om een afgeronde status te benadrukken)
 - Deadline icon: svg color Orange/4
 - Date:
-- Default: text color Grey/4
-- Deadline: text color Orange/5
+  - Default: text color Grey/4
+  - Deadline: text color Orange/5
 - Trailing icon: svg color Blue/3
 - Buttons: zoals beschreven staat bij het component Buttons.
 - Container: border color Grey/2
@@ -130,7 +126,7 @@ Datum:
 
 ## Accessibility
 
-Gebruik semantische HTML-tags om de taakcomponent te structureren, zoals <form>, <label> en <input>. Dit maakt het voor schermlezers en andere ondersteunende technologieën gemakkelijker om het doel van de component te begrijpen.
+Gebruik semantische HTML-tags om de taakcomponent te structureren, zoals `<form>`, `<label>` en `<input>`. Dit maakt het voor schermlezers en andere ondersteunende technologieën gemakkelijker om het doel van de component te begrijpen.
 
 Gebruik contrastrijke kleuren voor tekst en achtergronden om ervoor te zorgen dat de taakcomponent gemakkelijk leesbaar is voor gebruikers met visuele beperkingen. Test het onderdeel met een kleurcontrastcontrole om er zeker van te zijn dat het voldoet aan de toegankelijkheidsrichtlijnen.
 

--- a/components/Action/README.md
+++ b/components/Action/README.md
@@ -24,7 +24,11 @@ Een task is een interactief element dat je navigeert naar een andere pagina en a
 
 Een task bestaat uit:
 
-1. Leading icon (optional): biedt ondersteuning bij de bevestiging.
+1. Leading icon (optional): biedt ondersteuning bij de bevestiging. In de React-implementatie bestaat dit uit twee samenwerkende props op `ActionSingle`:
+   - `indicator` (`React.ReactNode`): bepaalt wélk icoon wordt getoond, bijvoorbeeld een `CheckedIcon` uit `@gemeente-denhaag/icons` bij een afgeronde taak. De implementatie bepaalt zelf welk icoon bij welke status hoort; het component schrijft geen vaste set statussen voor.
+   - `hasIndicator` (`boolean`): bepaalt of er ruimte voor het leading icon wordt gereserveerd in de layout, onafhankelijk van wat er als `indicator` wordt meegegeven. Wanneer `hasIndicator` `true` is, schuift de datum/context-sectie mee op zodat deze uitlijnt onder de label-tekst in plaats van onder het icoon — ook op smalle schermen.
+
+   Beide props zijn nodig om de component correct weer te geven. `indicator` bepaalt welk icoon wordt getoond, terwijl `hasIndicator` aangeeft dat er ruimte voor een indicator moet worden gereserveerd, zodat de inhoud correct wordt uitgelijnd. Gebruik daarom altijd beide props samenm voor een correcte uitlijning.
 2. Label: communiceert de taak die je gaat uitvoeren.
 3. Subtext: biedt ondersteuning aan de label.
 4. Deadline icon (optional): geeft weer dat er een waarschuwing is waar je op moet letten.
@@ -43,6 +47,8 @@ De task bevat de staten:
 - checked
 - focus
 
+De `checked` status wordt niet automatisch afgeleid door het component; de implementatie geeft zelf aan of een taak is afgerond door zowel `hasIndicator={true}` te zetten als een geschikt icoon (bijvoorbeeld `CheckedIcon`) mee te geven via de `indicator` prop. Wanneer `hasIndicator` niet wordt meegegeven (of `false` is), wordt er geen ruimte voor een leading icon gereserveerd en valt de layout terug op het standaardgedrag zonder indicator.
+
 ## Design properties
 
 **Typography**
@@ -59,6 +65,7 @@ Default:
 
 - Label: text color Grey/5
 - Subtext: text color Grey/4
+- Leading icon: svg color Blue/3 (standaardwaarde; via design tokens per implementatie aan te passen, bijvoorbeeld naar een groene kleur om een afgeronde status te benadrukken)
 - Deadline icon: svg color Orange/4
 - Date:
 - Default: text color Grey/4
@@ -130,3 +137,5 @@ Gebruik contrastrijke kleuren voor tekst en achtergronden om ervoor te zorgen da
 Zorg ervoor dat alle functionaliteit binnen de taakcomponent toegankelijk is via een toetsenbord. Gebruikers die geen muis kunnen gebruiken, vertrouwen op toetsenbordnavigatie voor interactie met webpagina's.
 
 Test met hulptechnologieën: test de taakcomponent met behulp van schermlezers en andere hulptechnologieën om ervoor te zorgen dat deze bruikbaar is voor gebruikers met een handicap.
+
+Het leading icon (bijvoorbeeld een vinkje bij een afgeronde taak) mag nooit de enige indicatie van status zijn. Zorg dat de status ook op een andere manier kenbaar wordt gemaakt, bijvoorbeeld via tekst (zoals het label "Afgerond" in eventueel bovenliggende tabs) of via een `aria-label`/visueel verborgen tekst op het icoon zelf, zodat schermlezergebruikers de status ook meekrijgen.

--- a/components/Action/src/Action.tsx
+++ b/components/Action/src/Action.tsx
@@ -13,6 +13,8 @@ export interface ActionSingleProps extends AnchorHTMLAttributes<HTMLAnchorElemen
   locale?: string;
   relativeDate?: boolean;
   labels?: FormatDateLabels;
+  indicator?: React.ReactNode;
+  hasIndicator?: boolean;
 }
 
 export interface ActionMultiProps extends HTMLAttributes<HTMLDivElement> {

--- a/components/Action/src/Action.tsx
+++ b/components/Action/src/Action.tsx
@@ -14,7 +14,6 @@ export interface ActionSingleProps extends AnchorHTMLAttributes<HTMLAnchorElemen
   relativeDate?: boolean;
   labels?: FormatDateLabels;
   indicator?: React.ReactNode;
-  hasIndicator?: boolean;
 }
 
 export interface ActionMultiProps extends HTMLAttributes<HTMLDivElement> {

--- a/components/Action/src/ActionIndicator.tsx
+++ b/components/Action/src/ActionIndicator.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface ActionIndicatorProps {
+  children?: React.ReactNode;
+}
+
+export const ActionIndicator = ({ children }: ActionIndicatorProps) => {
+  if (!children) return null;
+
+  return <div className="denhaag-action__indicator">{children}</div>;
+};

--- a/components/Action/src/ActionRow.tsx
+++ b/components/Action/src/ActionRow.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+interface ActionRowProps {
+  children: React.ReactNode;
+}
+
+export const ActionRow = ({ children }: ActionRowProps) => <div className="denhaag-action__row">{children}</div>;

--- a/components/Action/src/ActionSingle.tsx
+++ b/components/Action/src/ActionSingle.tsx
@@ -6,6 +6,7 @@ import { ActionDetails } from './ActionDetails';
 import { BasicLink } from '@gemeente-denhaag/link';
 import { ActionActions } from './ActionActions';
 import { ActionContext } from './ActionContext';
+import { ActionRow } from './ActionRow';
 import { ActionIndicator } from './ActionIndicator';
 
 export const ActionSingle = ({
@@ -32,10 +33,10 @@ export const ActionSingle = ({
       )}
       {...rest}
     >
-      <div className="denhaag-action__row">
+      <ActionRow>
         <ActionIndicator>{indicator}</ActionIndicator>
         <ActionContent>{children}</ActionContent>
-      </div>
+      </ActionRow>
       <ActionContext>
         <ActionDetails dateTime={dateTime} now={now} locale={locale} relativeDate={relativeDate} labels={labels}>
           {details}

--- a/components/Action/src/ActionSingle.tsx
+++ b/components/Action/src/ActionSingle.tsx
@@ -6,6 +6,7 @@ import { ActionDetails } from './ActionDetails';
 import { BasicLink } from '@gemeente-denhaag/link';
 import { ActionActions } from './ActionActions';
 import { ActionContext } from './ActionContext';
+import { ActionIndicator } from './ActionIndicator';
 
 export const ActionSingle = ({
   children,
@@ -17,12 +18,25 @@ export const ActionSingle = ({
   locale,
   relativeDate,
   labels,
+  indicator,
+  hasIndicator = false,
   className,
   ...rest
 }: ActionSingleProps) => {
   return (
-    <Link href={link} className={clsx('denhaag-action denhaag-action--single', className)} {...rest}>
-      <ActionContent>{children}</ActionContent>
+    <Link
+      href={link}
+      className={clsx(
+        'denhaag-action denhaag-action--single',
+        hasIndicator && 'denhaag-action--with-indicator',
+        className,
+      )}
+      {...rest}
+    >
+      <div className="denhaag-action__row">
+        <ActionIndicator>{indicator}</ActionIndicator>
+        <ActionContent>{children}</ActionContent>
+      </div>
       <ActionContext>
         <ActionDetails dateTime={dateTime} now={now} locale={locale} relativeDate={relativeDate} labels={labels}>
           {details}

--- a/components/Action/src/ActionSingle.tsx
+++ b/components/Action/src/ActionSingle.tsx
@@ -19,7 +19,6 @@ export const ActionSingle = ({
   relativeDate,
   labels,
   indicator,
-  hasIndicator = false,
   className,
   ...rest
 }: ActionSingleProps) => {
@@ -28,7 +27,7 @@ export const ActionSingle = ({
       href={link}
       className={clsx(
         'denhaag-action denhaag-action--single',
-        hasIndicator && 'denhaag-action--with-indicator',
+        indicator && 'denhaag-action--with-indicator',
         className,
       )}
       {...rest}

--- a/components/Action/src/index.scss
+++ b/components/Action/src/index.scss
@@ -43,6 +43,7 @@
     flex-shrink: 0;
     width: var(--denhaag-action-indicator-width);
     color: var(--denhaag-action-indicator-color);
+    background-color: var(--denhaag-action-indicator-background-color, transparent);
 
     svg {
       display: block;

--- a/components/Action/src/index.scss
+++ b/components/Action/src/index.scss
@@ -28,6 +28,19 @@
     padding-block-end: var(--denhaag-action-lg-padding-block-end);
   }
 
+  &__row {
+    display: flex;
+    align-items: flex-start;
+    flex-grow: 1;
+    gap: var(--denhaag-action-indicator-gap);
+  }
+
+  &__indicator {
+    flex-shrink: 0;
+    width: var(--denhaag-action-indicator-width);
+    color: var(--denhaag-action-indicator-color);
+  }
+
   &__content {
     flex-grow: 1;
 
@@ -137,6 +150,10 @@
       @media (width >= 768px) {
         gap: var(--denhaag-action-single-details-lg-gap);
       }
+    }
+
+    &.denhaag-action--with-indicator .denhaag-action__context {
+      margin-inline-start: calc(var(--denhaag-action-indicator-width) + var(--denhaag-action-indicator-gap));
     }
   }
 

--- a/components/Action/src/index.scss
+++ b/components/Action/src/index.scss
@@ -33,12 +33,20 @@
     align-items: flex-start;
     flex-grow: 1;
     gap: var(--denhaag-action-indicator-gap);
+
+    @media (width >= 768px) {
+      gap: var(--denhaag-action-indicator-lg-gap, 16px);
+    }
   }
 
   &__indicator {
     flex-shrink: 0;
     width: var(--denhaag-action-indicator-width);
     color: var(--denhaag-action-indicator-color);
+
+    svg {
+      display: block;
+    }
   }
 
   &__content {
@@ -153,7 +161,7 @@
     }
 
     &.denhaag-action--with-indicator .denhaag-action__context {
-      margin-inline-start: calc(var(--denhaag-action-indicator-width) + var(--denhaag-action-indicator-gap));
+      margin-inline-start: calc(var(--denhaag-action-indicator-width, 20px) + var(--denhaag-action-indicator-gap, 8px));
     }
   }
 

--- a/components/Action/src/index.tsx
+++ b/components/Action/src/index.tsx
@@ -8,4 +8,5 @@ export * from './ActionContext';
 export * from './ActionDetails';
 export * from './ActionDate';
 export * from './ActionActions';
+export * from './ActionIndicator';
 export * from './Time';

--- a/components/Action/src/index.tsx
+++ b/components/Action/src/index.tsx
@@ -8,5 +8,6 @@ export * from './ActionContext';
 export * from './ActionDetails';
 export * from './ActionDate';
 export * from './ActionActions';
+export * from './ActionRow';
 export * from './ActionIndicator';
 export * from './Time';

--- a/components/Action/tokens.json
+++ b/components/Action/tokens.json
@@ -52,6 +52,24 @@
           }
         },
         "type": "lineHeights"
+      },
+      "indicator": {
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
+          }
+        },
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
+          }
+        }
       }
     }
   }

--- a/packages/storybook/src/css/Action.stories.tsx
+++ b/packages/storybook/src/css/Action.stories.tsx
@@ -11,6 +11,7 @@ export {
   Focus,
   WithBadge,
   WithDate,
+  WithIndicatorAndDate,
   WithDateRelative,
   WithDateWarning,
   List,

--- a/packages/storybook/src/react/Action.stories.tsx
+++ b/packages/storybook/src/react/Action.stories.tsx
@@ -6,6 +6,7 @@ import readme from '../../../../components/Action/README.md?raw';
 import tokensDefinition from '../../../../components/Action/tokens.json';
 import { templateLocale } from '../templates/util';
 import { DataBadge } from '@gemeente-denhaag/data-badge';
+import { CheckedIcon } from '@gemeente-denhaag/icons';
 
 const labels = {
   today: 'vandaag',
@@ -60,6 +61,16 @@ export const WithBadge: Story = {
 
 export const WithDate: Story = {
   args: { ...Default.args, dateTime: '2023-09-28T19:47:36.593Z', locale: templateLocale },
+};
+
+export const WithIndicatorAndDate: Story = {
+  args: {
+    ...Default.args,
+    indicator: <CheckedIcon />,
+    hasIndicator: true,
+    dateTime: '2023-09-28T19:47:36.593Z',
+    locale: templateLocale,
+  },
 };
 
 export const WithDateRelative: Story = {

--- a/packages/storybook/src/react/Action.stories.tsx
+++ b/packages/storybook/src/react/Action.stories.tsx
@@ -98,15 +98,6 @@ export const List: Story = {
       <ActionSingle {...exampleArgs} />
       <ActionSingle {...exampleArgs} />
       <ActionSingle {...exampleArgs} />
-      <ActionSingle
-        {...exampleArgs}
-        link="#taak-4"
-        indicator={<CheckedIcon />}
-        dateTime="2026-10-15T19:47:36.593Z"
-        locale={templateLocale}
-      >
-        <strong>Taak checked</strong>
-      </ActionSingle>
     </>
   ),
 };

--- a/packages/storybook/src/react/Action.stories.tsx
+++ b/packages/storybook/src/react/Action.stories.tsx
@@ -67,7 +67,6 @@ export const WithIndicatorAndDate: Story = {
   args: {
     ...Default.args,
     indicator: <CheckedIcon />,
-    hasIndicator: true,
     dateTime: '2023-09-28T19:47:36.593Z',
     locale: templateLocale,
   },
@@ -99,6 +98,15 @@ export const List: Story = {
       <ActionSingle {...exampleArgs} />
       <ActionSingle {...exampleArgs} />
       <ActionSingle {...exampleArgs} />
+      <ActionSingle
+        {...exampleArgs}
+        link="#taak-4"
+        indicator={<CheckedIcon />}
+        dateTime="2026-10-15T19:47:36.593Z"
+        locale={templateLocale}
+      >
+        <strong>Taak checked</strong>
+      </ActionSingle>
     </>
   ),
 };

--- a/proprietary/tokens/src/components/denhaag/action.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/action.tokens.json
@@ -79,7 +79,12 @@
       },
       "indicator": {
         "gap": {
-          "value": "{denhaag.space.inline.sm}"
+          "value": "8px"
+        },
+        "lg": {
+          "gap": {
+            "value": "16px"
+          }
         },
         "width": {
           "value": "20px"

--- a/proprietary/tokens/src/components/denhaag/action.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/action.tokens.json
@@ -77,6 +77,17 @@
           }
         }
       },
+      "indicator": {
+        "gap": {
+          "value": "{denhaag.space.inline.sm}"
+        },
+        "width": {
+          "value": "20px"
+        },
+        "color": {
+          "value": "{denhaag.color.blue.3}"
+        }
+      },
       "actions": {
         "gap": {
           "value": "{denhaag.space.inline.xs}"

--- a/proprietary/tokens/src/components/denhaag/action.tokens.json
+++ b/proprietary/tokens/src/components/denhaag/action.tokens.json
@@ -91,6 +91,9 @@
         },
         "color": {
           "value": "{denhaag.color.blue.3}"
+        },
+        "background-color": {
+          "value": "transparent"
         }
       },
       "actions": {


### PR DESCRIPTION
For the user-tested MijnPlan pattern, part of MijnServices, we need a new structure to accommodate the use of an indicator + adding token for indentation. The checkmark is not just simply an inline element: on smaller screens the title will get extra spacing, but needs to align with the dates/labels so these data/meta-data need extra spacing to the left in case there is a check-mark.

<img width="621" height="444" alt="Screenshot 2026-06-30 at 13 08 58" src="https://github.com/user-attachments/assets/179d888c-f3e4-415f-a86e-624501d2cbab" />

**Closing issues**

https://github.com/nl-design-system/mijn-services/issues/491

**Open question: **
unchecked items don't indent, checked items do. There is no design yet for mixed lists. 