### PR TITLE
fix(open-forms): shrink heading-1 to heading-2 size on small screens

### DIFF
--- a/packages/open-forms/src/index.scss
+++ b/packages/open-forms/src/index.scss
@@ -186,3 +186,9 @@
 .openforms-progress-indicator-item {
   --utrecht-link-text-decoration: none;
 }
+
+@media (width<= 768px) {
+  .utrecht-heading-1 {
+    font-size: var(--utrecht-heading-2-font-size);
+  }
+}


### PR DESCRIPTION
shrink heading-1 to heading-2 size on small screens