### PR TITLE
ci: rerun workflow when marking PRs as ready for review

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # opened, synchronize, reopened are default; ready_for_review is needed to
+      # run steps that are skipped in draft PRs.
+      - ready_for_review
 
 jobs:
   build:


### PR DESCRIPTION
This fixes an issue where Chromatic (a required check) is not run.

<!--

IMPORTANT: Please do not create a Pull Request without creating an issue first.
Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.

Explain the details for making this change. What existing problem does the pull request solve?
Example: When "Adding a function to do X", explain why it is necessary to have a way to do X.

-->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
